### PR TITLE
Amended to use 0.2.1 of NTBEA for Java 8 compatibility

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.hopshackle</groupId>
             <artifactId>NTBEA</artifactId>
-            <version>0.2</version>
+            <version>0.2.1</version>
         </dependency>
     </dependencies>
 


### PR DESCRIPTION
Currently the 0.2 library of NTBEA is compiled under Java 11, and so requires this in ModernBoardGames.

A new version 0.2.1 is compiled under Java 8 to removed this unwanted dependency. The ModernBoardGames pom.xml file is now updated to use 0.2.1 as a dependency.