### PR TITLE
Open Loop, Information Set and RegretMatching MCTS (amongst others)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,7 +29,5 @@ target/
 target/classes/META-INF/ModernBoardGame.kotlin_module
 
 out/production/ModernBoardGame/META-INF/
-*.kotlin_module
-target/classes/META-INF/ModernBoardGame.kotlin_module
 
 javadoc/

--- a/pom.xml
+++ b/pom.xml
@@ -40,7 +40,7 @@
         <dependency>
             <groupId>com.github.hopshackle</groupId>
             <artifactId>NTBEA</artifactId>
-            <version>0.2</version>
+            <version>0.2.1</version>
         </dependency>
     </dependencies>
 

--- a/resources/manifests/ParameterSearch/META-INF/MANIFEST.MF
+++ b/resources/manifests/ParameterSearch/META-INF/MANIFEST.MF
@@ -1,0 +1,3 @@
+Manifest-Version: 1.0
+Main-Class: evaluation.ParameterSearch
+

--- a/resources/manifests/ParameterSearch/META-INF/MANIFEST.MF
+++ b/resources/manifests/ParameterSearch/META-INF/MANIFEST.MF
@@ -1,3 +1,0 @@
-Manifest-Version: 1.0
-Main-Class: evaluation.ParameterSearch
-

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -126,7 +126,7 @@ public abstract class AbstractGameState {
      * @param playerId - player observing the state
      * @return - reduced copy of the game state.
      */
-    final AbstractGameState copy(int playerId) {
+    public final AbstractGameState copy(int playerId) {
         AbstractGameState s = _copy(playerId);
         // Copy super class things
         s.turnOrder = turnOrder.copy();

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -28,6 +28,7 @@ public abstract class AbstractGameState {
     protected final AbstractParameters gameParameters;
     protected TurnOrder turnOrder;
     private Area allComponents;
+    private List<AbstractAction> history = new ArrayList<>();
 
     // List of actions currently available for the player
     protected List<AbstractAction> availableActions;
@@ -140,6 +141,8 @@ public abstract class AbstractGameState {
         for (AbstractAction a: availableActions) {
             s.availableActions.add(a.copy());
         }
+        s.history = new ArrayList<>(history);
+            // we do not copy individual actions in history, as these are now dead and should not change
 
         // Update the list of components for ID matching in actions.
         s.addAllComponents();

--- a/src/main/java/core/AbstractPlayer.java
+++ b/src/main/java/core/AbstractPlayer.java
@@ -1,9 +1,12 @@
 package core;
 
 import core.actions.AbstractAction;
+import core.interfaces.IStatisticLogger;
+import utilities.SummaryLogger;
 
 public abstract class AbstractPlayer {
 
+    protected IStatisticLogger statsLogger = new SummaryLogger();
     // ID of this player, assigned by the game
     int playerID;
     // Forward model for the game
@@ -64,5 +67,13 @@ public abstract class AbstractPlayer {
     @Override
     public String toString() {
         return name;
+    }
+
+    public IStatisticLogger getStatsLogger() {
+        return statsLogger;
+    }
+
+    public void setStatsLogger(IStatisticLogger logger) {
+        this.statsLogger = logger;
     }
 }

--- a/src/main/java/core/interfaces/IStatisticLogger.java
+++ b/src/main/java/core/interfaces/IStatisticLogger.java
@@ -11,14 +11,14 @@ public interface IStatisticLogger {
      *
      * @param data A map of name -> value pairs
      */
-    void record(Map<String, Number> data);
+    void record(Map<String, ?> data);
 
     /**
      * Use to record a single datum. For example
      * @param key
      * @param datum
      */
-    void record(String key, Number datum);
+    void record(String key, Object datum);
 
     /**
      * Trigger any specific batch processing of data by this Logger.

--- a/src/main/java/core/interfaces/IStatisticLogger.java
+++ b/src/main/java/core/interfaces/IStatisticLogger.java
@@ -6,8 +6,32 @@ import java.util.*;
 
 public interface IStatisticLogger {
 
-    void record(Map<String, ?> data);
+    /**
+     * Use to register a set of data in one go
+     *
+     * @param data A map of name -> value pairs
+     */
+    void record(Map<String, Number> data);
 
-    StatSummary summary();
+    /**
+     * Use to record a single datum. For example
+     * @param key
+     * @param datum
+     */
+    void record(String key, Number datum);
+
+    /**
+     * Trigger any specific batch processing of data by this Logger.
+     * This should be called once all data has been collected. This may also, for example,
+     * purge all buffers and close files/database connections.
+     */
+    void processDataAndFinish();
+
+    /**
+     * This should return a Map with one entry for each type of data
+     *
+     * @return A summary of the data
+     */
+    Map<String, StatSummary> summary();
 
 }

--- a/src/main/java/core/interfaces/IStatisticLogger.java
+++ b/src/main/java/core/interfaces/IStatisticLogger.java
@@ -1,0 +1,13 @@
+package core.interfaces;
+
+import utilities.StatSummary;
+
+import java.util.*;
+
+public interface IStatisticLogger {
+
+    void record(Map<String, ?> data);
+
+    StatSummary summary();
+
+}

--- a/src/main/java/evaluation/GameEvaluator.java
+++ b/src/main/java/evaluation/GameEvaluator.java
@@ -1,8 +1,11 @@
 package evaluation;
 
 import core.*;
+import core.interfaces.IStatisticLogger;
 import evodef.*;
 import games.GameType;
+import players.mcts.MCTSPlayer;
+import utilities.SummaryLogger;
 
 import java.util.*;
 import java.util.stream.*;
@@ -23,6 +26,8 @@ public class GameEvaluator implements SolutionEvaluator {
     int nEvals = 0;
     Random rnd;
     boolean avoidOppDupes;
+    public boolean reportStatistics;
+    public IStatisticLogger statsLogger = new SummaryLogger();
 
     /**
      * GameEvaluator
@@ -97,7 +102,9 @@ public class GameEvaluator implements SolutionEvaluator {
                     throw new AssertionError("Something has gone wrong. We seem to have insufficient opponents");
                 allPlayers.add(opponents.get(oppIndex));
             } else {
-                allPlayers.add((AbstractPlayer) configuredThing);
+                AbstractPlayer tunedPlayer = (AbstractPlayer) configuredThing;
+                if (reportStatistics) tunedPlayer.setStatsLogger(statsLogger);
+                allPlayers.add(tunedPlayer);
             }
         }
 

--- a/src/main/java/evaluation/ParameterSearch.java
+++ b/src/main/java/evaluation/ParameterSearch.java
@@ -148,8 +148,10 @@ public class ParameterSearch {
             Pair<Double, Double> r = runNTBEA(evaluator, searchFramework, iterationsPerRun, iterationsPerRun, evalGames, verbose);
             Pair<Pair<Double, Double>, double[]> retValue = new Pair<>(r, landscapeModel.getBestOfSampled());
             printDetailsOfRun(retValue, searchSpace);
-            System.out.println("MCTS Statistics: ");
-            System.out.println(evaluator.statsLogger.toString());
+            if (verbose) {
+                System.out.println("MCTS Statistics: ");
+                System.out.println(evaluator.statsLogger.toString());
+            }
             evaluator.statsLogger = new SummaryLogger();
             if (retValue.a.a > bestResult.a.a)
                 bestResult = retValue;

--- a/src/main/java/evaluation/ParameterSearch.java
+++ b/src/main/java/evaluation/ParameterSearch.java
@@ -10,6 +10,7 @@ import players.PlayerFactory;
 import players.simple.RandomPlayer;
 import utilities.Pair;
 import utilities.StatSummary;
+import utilities.SummaryLogger;
 
 import java.io.File;
 import java.lang.reflect.Constructor;
@@ -24,7 +25,7 @@ public class ParameterSearch {
 
     public static void main(String[] args) {
         List<String> argsList = Arrays.asList(args);
-        if (argsList.contains("--help") || argsList.contains("-h")) System.out.println(
+        if (argsList.isEmpty() || argsList.contains("--help") || argsList.contains("-h")) System.out.println(
                 "The first three arguments must be \n" +
                         "\t<filename for searchSpace definition> or <ITunableParameters classname>\n" +
                         "\t<number of NTBEA iterations>\n" +
@@ -128,7 +129,7 @@ public class ParameterSearch {
         // and then for Game tuning other items that measure how close the result is, etc.
 
         // Initialise the GameEvaluator that will do all the heavy lifting
-        SolutionEvaluator evaluator = new GameEvaluator(
+        GameEvaluator evaluator = new GameEvaluator(
                 game,
                 searchSpace,
                 nPlayers,
@@ -147,6 +148,9 @@ public class ParameterSearch {
             Pair<Double, Double> r = runNTBEA(evaluator, searchFramework, iterationsPerRun, iterationsPerRun, evalGames, verbose);
             Pair<Pair<Double, Double>, double[]> retValue = new Pair<>(r, landscapeModel.getBestOfSampled());
             printDetailsOfRun(retValue, searchSpace);
+            System.out.println("MCTS Statistics: ");
+            System.out.println(evaluator.statsLogger.toString());
+            evaluator.statsLogger = new SummaryLogger();
             if (retValue.a.a > bestResult.a.a)
                 bestResult = retValue;
 
@@ -205,7 +209,7 @@ public class ParameterSearch {
      *                        really matter.
      * @return This returns Pair<Mean, Std Error on Mean> as calculated from the evaluation games
      */
-    public static Pair<Double, Double> runNTBEA(SolutionEvaluator evaluator,
+    public static Pair<Double, Double> runNTBEA(GameEvaluator evaluator,
                                                 EvoAlg searchFramework,
                                                 int totalRuns, int reportEvery,
                                                 int evalGames, boolean logResults) {
@@ -259,6 +263,7 @@ public class ParameterSearch {
         }
         // now run the evaluation games on the final recommendation
         if (evalGames > 0) {
+            evaluator.reportStatistics = true;
             double[] results = IntStream.range(0, evalGames)
                     .mapToDouble(answer -> {
                         int[] settings = Arrays.stream(landscapeModel.getBestOfSampled())
@@ -271,6 +276,7 @@ public class ParameterSearch {
             double stdErr = Math.sqrt(Arrays.stream(results)
                     .map(d -> Math.pow(d - avg, 2.0)).sum()) / (evalGames - 1.0);
 
+            evaluator.reportStatistics = false;
             return new Pair<>(avg, stdErr);
         } else {
             return new Pair<>(landscapeModel.getMeanEstimate(landscapeModel.getBestOfSampled()), 0.0);

--- a/src/main/java/evaluation/PlayerReport.java
+++ b/src/main/java/evaluation/PlayerReport.java
@@ -80,7 +80,6 @@ public class PlayerReport {
 
             Game game = gameType.createGameInstance(playerCount);
             for (int i = 0; i < nGames; i++) {
-
                 // Set up opponents and the tracked player
                 // We can reduce variance here by cycling the playerIndex on each iteration
                 int playerIndex = i % playerCount;
@@ -95,6 +94,8 @@ public class PlayerReport {
                 game.reset(allPlayers);
                 playerToTrack.initializePlayer(game.getGameState());
                 game.run();
+                playerToTrack.getStatsLogger().record("Win", game.getGameState().getPlayerResults()[playerIndex].value);
+                playerToTrack.getStatsLogger().record("Score", game.getGameState().getScore(playerIndex));
             }
             // Once all games are complete, call processDataAndFinish()
             playerToTrack.getStatsLogger().processDataAndFinish();

--- a/src/main/java/evaluation/PlayerReport.java
+++ b/src/main/java/evaluation/PlayerReport.java
@@ -1,0 +1,113 @@
+package evaluation;
+
+import core.AbstractPlayer;
+import core.*;
+import core.interfaces.IStatisticLogger;
+import games.*;
+import players.PlayerFactory;
+import players.simple.RandomPlayer;
+import utilities.SummaryLogger;
+
+import java.lang.reflect.Constructor;
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+import static utilities.Utils.*;
+
+public class PlayerReport {
+
+    /**
+     * The idea here is that we get statistics from the the decisions of a particular agent in
+     * a game, or set of games
+     *
+     * @param args
+     */
+    public static void main(String[] args) {
+        List<String> argsList = Arrays.asList(args);
+        if (argsList.isEmpty() || argsList.contains("--help") || argsList.contains("-h")) System.out.println(
+                "There are a number of possible arguments:\n" +
+                        "\tgames=         A list of the games to be played. If there is more than one, then use a \n" +
+                        "\t               pipe-delimited list, for example games=Uno|ColtExpress|Pandemic. No default.\n" +
+                        "\tplayer=        The JSON file containing the details of the Player to monitor, OR\n" +
+                        "\t               one of mcts|rmhc|random|osla|<className>.\n" +
+                        "\tlogger=        The full class name of an IStatisticsLogger implementation.\n" +
+                        "\t               Defaults to SummaryLogger. \n" +
+                        "\tnPlayers=      The total number of players in each game (the default is game.Min#players) \n " +
+                        "\t               Different player counts can be specified for each game in pipe-delimited format.\n" +
+                        "\tnGames=        The number of games to run for each game type. Defaults to 1.\n" +
+                        "\topponent=      The agent used as opponent. Default is a Random player. \n" +
+                        "\t               This can either be a json-format file detailing the parameters, or\n" +
+                        "\t               one of mcts|rmhc|random|osla|<className>  \n" +
+                        "\t               If className is specified, this must be the full name of a class implementing AbstractPlayer\n" +
+                        "\t               with a no-argument constructor\n"
+        );
+
+        // Now I get the Player and Opponent to be used
+        String opponentDescriptor = getArg(args, "opponent", "");
+        String playerDescriptor = getArg(args, "player", "");
+        if (playerDescriptor.equals(""))
+            throw new IllegalArgumentException("Must specify a player file or type");
+        AbstractPlayer playerToTrack = PlayerFactory.createPlayer(playerDescriptor);
+
+        String loggerClass = getArg(args, "logger", "utilities.SummaryLogger");
+
+        int nGames = getArg(args, "nGames", 1);
+        List<String> games = Arrays.asList(getArg(args, "games", "").split("\\|"));
+        if (games.isEmpty())
+            throw new IllegalArgumentException("Must specify at least one game");
+
+        List<Integer> nPlayers = Arrays.stream(getArg(args, "nPlayers", "").split("\\|"))
+                .mapToInt(Integer::valueOf).boxed().collect(toList());
+
+        if (nPlayers.size() > 1 && nPlayers.size() != games.size())
+            throw new IllegalArgumentException("If specified, then nPlayers length must be one, or match the length of the games list");
+
+
+        // Then iterate over the Game Types
+        for (int gameIndex = 0; gameIndex < games.size(); gameIndex++) {
+            GameType gameType = GameType.valueOf(games.get(gameIndex));
+            System.out.println("Game: " + gameType.name());
+
+            // For each type, instantiate a new IStatisticsLogger
+            playerToTrack.setStatsLogger(createLogger(loggerClass));
+
+            int playerCount = gameType.getMinPlayers();
+            if (nPlayers.size() == 1) playerCount = nPlayers.get(0);
+            if (nPlayers.size() > 1) playerCount = nPlayers.get(gameIndex);
+
+            Game game = gameType.createGameInstance(playerCount);
+            for (int i = 0; i < nGames; i++) {
+
+                // Set up opponents and the tracked player
+                // We can reduce variance here by cycling the playerIndex on each iteration
+                int playerIndex = i % playerCount;
+                List<AbstractPlayer> allPlayers = new ArrayList<>();
+                for (int j = 0; j < playerCount; j++) {
+                    if (j == playerIndex)
+                        allPlayers.add(playerToTrack);
+                    else
+                        allPlayers.add(opponentDescriptor.isEmpty() ? new RandomPlayer() : PlayerFactory.createPlayer(opponentDescriptor));
+                }
+                // Run games, resetting the player each time
+                game.reset(allPlayers);
+                playerToTrack.initializePlayer(game.getGameState());
+                game.run();
+            }
+            // Once all games are complete, call processDataAndFinish()
+            playerToTrack.getStatsLogger().processDataAndFinish();
+        }
+    }
+
+    private static IStatisticLogger createLogger(String loggerClass) {
+        IStatisticLogger logger = new SummaryLogger();
+        try {
+            Class<?> clazz = Class.forName(loggerClass);
+            Constructor<?> constructor = clazz.getConstructor();
+            logger = (IStatisticLogger) constructor.newInstance();
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return logger;
+    }
+
+}

--- a/src/main/java/evaluation/RoundRobinTournament.java
+++ b/src/main/java/evaluation/RoundRobinTournament.java
@@ -2,6 +2,7 @@ package evaluation;
 
 import core.AbstractPlayer;
 import games.GameType;
+import players.mcts.BasicMCTSPlayer;
 import players.simple.OSLAPlayer;
 import players.simple.RandomPlayer;
 import players.mcts.MCTSPlayer;
@@ -26,18 +27,18 @@ public class RoundRobinTournament extends AbstractTournament {
     @SuppressWarnings({"UnnecessaryLocalVariable", "ConstantConditions"})
     public static void main(String[] args){
         /* 1. Settings for the tournament */
-        GameType gameToPlay = TicTacToe;
+        GameType gameToPlay = Uno;
         int nPlayersTotal = 4;
-        int nPlayersPerGame = 2;
-        int nGamesPerMatchUp = 100;
+        int nPlayersPerGame = 3;
+        int nGamesPerMatchUp = 10;
         boolean selfPlay = false;
 
         /* 2. Set up players */
         LinkedList<AbstractPlayer> agents = new LinkedList<>();
         agents.add(new RandomPlayer());
+        agents.add(new BasicMCTSPlayer());
         agents.add(new RMHCPlayer());
         agents.add(new OSLAPlayer());
-        agents.add(new MCTSPlayer());
 
         // Run!
         AbstractTournament tournament = new RoundRobinTournament(agents, gameToPlay, nPlayersPerGame, nGamesPerMatchUp, selfPlay);

--- a/src/main/java/games/GameType.java
+++ b/src/main/java/games/GameType.java
@@ -194,10 +194,8 @@ public enum GameType {
      */
     public Game createGameInstance(int nPlayers, long seed, AbstractParameters params) {
         if (nPlayers < minPlayers || nPlayers > maxPlayers) {
-            if (VERBOSE) {
                 System.out.println("Unsupported number of players: " + nPlayers
                         + ". Should be in range [" + minPlayers + "," + maxPlayers + "].");
-            }
             return null;
         }
 

--- a/src/main/java/games/explodingkittens/ExplodingKittensForwardModel.java
+++ b/src/main/java/games/explodingkittens/ExplodingKittensForwardModel.java
@@ -310,6 +310,8 @@ public class ExplodingKittensForwardModel extends AbstractForwardModel {
         for (int card = 0; card < playerDeck.getSize(); card++) {
             actions.add(new GiveCard(playerDeck.getComponentID(), receiverDeck.getComponentID(), card));
         }
+        if (actions.isEmpty()) // the target has no cards.
+            actions.add(new GiveCard(playerDeck.getComponentID(), receiverDeck.getComponentID(), -1));
         return actions;
     }
 

--- a/src/main/java/games/explodingkittens/actions/reactions/GiveCard.java
+++ b/src/main/java/games/explodingkittens/actions/reactions/GiveCard.java
@@ -19,11 +19,13 @@ public class GiveCard extends DrawCard implements IPrintable {
     public boolean execute(AbstractGameState gs) {
         ExplodingKittensGameState ekgs = (ExplodingKittensGameState) gs;
         ExplodingKittensTurnOrder ekto = ((ExplodingKittensTurnOrder) gs.getTurnOrder());
-        Deck<ExplodingKittensCard> from = (Deck<ExplodingKittensCard>) ekgs.getComponentById(deckFrom);
-        Deck<ExplodingKittensCard> to = (Deck<ExplodingKittensCard>) ekgs.getComponentById(deckTo);
+        if (fromIndex > -1) { // to allow for GiveCard to occur when the target's deck is empty
+            Deck<ExplodingKittensCard> from = (Deck<ExplodingKittensCard>) ekgs.getComponentById(deckFrom);
+            Deck<ExplodingKittensCard> to = (Deck<ExplodingKittensCard>) ekgs.getComponentById(deckTo);
 
-        ExplodingKittensCard c = from.pick(fromIndex);
-        to.add(c);
+            ExplodingKittensCard c = from.pick(fromIndex);
+            to.add(c);
+        }
         gs.setMainGamePhase();
         ekto.endPlayerTurnStep(gs);
         ekto.addReactivePlayer(ekgs.getPlayerGettingAFavor());

--- a/src/main/java/games/virus/VirusForwardModel.java
+++ b/src/main/java/games/virus/VirusForwardModel.java
@@ -9,9 +9,8 @@ import games.virus.cards.*;
 import games.virus.components.VirusBody;
 import utilities.Utils;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
+import java.util.stream.Collectors;
 
 import static core.CoreConstants.VERBOSE;
 import static games.virus.cards.VirusCard.OrganType.Treatment;
@@ -163,8 +162,9 @@ public class VirusForwardModel extends AbstractForwardModel {
         }
 
         // Playable cards actions
-        for (int i = 0; i < playerHand.getSize(); i++)
-            addActionsForCard(vgs, playerHand.peek(i), actions, playerHand);
+        Set<VirusCard> uniqueCards = new HashSet<>(playerHand.getComponents());
+        for (VirusCard card : uniqueCards)
+            addActionsForCard(vgs, card, actions, playerHand);
 
         // Create DiscardCard actions. The player can always discard 1, 2 or 3 cards TODO: variable player hand card size
         // Discard one card

--- a/src/main/java/games/virus/actions/PlayLatexGlove.java
+++ b/src/main/java/games/virus/actions/PlayLatexGlove.java
@@ -17,23 +17,23 @@ public class PlayLatexGlove extends PlayVirusCard implements IPrintable {
 
     public PlayLatexGlove(int deckFrom, int deckTo, int fromIndex, int bodyId, int otherPlayerId, int otherPlayerHandId) {
         super(deckFrom, deckTo, fromIndex, bodyId);
-        this.otherPlayerId     = otherPlayerId;
+        this.otherPlayerId = otherPlayerId;
         this.otherPlayerHandId = otherPlayerHandId;
     }
 
     @Override
     public boolean execute(AbstractGameState gs) {
-        VirusGameState vgs = (VirusGameState) gs;
         super.execute(gs);
 
         // Discard three card on other player hand
-        Deck<Card> to              = (Deck<Card>) gs.getComponentById(deckTo);
+        Deck<Card> to = (Deck<Card>) gs.getComponentById(deckTo);
         Deck<Card> otherPlayerHand = (Deck<Card>) gs.getComponentById(otherPlayerHandId);
 
-        int nCards = ((VirusGameParameters)gs.getGameParameters()).nCardsDiscardLatexGlove;
-        for (int i=0; i<nCards; i++) {
+        int nCards = ((VirusGameParameters) gs.getGameParameters()).nCardsDiscardLatexGlove;
+        for (int i = 0; i < nCards; i++) {
             VirusCard card = (VirusCard) otherPlayerHand.draw();
-            to.add(card, toIndex);
+            if (card != null)
+                to.add(card, toIndex);
         }
         return true;
     }

--- a/src/main/java/players/PlayerParameters.java
+++ b/src/main/java/players/PlayerParameters.java
@@ -8,7 +8,7 @@ import java.util.*;
 public abstract class PlayerParameters extends TunableParameters {
 
     // Budget settings
-    public PlayerConstants budgetType = PlayerConstants.BUDGET_ITERATIONS;
+    public PlayerConstants budgetType = PlayerConstants.BUDGET_FM_CALLS;
     public int iterationsBudget = 1000;
     public int fmCallsBudget = 4000;
     public int timeBudget = 100; //milliseconds
@@ -19,7 +19,7 @@ public abstract class PlayerParameters extends TunableParameters {
 
     public PlayerParameters(long seed) {
         super(seed);
-        addTunableParameter("budgetType", PlayerConstants.BUDGET_ITERATIONS);
+        addTunableParameter("budgetType", PlayerConstants.BUDGET_FM_CALLS);
         addTunableParameter("iterationsBudget", 1000);
         addTunableParameter("fmCallsBudget", 4000);
         addTunableParameter("timeBudget", 100);

--- a/src/main/java/players/PlayerParameters.java
+++ b/src/main/java/players/PlayerParameters.java
@@ -8,8 +8,8 @@ import java.util.*;
 public abstract class PlayerParameters extends TunableParameters {
 
     // Budget settings
-    public PlayerConstants budgetType = PlayerConstants.BUDGET_FM_CALLS;
-    public int iterationsBudget = 200;
+    public PlayerConstants budgetType = PlayerConstants.BUDGET_ITERATIONS;
+    public int iterationsBudget = 1000;
     public int fmCallsBudget = 4000;
     public int timeBudget = 100; //milliseconds
     public int breakMS = 10;
@@ -19,8 +19,8 @@ public abstract class PlayerParameters extends TunableParameters {
 
     public PlayerParameters(long seed) {
         super(seed);
-        addTunableParameter("budgetType", PlayerConstants.BUDGET_FM_CALLS);
-        addTunableParameter("iterationsBudget", 200);
+        addTunableParameter("budgetType", PlayerConstants.BUDGET_ITERATIONS);
+        addTunableParameter("iterationsBudget", 1000);
         addTunableParameter("fmCallsBudget", 4000);
         addTunableParameter("timeBudget", 100);
         addTunableParameter("breakMS", 10);

--- a/src/main/java/players/mcts/BasicMCTSPlayer.java
+++ b/src/main/java/players/mcts/BasicMCTSPlayer.java
@@ -63,4 +63,8 @@ public class BasicMCTSPlayer extends AbstractPlayer {
         return root.bestAction();
     }
 
+    @Override
+    public String toString() {
+        return "BasicMCTS";
+    }
 }

--- a/src/main/java/players/mcts/BasicMCTSPlayer.java
+++ b/src/main/java/players/mcts/BasicMCTSPlayer.java
@@ -1,0 +1,66 @@
+package players.mcts;
+
+import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.actions.AbstractAction;
+import core.interfaces.IStateHeuristic;
+
+import java.util.List;
+import java.util.Random;
+
+import static players.mcts.MCTSEnums.OpponentTreePolicy.Paranoid;
+import static players.mcts.MCTSEnums.SelectionPolicy.ROBUST;
+import static players.mcts.MCTSEnums.TreePolicy.UCB;
+import static players.mcts.MCTSEnums.strategies.RANDOM;
+
+/**
+ * This is a simple version of MCTS that may be useful for newcomers to TAG and MCTS-like algorithms
+ * It strips out some of the additional configuration of MCTSPlayer. It uses BasicTreeNode in place of
+ * SingleTreeNode.
+ */
+public class BasicMCTSPlayer extends AbstractPlayer {
+
+    Random rnd;
+    MCTSParams params;
+
+    public BasicMCTSPlayer() {
+        this(System.currentTimeMillis());
+    }
+
+    public BasicMCTSPlayer(long seed) {
+        this.params = new MCTSParams(seed);
+        rnd = new Random(seed);
+
+        // These parameters can be changed, and will impact the Basic MCTS algorithm
+        this.params.K = Math.sqrt(2);
+        this.params.rolloutLength = 10;
+        this.params.maxTreeDepth = 5;
+        this.params.epsilon = 1e-6;
+
+        // These parameters are ignored by BasicMCTS - if you want to play with these, you'll
+        // need to upgrade to MCTSPlayer
+        this.params.openLoop = false;
+        this.params.redeterminise = false;
+        this.params.rolloutType = RANDOM;
+        this.params.selectionPolicy = ROBUST;
+        this.params.opponentTreePolicy = Paranoid;
+        this.params.treePolicy = UCB;
+    }
+
+    @Override
+    public AbstractAction getAction(AbstractGameState gameState) {
+        // Gather all available actions:
+        List<AbstractAction> allActions = gameState.getActions();
+
+        // Search for best action from the root
+        BasicTreeNode root = new BasicTreeNode(this, allActions, rnd);
+        root.setRootGameState(root, gameState);
+
+        // mctsSearch does all of the hard work
+        root.mctsSearch();
+
+        // Return best action
+        return root.bestAction();
+    }
+
+}

--- a/src/main/java/players/mcts/BasicTreeNode.java
+++ b/src/main/java/players/mcts/BasicTreeNode.java
@@ -1,0 +1,329 @@
+package players.mcts;
+
+import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.actions.AbstractAction;
+import core.interfaces.IStatisticLogger;
+import players.PlayerConstants;
+import players.simple.RandomPlayer;
+import utilities.ElapsedCpuTimer;
+import utilities.Utils;
+
+import java.util.*;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.*;
+import static players.PlayerConstants.*;
+import static players.mcts.MCTSEnums.OpponentTreePolicy.SelfOnly;
+import static players.mcts.MCTSEnums.TreePolicy.AlphaGo;
+import static utilities.Utils.entropyOf;
+import static utilities.Utils.noise;
+
+class BasicTreeNode {
+    // Root node of tree
+    BasicTreeNode root;
+    // Parent of this node
+    BasicTreeNode parent;
+    // Children of this node
+    Map<AbstractAction, BasicTreeNode> children = new HashMap<>();
+    // Depth of this node
+    final int depth;
+
+    // Total value of this node
+    private double totValue;
+    // Number of visits
+    private int nVisits;
+    // Number of FM calls and State copies up until this node
+    private int fmCallsCount;
+    // Parameters guiding the search
+    private BasicMCTSPlayer player;
+    private Random rnd;
+    private RandomPlayer randomPlayer = new RandomPlayer();
+
+    // State in this node (closed loop)
+    private AbstractGameState state;
+
+    // Called from MCTSPlayer
+    BasicTreeNode(BasicMCTSPlayer player, List<AbstractAction> actionsAvailable, Random rnd) {
+        this(player, actionsAvailable, null, null, null, rnd);
+    }
+
+    // Called in tree expansion
+    private BasicTreeNode(BasicMCTSPlayer player, List<AbstractAction> actionsAvailable, BasicTreeNode parent,
+                          BasicTreeNode root, AbstractGameState state, Random rnd) {
+        this.player = player;
+        this.fmCallsCount = 0;
+        this.parent = parent;
+        this.root = root;
+        actionsAvailable.forEach(a -> children.put(a, null));
+        totValue = 0.0;
+        this.state = state;
+        if (parent != null) {
+            depth = parent.depth + 1;
+        } else {
+            depth = 0;
+        }
+        this.rnd = rnd;
+    }
+
+    /**
+     * Initializes the root node
+     *
+     * @param root - root node
+     * @param gs   - root game state
+     */
+    void setRootGameState(BasicTreeNode root, AbstractGameState gs) {
+        this.state = gs;
+        this.root = root;
+    }
+
+    /**
+     * Performs full MCTS search, using the defined budget limits.
+     */
+    void mctsSearch() {
+
+        // Variables for tracking time budget
+        double avgTimeTaken;
+        double acumTimeTaken = 0;
+        long remaining;
+        int remainingLimit = player.params.breakMS;
+        ElapsedCpuTimer elapsedTimer = new ElapsedCpuTimer();
+        if (player.params.budgetType == BUDGET_TIME) {
+            elapsedTimer.setMaxTimeMillis(player.params.timeBudget);
+        }
+
+        // Tracking number of iterations for iteration budget
+        int numIters = 0;
+
+        boolean stop = false;
+
+        while (!stop) {
+            // New timer for this iteration
+            ElapsedCpuTimer elapsedTimerIteration = new ElapsedCpuTimer();
+
+            // Selection + expansion: navigate tree until a node not fully expanded is found, add a new node to the tree
+            BasicTreeNode selected = treePolicy();
+            // Monte carlo rollout: return value of MC rollout from the newly added node
+            double delta = selected.rollOut();
+            // Back up the value of the rollout through the tree
+            selected.backUp(delta);
+            // Finished iteration
+            numIters++;
+
+            // Check stopping condition
+            PlayerConstants budgetType = player.params.budgetType;
+            if (budgetType == BUDGET_TIME) {
+                // Time budget
+                acumTimeTaken += (elapsedTimerIteration.elapsedMillis());
+                avgTimeTaken = acumTimeTaken / numIters;
+                remaining = elapsedTimer.remainingTimeMillis();
+                stop = remaining <= 2 * avgTimeTaken || remaining <= remainingLimit;
+            } else if (budgetType == BUDGET_ITERATIONS) {
+                // Iteration budget
+                stop = numIters >= player.params.iterationsBudget;
+            } else if (budgetType == BUDGET_FM_CALLS) {
+                // FM calls budget
+                stop = fmCallsCount > player.params.fmCallsBudget;
+            }
+        }
+    }
+
+    /**
+     * Selection + expansion steps.
+     * - Tree is traversed until a node not fully expanded is found.
+     * - A new child of this node is added to the tree.
+     *
+     * @return - new node added to the tree.
+     */
+    private BasicTreeNode treePolicy() {
+
+        BasicTreeNode cur = this;
+
+        // Keep iterating while the state reached is not terminal and the depth of the tree is not exceeded
+        while (cur.state.isNotTerminal() && cur.depth < player.params.maxTreeDepth && cur.state.getActions().size() > 0) {
+            if (!cur.unexpandedActions().isEmpty()) {
+                // We have an unexpanded action
+                cur = cur.expand();
+            } else {
+                // Move to next child given by UCT function
+                AbstractAction actionChosen = cur.ucb();
+                cur = cur.children.get(actionChosen);
+            }
+        }
+
+        return cur;
+    }
+
+    /**
+     * @return A list of the unexpanded Actions from this State
+     */
+    private List<AbstractAction> unexpandedActions() {
+        return state.getActions().stream().filter(a -> children.get(a) == null).collect(toList());
+    }
+
+    /**
+     * Expands the node by creating a new random child node and adding to the tree.
+     *
+     * @return - new child node.
+     */
+    private BasicTreeNode expand() {
+        // Find random child not already created
+        Random r = new Random(player.params.getRandomSeed());
+        // pick a random unchosen action
+        List<AbstractAction> notChosen = unexpandedActions();
+        AbstractAction chosen = notChosen.get(r.nextInt(notChosen.size()));
+
+        // copy the current state and advance it using the chosen action
+        // we first copy the action so that the one stored in the node will not have any state changes
+        AbstractGameState nextState = state.copy();
+        List<AbstractAction> nextActions = advance(nextState, chosen.copy());
+
+        // then instantiate a new node
+        BasicTreeNode tn = new BasicTreeNode(player, nextActions, this, depth == 0 ? this : root, nextState, rnd);
+        children.put(chosen, tn);
+        return tn;
+    }
+
+    /**
+     * Advance the current game state with the given action, count the FM call and compute the next available actions.
+     *
+     * @param gs  - current game state
+     * @param act - action to apply
+     * @return - list of actions available in the next state
+     */
+    private List<AbstractAction> advance(AbstractGameState gs, AbstractAction act) {
+        player.getForwardModel().next(gs, act);
+        player.getForwardModel().computeAvailableActions(gs);
+        if (gs.isNotTerminal() && gs.getActions().isEmpty()) {
+            throw new AssertionError("Should always have at least one action possible...");
+        }
+        root.fmCallsCount++;
+        return gs.getActions();
+    }
+
+    private AbstractAction ucb() {
+        // Find child with highest UCB value, maximising for ourselves and minimizing for opponent
+        AbstractAction bestAction = null;
+        double bestValue = -Double.MAX_VALUE;
+
+        for (AbstractAction action : state.getActions()) {
+            BasicTreeNode child = children.get(action);
+            if (child == null)
+                throw new AssertionError("Should not be here");
+
+            // Find child value
+            double hvVal = child.totValue;
+            double childValue = hvVal / (child.nVisits + player.params.epsilon);
+
+            // default to standard UCB
+            double explorationTerm = player.params.K * Math.sqrt(Math.log(this.nVisits + 1) / (child.nVisits + player.params.epsilon));
+            // unless we are using a variant
+
+            // Find 'UCB' value
+            // If 'we' are taking a turn we use classic UCB
+            // If it is an opponent's turn, then we assume they are trying to minimise our score (with exploration)
+            boolean iAmMoving = state.getCurrentPlayer() == player.getPlayerID();
+            double uctValue = iAmMoving ? childValue : -childValue;
+            uctValue += explorationTerm;
+
+            // Apply small noise to break ties randomly
+            uctValue = noise(uctValue, player.params.epsilon, player.rnd.nextDouble());
+
+            // Assign value
+            if (uctValue > bestValue) {
+                bestAction = action;
+                bestValue = uctValue;
+            }
+        }
+
+        if (bestAction == null)
+            throw new AssertionError("We have a null value in UCT : shouldn't really happen!");
+
+        root.fmCallsCount++;  // log one iteration complete
+        return bestAction;
+    }
+
+    /**
+     * Perform a Monte Carlo rollout from this node.
+     *
+     * @return - value of rollout.
+     */
+    private double rollOut() {
+        int rolloutDepth = 0; // counting from end of tree
+
+        // If rollouts are enabled, select actions for the rollout in line with the rollout policy
+        AbstractGameState rolloutState = state;
+        if (player.params.rolloutLength > 0) {
+            while (!finishRollout(rolloutState, rolloutDepth)) {
+                AbstractAction next = randomPlayer.getAction(rolloutState);
+                advance(rolloutState, next);
+                rolloutDepth++;
+            }
+        }
+        // Evaluate final state and return normalised score
+        return rolloutState.getScore(player.getPlayerID());
+    }
+
+    /**
+     * Checks if rollout is finished. Rollouts end on maximum length, or if game ended.
+     *
+     * @param rollerState - current state
+     * @param depth       - current depth
+     * @return - true if rollout finished, false otherwise
+     */
+    private boolean finishRollout(AbstractGameState rollerState, int depth) {
+        if (depth >= player.params.rolloutLength)
+            return true;
+
+        // End of game
+        return !rollerState.isNotTerminal();
+    }
+
+    /**
+     * Back up the value of the child through all parents. Increase number of visits and total value.
+     *
+     * @param result - value of rollout to backup
+     */
+    private void backUp(double result) {
+        BasicTreeNode n = this;
+        while (n != null) {
+            n.nVisits++;
+            n.totValue += result;
+            n = n.parent;
+        }
+    }
+
+    /**
+     * Calculates the best action from the root according to the most visited node
+     *
+     * @return - the best AbstractAction
+     */
+    AbstractAction bestAction() {
+
+        double bestValue = -Double.MAX_VALUE;
+        AbstractAction bestAction = null;
+
+        for (AbstractAction action : children.keySet()) {
+            if (children.get(action) != null) {
+                BasicTreeNode node = children.get(action);
+                double childValue = node.nVisits;
+
+                // Apply small noise to break ties randomly
+                childValue = noise(childValue, player.params.epsilon, player.rnd.nextDouble());
+
+                // Save best value (highest visit count)
+                if (childValue > bestValue) {
+                    bestValue = childValue;
+                    bestAction = action;
+                }
+            }
+        }
+
+        if (bestAction == null) {
+            throw new AssertionError("Unexpected - no selection made.");
+        }
+
+        return bestAction;
+    }
+
+}

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -6,4 +6,8 @@ public class MCTSEnums {
         RANDOM
     }
 
+    public enum SelectionPolicy {
+        ROBUST, SIMPLE
+    }
+
 }

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -19,7 +19,7 @@ public class MCTSEnums {
     }
 
     public enum OpponentTreePolicy {
-        SelfOnly, Paranoid, Paranoid2
+        SelfOnly, Paranoid
         // TODO: MaxN to be added at some point - but that needs a vector reward to be back-propagated
     }
 

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -1,5 +1,9 @@
 package players.mcts;
 
+import core.actions.AbstractAction;
+
+import java.util.function.Function;
+
 public class MCTSEnums {
 
     public enum strategies {
@@ -8,6 +12,15 @@ public class MCTSEnums {
 
     public enum SelectionPolicy {
         ROBUST, SIMPLE
+    }
+
+    public enum TreePolicy {
+        UCB, EXP3, AlphaGo, RegretMatching
+    }
+
+    public enum OpponentTreePolicy {
+        SelfOnly, Paranoid, Paranoid2
+        // TODO: MaxN to be added at some point - but that needs a vector reward to be back-propagated
     }
 
 }

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -8,6 +8,8 @@ import java.util.*;
 
 import static players.mcts.MCTSEnums.SelectionPolicy.*;
 import static players.mcts.MCTSEnums.strategies.*;
+import static players.mcts.MCTSEnums.TreePolicy.*;
+import static players.mcts.MCTSEnums.OpponentTreePolicy.*;
 
 public class MCTSParams extends PlayerParameters {
 
@@ -18,8 +20,10 @@ public class MCTSParams extends PlayerParameters {
     public MCTSEnums.strategies rolloutType = RANDOM;
     public boolean openLoop = false;
     public boolean redeterminise = false;
-    public boolean selfOnlyInTree = false;
     public MCTSEnums.SelectionPolicy selectionPolicy = ROBUST;
+    public MCTSEnums.TreePolicy treePolicy = UCB;
+    public MCTSEnums.OpponentTreePolicy opponentTreePolicy = Paranoid;
+    public double exploreEpsilon = 0.1;
 
     public MCTSParams() {
         this(System.currentTimeMillis());
@@ -34,8 +38,10 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("rolloutType", RANDOM);
         addTunableParameter("openLoop", false, Arrays.asList(false, true));
         addTunableParameter("redeterminise", false, Arrays.asList(false, true));
-        addTunableParameter("selfOnlyInTree", false, Arrays.asList(false, true));
         addTunableParameter("selectionPolicy", ROBUST, Arrays.asList(MCTSEnums.SelectionPolicy.values()));
+        addTunableParameter("treePolicy", UCB);
+        addTunableParameter("opponentTreePolicy", Paranoid);
+        addTunableParameter("exploreEpsilon", 0.1);
     }
 
     @Override
@@ -48,8 +54,10 @@ public class MCTSParams extends PlayerParameters {
         rolloutType = (MCTSEnums.strategies) getParameterValue("rolloutType");
         openLoop = (boolean) getParameterValue("openLoop");
         redeterminise = (boolean) getParameterValue("redeterminise");
-        selfOnlyInTree = (boolean) getParameterValue("selfOnlyInTree");
         selectionPolicy = (MCTSEnums.SelectionPolicy) getParameterValue("selectionPolicy");
+        treePolicy = (MCTSEnums.TreePolicy) getParameterValue("treePolicy");
+        opponentTreePolicy = (MCTSEnums.OpponentTreePolicy) getParameterValue("opponentTreePolicy");
+        exploreEpsilon = (double) getParameterValue("exploreEpsilon");
     }
 
     @Override

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -15,7 +15,7 @@ public class MCTSParams extends PlayerParameters {
 
     public double K = Math.sqrt(2);
     public int rolloutLength = 10;
-    public boolean rolloutsEnabled = false;
+    public int maxTreeDepth = 10;
     public double epsilon = 1e-6;
     public MCTSEnums.strategies rolloutType = RANDOM;
     public boolean openLoop = false;
@@ -32,8 +32,8 @@ public class MCTSParams extends PlayerParameters {
     public MCTSParams(long seed) {
         super(seed);
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
-        addTunableParameter("rolloutLength", 10, Arrays.asList(6, 8, 10, 12, 20));
-        addTunableParameter("rolloutsEnabled", false, Arrays.asList(false, true));
+        addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 6, 8, 10, 12, 20));
+        addTunableParameter("maxTreeDepth", 10);
         addTunableParameter("epsilon", 1e-6);
         addTunableParameter("rolloutType", RANDOM);
         addTunableParameter("openLoop", false, Arrays.asList(false, true));
@@ -49,7 +49,7 @@ public class MCTSParams extends PlayerParameters {
         super._reset();
         K = (double) getParameterValue("K");
         rolloutLength = (int) getParameterValue("rolloutLength");
-        rolloutsEnabled = (boolean) getParameterValue("rolloutsEnabled");
+        maxTreeDepth = (int) getParameterValue("maxTreeDepth");
         epsilon = (double) getParameterValue("epsilon");
         rolloutType = (MCTSEnums.strategies) getParameterValue("rolloutType");
         openLoop = (boolean) getParameterValue("openLoop");

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -3,9 +3,11 @@ package players.mcts;
 import core.*;
 import players.PlayerParameters;
 import players.simple.RandomPlayer;
+
 import java.util.*;
 
-import static players.mcts.MCTSEnums.strategies.RANDOM;
+import static players.mcts.MCTSEnums.SelectionPolicy.*;
+import static players.mcts.MCTSEnums.strategies.*;
 
 public class MCTSParams extends PlayerParameters {
 
@@ -13,11 +15,16 @@ public class MCTSParams extends PlayerParameters {
     public int rolloutLength = 10;
     public boolean rolloutsEnabled = false;
     public double epsilon = 1e-6;
-    public MCTSEnums.strategies rolloutType = RANDOM;           ;
+    public MCTSEnums.strategies rolloutType = RANDOM;
+    public boolean openLoop = false;
+    public boolean redeterminise = false;
+    public boolean selfOnlyInTree = false;
+    public MCTSEnums.SelectionPolicy selectionPolicy = ROBUST;
 
     public MCTSParams() {
         this(System.currentTimeMillis());
     }
+
     public MCTSParams(long seed) {
         super(seed);
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
@@ -25,6 +32,10 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("rolloutsEnabled", false, Arrays.asList(false, true));
         addTunableParameter("epsilon", 1e-6);
         addTunableParameter("rolloutType", RANDOM);
+        addTunableParameter("openLoop", false, Arrays.asList(false, true));
+        addTunableParameter("redeterminise", false, Arrays.asList(false, true));
+        addTunableParameter("selfOnlyInTree", false, Arrays.asList(false, true));
+        addTunableParameter("selectionPolicy", ROBUST, Arrays.asList(MCTSEnums.SelectionPolicy.values()));
     }
 
     @Override
@@ -35,6 +46,10 @@ public class MCTSParams extends PlayerParameters {
         rolloutsEnabled = (boolean) getParameterValue("rolloutsEnabled");
         epsilon = (double) getParameterValue("epsilon");
         rolloutType = (MCTSEnums.strategies) getParameterValue("rolloutType");
+        openLoop = (boolean) getParameterValue("openLoop");
+        redeterminise = (boolean) getParameterValue("redeterminise");
+        selfOnlyInTree = (boolean) getParameterValue("selfOnlyInTree");
+        selectionPolicy = (MCTSEnums.SelectionPolicy) getParameterValue("selectionPolicy");
     }
 
     @Override
@@ -44,9 +59,13 @@ public class MCTSParams extends PlayerParameters {
 
     /**
      * @return Returns the AbstractPlayer policy that will take actions during an MCTS rollout.
-     *         This defaults to a Random player.
+     * This defaults to a Random player.
      */
     public AbstractPlayer getRolloutStrategy() {
+        return new RandomPlayer(new Random(getRandomSeed()));
+    }
+
+    public AbstractPlayer getOpponentModel() {
         return new RandomPlayer(new Random(getRandomSeed()));
     }
 

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -4,6 +4,8 @@ import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.actions.AbstractAction;
 import core.interfaces.IStateHeuristic;
+import core.interfaces.IStatisticLogger;
+import utilities.SummaryLogger;
 
 import java.util.List;
 import java.util.Random;
@@ -65,7 +67,8 @@ public class MCTSPlayer extends AbstractPlayer {
         // Search for best action from the root
         SingleTreeNode root = new SingleTreeNode(this, allActions);
         root.setRootGameState(root, gameState);
-        root.mctsSearch();
+        root.mctsSearch(getStatsLogger());
+
         if (debug)
             System.out.println(root.toString());
 

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -65,7 +65,7 @@ public class MCTSPlayer extends AbstractPlayer {
         List<AbstractAction> allActions = gameState.getActions();
 
         // Search for best action from the root
-        SingleTreeNode root = new SingleTreeNode(this, allActions);
+        SingleTreeNode root = new SingleTreeNode(this, allActions, rnd);
         root.setRootGameState(root, gameState);
         root.mctsSearch(getStatsLogger());
 

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -17,6 +17,7 @@ public class MCTSPlayer extends AbstractPlayer {
     // Heuristics used for the agent
     IStateHeuristic heuristic;
     AbstractPlayer rolloutStrategy;
+    AbstractPlayer opponentModel;
     private boolean debug = false;
 
     public MCTSPlayer() {
@@ -35,6 +36,7 @@ public class MCTSPlayer extends AbstractPlayer {
         this.params = params;
         rnd = new Random(this.params.getRandomSeed());
         rolloutStrategy = params.getRolloutStrategy();
+        opponentModel = params.getOpponentModel();
         setName(name);
     }
 
@@ -61,7 +63,7 @@ public class MCTSPlayer extends AbstractPlayer {
         List<AbstractAction> allActions = gameState.getActions();
 
         // Search for best action from the root
-        SingleTreeNode root = new SingleTreeNode(this, allActions.size());
+        SingleTreeNode root = new SingleTreeNode(this, allActions);
         root.setRootGameState(root, gameState);
         root.mctsSearch();
         if (debug)
@@ -69,7 +71,10 @@ public class MCTSPlayer extends AbstractPlayer {
 
 
         // Return best action
-        return allActions.get(root.mostVisitedAction());
+        return root.bestAction();
     }
 
+    public AbstractPlayer getOpponentModel(int playerID) {
+        return opponentModel;
+    }
 }

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -39,6 +39,7 @@ class SingleTreeNode {
 
     // State in this node (closed loop)
     private AbstractGameState state;
+    public AbstractGameState getState() { return state;}
 
     // Called from MCTSPlayer
     SingleTreeNode(MCTSPlayer player, List<AbstractAction> actionsAvailable, Random rnd) {
@@ -155,6 +156,7 @@ class SingleTreeNode {
         stats.put("time", timeTaken);
         stats.put("totalNodes", treeStats.totalNodes);
         stats.put("leafNodes", treeStats.totalLeaves);
+        stats.put("terminalNodes", treeStats.totalTerminalNodes);
         stats.put("maxDepth", treeStats.depthReached);
         stats.put("nActions", children.size());
         OptionalInt maxVisits = children.values().stream().filter(Objects::nonNull).mapToInt(n -> n.nVisits).max();
@@ -332,8 +334,8 @@ class SingleTreeNode {
 
         // Only advance the state if this is open loop
         if (player.params.openLoop) {
-            // we do not need to copy the state, as we advance this as we descend the tree
-            // in open loop we never re-use the state...the only purpose of storing it on the Node is
+            // We do not need to copy the state, as we advance this as we descend the tree.
+            // In open loop we never re-use the state...the only purpose of storing it on the Node is
             // to pick it up in the next uct() call as we descend the tree
             List<AbstractAction> nextActions = advance(state, bestAction.copy());
             selected.state = state;
@@ -350,15 +352,13 @@ class SingleTreeNode {
 
     public double exp3Value(AbstractAction action) {
         SingleTreeNode child = children.get(action);
-//        int nActions = state.getActions().size();
-//        double gamma = player.params.exploreEpsilon;
         double meanAdvantageFromAction = (child.totValue / child.nVisits) - (totValue / nVisits);
         return Math.exp(meanAdvantageFromAction);
     }
 
     public double rmValue(AbstractAction action) {
         // TODO: This is not quite correct for game in which not all actions are available for each visit
-        // TODO: (see comment in checkActions() - to be enhanced to keep track of this at some future point
+        // TODO: (see comment in checkActions() - to be enhanced to keep track of this at some future point)
         SingleTreeNode child = children.get(action);
         // potential value is our estimate of our accumulated reward if we had always taken this action
         double potentialValue = child.totValue * nVisits / child.nVisits;

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -210,14 +210,14 @@ class SingleTreeNode {
     private void advanceToTurnOfPlayer(AbstractGameState gs, int id) {
         // For the moment we only have one opponent model - that of a random player
         List<AbstractAction> actionsTaken = new ArrayList<>();
-        do {
+        while (gs.getCurrentPlayer() != id && gs.isNotTerminal()) {
             AbstractPlayer oppModel = player.getOpponentModel(gs.getCurrentPlayer());
             AbstractAction action = oppModel.getAction(gs);
             actionsTaken.add(action);
             player.getForwardModel().next(gs, action);
             player.getForwardModel().computeAvailableActions(gs);
             root.fmCallsCount++;
-        } while (gs.getCurrentPlayer() != id && gs.isNotTerminal());
+        }
     }
 
     /**

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -227,6 +227,9 @@ class SingleTreeNode {
     private List<AbstractAction> advance(AbstractGameState gs, AbstractAction act) {
         player.getForwardModel().next(gs, act);
         player.getForwardModel().computeAvailableActions(gs);
+        if (gs.getActions().isEmpty()) {
+            throw new AssertionError("Should always have at least one action possible...");
+        }
         root.fmCallsCount++;
         if (player.params.opponentTreePolicy == SelfOnly && gs.getCurrentPlayer() != player.getPlayerID())
             advanceToTurnOfPlayer(gs, player.getPlayerID());
@@ -248,6 +251,8 @@ class SingleTreeNode {
             actionsTaken.add(action);
             player.getForwardModel().next(gs, action);
             player.getForwardModel().computeAvailableActions(gs);
+            if (gs.getActions().isEmpty())
+                throw new AssertionError("Should always have at least one action possible...");
             root.fmCallsCount++;
         }
     }

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -311,11 +311,6 @@ class SingleTreeNode {
                 case Paranoid:
                     uctValue = iAmMoving ? childValue + explorationTerm : -childValue + explorationTerm;
                     break;
-                case Paranoid2:
-                    // This is the old policy - I'm not sure I agree that the exploration term should be treated
-                    // in the same way as the exploitation term (childValue). Hence my two versions of Paranoid. James.
-                    uctValue = iAmMoving ? childValue + explorationTerm : -childValue - explorationTerm;
-                    break;
                 case SelfOnly:
                     uctValue = childValue + explorationTerm;
             }

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -174,7 +174,7 @@ class SingleTreeNode {
         SingleTreeNode cur = this;
 
         // Keep iterating while the state reached is not terminal and the depth of the tree is not exceeded
-        while (cur.state.isNotTerminal() && cur.depth < player.params.maxTreeDepth && state.getActions().size() > 0) {
+        while (cur.state.isNotTerminal() && cur.depth < player.params.maxTreeDepth && cur.state.getActions().size() > 0) {
             if (!cur.unexpandedActions().isEmpty()) {
                 // We have an unexpanded action
                 cur = cur.expand();

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -227,7 +227,7 @@ class SingleTreeNode {
     private List<AbstractAction> advance(AbstractGameState gs, AbstractAction act) {
         player.getForwardModel().next(gs, act);
         player.getForwardModel().computeAvailableActions(gs);
-        if (gs.getActions().isEmpty()) {
+        if (gs.isNotTerminal() && gs.getActions().isEmpty()) {
             throw new AssertionError("Should always have at least one action possible...");
         }
         root.fmCallsCount++;
@@ -251,7 +251,7 @@ class SingleTreeNode {
             actionsTaken.add(action);
             player.getForwardModel().next(gs, action);
             player.getForwardModel().computeAvailableActions(gs);
-            if (gs.getActions().isEmpty())
+            if (gs.isNotTerminal() && gs.getActions().isEmpty())
                 throw new AssertionError("Should always have at least one action possible...");
             root.fmCallsCount++;
         }

--- a/src/main/java/players/mcts/TreeStatistics.java
+++ b/src/main/java/players/mcts/TreeStatistics.java
@@ -10,8 +10,10 @@ public class TreeStatistics {
     int depthReached = 0;
     int[] nodesAtDepth = new int[maxDepth];
     int[] leavesAtDepth = new int[maxDepth];
+    int[] gameTerminalNodesAtDepth = new int[maxDepth];
     int totalNodes;
     int totalLeaves;
+    int totalTerminalNodes;
     double[] nodeDistribution;
     double[] leafDistribution;
 
@@ -22,6 +24,8 @@ public class TreeStatistics {
             SingleTreeNode node = nodeQueue.poll();
             if (node.depth < maxDepth) {
                 nodesAtDepth[node.depth]++;
+                if (!node.getState().isNotTerminal())
+                    gameTerminalNodesAtDepth[node.depth]++;
                 for (SingleTreeNode child : node.children.values()) {
                     if (child != null)
                         nodeQueue.add(child);

--- a/src/main/java/players/mcts/TreeStatistics.java
+++ b/src/main/java/players/mcts/TreeStatistics.java
@@ -1,0 +1,55 @@
+package players.mcts;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.toList;
+
+public class TreeStatistics {
+
+    int maxDepth = 100;
+    int depthReached = 0;
+    int[] nodesAtDepth = new int[maxDepth];
+    int[] leavesAtDepth = new int[maxDepth];
+    int totalNodes;
+    int totalLeaves;
+    double[] nodeDistribution;
+    double[] leafDistribution;
+
+    public TreeStatistics(SingleTreeNode root) {
+        Queue<SingleTreeNode> nodeQueue = new ArrayDeque<>();
+        nodeQueue.add(root);
+        while (!nodeQueue.isEmpty()) {
+            SingleTreeNode node = nodeQueue.poll();
+            if (node.depth < maxDepth) {
+                nodesAtDepth[node.depth]++;
+                for (SingleTreeNode child : node.children.values()) {
+                    if (child != null)
+                        nodeQueue.add(child);
+                }
+                if (node.children.values().stream().allMatch(Objects::isNull))
+                    leavesAtDepth[node.depth]++;
+            }
+            if (node.depth > depthReached)
+                depthReached = node.depth;
+        }
+
+        totalNodes = Arrays.stream(nodesAtDepth).sum();
+        totalLeaves = Arrays.stream(leavesAtDepth).sum();
+        nodeDistribution = Arrays.stream(nodesAtDepth, 0, Math.min(depthReached + 1, maxDepth)).asDoubleStream().map(i -> i / totalNodes).toArray();
+        leafDistribution = Arrays.stream(leavesAtDepth, 0, Math.min(depthReached + 1, maxDepth)).asDoubleStream().map(i -> i / totalLeaves).toArray();
+    }
+
+
+
+    @Override
+    public String toString() {
+        StringBuilder retValue = new StringBuilder();
+        retValue.append(String.format("%d nodes and %d leaves, with maximum depth %d\n", totalNodes, totalLeaves, depthReached));
+        List<String> nodeDist = Arrays.stream(nodeDistribution).mapToObj(n -> String.format("%2.0f%%", n * 100.0)).collect(toList());
+        List<String> leafDist = Arrays.stream(leafDistribution).mapToObj(n -> String.format("%2.0f%%", n * 100.0)).collect(toList());
+        retValue.append(String.format("\tNodes  by depth: %s\n", String.join(", ", nodeDist)));
+        retValue.append(String.format("\tLeaves by depth: %s\n", String.join(", ", leafDist)));
+
+        return retValue.toString();
+    }
+}

--- a/src/main/java/players/rmhc/RMHCPlayer.java
+++ b/src/main/java/players/rmhc/RMHCPlayer.java
@@ -106,6 +106,11 @@ public class RMHCPlayer extends AbstractPlayer {
         avgTimeTaken = acumTimeTaken / numIters;
     }
 
+    @Override
+    public String toString() {
+        return "RMHC";
+    }
+
 //    public static void main(String[] args){
 //        /* 1. Action controller for GUI interactions. If set to null, running without visuals. */
 //        ActionController ac = new ActionController(); //null;

--- a/src/main/java/players/simple/OSLAPlayer.java
+++ b/src/main/java/players/simple/OSLAPlayer.java
@@ -64,4 +64,9 @@ public class OSLAPlayer extends AbstractPlayer {
         return bestAction;
     }
 
+    @Override
+    public String toString() {
+        return "OSLA";
+    }
+
 }

--- a/src/main/java/players/simple/RandomPlayer.java
+++ b/src/main/java/players/simple/RandomPlayer.java
@@ -30,4 +30,9 @@ public class RandomPlayer extends AbstractPlayer {
         List<AbstractAction> actions = observation.getActions();
         return actions.get(randomAction);
     }
+
+    @Override
+    public String toString() {
+        return "Random";
+    }
 }

--- a/src/main/java/utilities/FileStatsLogger.java
+++ b/src/main/java/utilities/FileStatsLogger.java
@@ -1,0 +1,109 @@
+package utilities;
+
+import core.interfaces.IStatisticLogger;
+
+import java.io.*;
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+
+/**
+ * A Class to log details to file for later analysis
+ */
+public class FileStatsLogger implements IStatisticLogger {
+
+    private String delimiter;
+    private FileWriter writer;
+    public String doubleFormat = "%.3g";
+    public String intFormat = "%d";
+
+    private Set<String> allKeys = new HashSet<>();
+
+    /**
+     * Note that one line will be output to the file per Map<String, ?>
+     * provided via record()
+     *
+     * @param fileName  The full location of the file to write results to
+     * @param delimiter The delimiter to use in the file between data items
+     */
+    public FileStatsLogger(String fileName, String delimiter) {
+        this.delimiter = delimiter;
+        try {
+            writer = new FileWriter(fileName);
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new AssertionError("Problem opening file " + fileName + " : " + e.getMessage());
+        }
+    }
+    public FileStatsLogger(String fileName) {
+        this(fileName, "\t");
+    }
+
+    /**
+     * Use to register a set of data in one go. It is not possible to add new keys after the first call
+     * of record(Map). Data linked to new, previously unseen keys will be ignored (and logged to console)
+     *
+     * @param data A map of name -> value pairs
+     */
+    @Override
+    public void record(Map<String, ?> data) {
+        try {
+            if (allKeys.isEmpty()) {
+                allKeys = data.keySet();
+                // then write a header line to the file
+                String outputLine = String.join(delimiter, allKeys) + "\n";
+                writer.write(outputLine);
+            } else {
+                data.keySet().forEach(s -> {
+                            if (!allKeys.contains(s)) {
+                                System.out.println("Unknown key in FileStatsLogger : " + s);
+                            }
+                        }
+                );
+            }
+            List<String> outputData = allKeys.stream().map(key -> {
+                Object datum = data.get(key);
+                if (datum == null) return "";
+                if (datum instanceof Integer) return String.format(intFormat, datum);
+                if (datum instanceof Double) return String.format(doubleFormat, datum);
+                return datum.toString();
+            }).collect(toList());
+
+            String outputLine = String.join(delimiter, outputData) + "\n";
+
+            writer.write(outputLine);
+        } catch (IOException e) {
+            e.printStackTrace();
+            throw new AssertionError("Problem writing to file " + writer.toString() + " : " + e.getMessage());
+        }
+    }
+
+    @Override
+    public void record(String key, Object datum) {
+        System.out.println("Datum ignored - FileStatsLogger only to be used with other record()");
+    }
+
+    /**
+     * This just closes the file
+     */
+    @Override
+    public void processDataAndFinish() {
+        try {
+            writer.flush();
+            writer.close();
+        } catch (Exception e) {
+            e.printStackTrace();
+            throw new AssertionError("Problem closing file " + writer.toString() + " : " + e.getMessage());
+        }
+    }
+
+    /**
+     * This always returns an empty Map
+     *
+     * @return A summary of the data
+     */
+    @Override
+    public Map<String, StatSummary> summary() {
+        return new HashMap<>();
+    }
+}

--- a/src/main/java/utilities/SummaryLogger.java
+++ b/src/main/java/utilities/SummaryLogger.java
@@ -1,0 +1,49 @@
+package utilities;
+
+import core.interfaces.IStatisticLogger;
+
+import java.util.*;
+
+import static java.util.stream.Collectors.*;
+
+public class SummaryLogger implements IStatisticLogger {
+
+    Map<String, StatSummary> allData = new HashMap<>();
+
+    @Override
+    public void record(String key, Number value) {
+        if (!allData.containsKey(key))
+            allData.put(key, new StatSummary());
+        allData.get(key).add(value);
+    }
+
+    @Override
+    public void record(Map<String, Number> data) {
+        for (String key : data.keySet()) {
+            record(key, data.get(key));
+        }
+    }
+
+    @Override
+    public Map<String, StatSummary> summary() {
+        return allData;
+    }
+
+    @Override
+    public void processDataAndFinish() {
+        System.out.println(toString());
+    }
+
+    @Override
+    public String toString() {
+        // We want to print out something vaguely pretty
+        List<String> alphabeticOrder = allData.keySet().stream().sorted().collect(toList());
+        StringBuilder sb = new StringBuilder();
+        for (String key : alphabeticOrder) {
+            StatSummary stats = allData.get(key);
+            sb.append(String.format("%30s  Mean: %.3g +/- %.2g,\t[%d, %d], pop sd %.3g,\tn=%d\n", key,
+                    stats.mean(), stats.stdErr(), (int) stats.min(), (int) stats.max(), stats.sd(), stats.n()));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/utilities/SummaryLogger.java
+++ b/src/main/java/utilities/SummaryLogger.java
@@ -6,19 +6,31 @@ import java.util.*;
 
 import static java.util.stream.Collectors.*;
 
+/**
+ * Statistics Logger that just takes in Numeric data and maintains summery statistics for each type:
+ * - mean, min, max, standard error, standard deviation, n
+ * A summary is printed out in alphabetic order once finished.
+ */
 public class SummaryLogger implements IStatisticLogger {
 
     Map<String, StatSummary> allData = new HashMap<>();
 
     @Override
-    public void record(String key, Number value) {
-        if (!allData.containsKey(key))
-            allData.put(key, new StatSummary());
-        allData.get(key).add(value);
+    public void record(String key, Object value) {
+        if (value instanceof Number) {
+            if (!allData.containsKey(key))
+                allData.put(key, new StatSummary());
+            allData.get(key).add((Number) value);
+        }
     }
 
+    /**
+     * Any data that is not numeric will be silently ignored
+     *
+     * @param data A map of name -> Number pairs
+     */
     @Override
-    public void record(Map<String, Number> data) {
+    public void record(Map<String, ?> data) {
         for (String key : data.keySet()) {
             record(key, data.get(key));
         }

--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -11,23 +11,35 @@ import java.util.*;
 import java.util.List;
 import java.util.function.Function;
 
+import static java.util.stream.Collectors.toList;
 import static java.util.stream.Collectors.toMap;
 
 public abstract class Utils {
 
     public static Color stringToColor(String c) {
-        switch(c.toLowerCase()) {
-            case "blue": return Color.BLUE;
-            case "black": return Color.BLACK;
-            case "yellow": return Color.YELLOW;
-            case "red": return Color.RED;
-            case "green": return new Color(30, 108, 47);
-            case "white": return Color.WHITE;
-            case "brown": return new Color(69, 29, 26);
-            case "pink": return Color.PINK;
-            case "orange": return Color.ORANGE;
-            case "light green": return Color.GREEN;
-            default: return null;
+        switch (c.toLowerCase()) {
+            case "blue":
+                return Color.BLUE;
+            case "black":
+                return Color.BLACK;
+            case "yellow":
+                return Color.YELLOW;
+            case "red":
+                return Color.RED;
+            case "green":
+                return new Color(30, 108, 47);
+            case "white":
+                return Color.WHITE;
+            case "brown":
+                return new Color(69, 29, 26);
+            case "pink":
+                return Color.PINK;
+            case "orange":
+                return Color.ORANGE;
+            case "light green":
+                return Color.GREEN;
+            default:
+                return null;
         }
     }
 
@@ -59,11 +71,12 @@ public abstract class Utils {
 
     /**
      * Finds index in array of String objects.
-     * @param array - array of String
+     *
+     * @param array  - array of String
      * @param object - object to look for
      * @return - index of String object, -1 if not found
      */
-    public static int indexOf (String[] array, String object) {
+    public static int indexOf(String[] array, String object) {
         for (int i = 0; i < array.length; i++) {
             if (object.equals(array[i])) {
                 return i;
@@ -74,11 +87,12 @@ public abstract class Utils {
 
     /**
      * Finds index of integer in array.
-     * @param array - array of integers
+     *
+     * @param array  - array of integers
      * @param object - integer to look for
      * @return - index of integer object, -1 if not found
      */
-    public static int indexOf (int[] array, int object) {
+    public static int indexOf(int[] array, int object) {
         for (int i = 0; i < array.length; i++) {
             if (object == array[i]) {
                 return i;
@@ -89,20 +103,21 @@ public abstract class Utils {
 
     /**
      * Generates all permutations of a given array of integers.
-     * @param n - current index to search up to
+     *
+     * @param n        - current index to search up to
      * @param elements - array with elements
-     * @param all - list where all permutations should be added
+     * @param all      - list where all permutations should be added
      */
     public static void generatePermutations(int n, int[] elements, ArrayList<int[]> all) {
         if (n == 1) {
             all.add(elements.clone());
         } else {
-            for(int i = 0; i < n-1; i++) {
+            for (int i = 0; i < n - 1; i++) {
                 generatePermutations(n - 1, elements, all);
-                if(n % 2 == 0) {
-                    swap(elements, i, n-1);
+                if (n % 2 == 0) {
+                    swap(elements, i, n - 1);
                 } else {
-                    swap(elements, 0, n-1);
+                    swap(elements, 0, n - 1);
                 }
             }
             generatePermutations(n - 1, elements, all);
@@ -111,9 +126,10 @@ public abstract class Utils {
 
     /**
      * Performs a swap of 2 elements in an integer array at given indexes. Modifies original array.
+     *
      * @param input - input array
-     * @param a - index of first element
-     * @param b - index of second element
+     * @param a     - index of first element
+     * @param b     - index of second element
      */
     public static void swap(int[] input, int a, int b) {
         int tmp = input[a];
@@ -124,51 +140,54 @@ public abstract class Utils {
     /**
      * Find a list of coordinates for neighbours of point at (x, y) in 2D grid of given width and height, with either
      * 8-way or 4-way connectivity.
-     * @param x - x coordinate of point
-     * @param y - y coordinate of point
-     * @param width - width of grid
+     *
+     * @param x      - x coordinate of point
+     * @param y      - y coordinate of point
+     * @param width  - width of grid
      * @param height - height of grid
-     * @param way8 - if true, grid has 8-way connectivity, otherwise just 4.
+     * @param way8   - if true, grid has 8-way connectivity, otherwise just 4.
      * @return List of Vector2D, coordinates for valid neighbours
      */
     public static java.util.List<Vector2D> getNeighbourhood(int x, int y, int width, int height, boolean way8) {
         List<Vector2D> neighbours = new ArrayList<>();
 
         // Add orthogonal neighbours
-        if (x > 0) neighbours.add(new Vector2D(x-1, y));
-        if (x < width-1) neighbours.add(new Vector2D(x+1, y));
-        if (y > 0) neighbours.add(new Vector2D(x, y-1));
-        if (y < height-1) neighbours.add(new Vector2D(x, y+1));
+        if (x > 0) neighbours.add(new Vector2D(x - 1, y));
+        if (x < width - 1) neighbours.add(new Vector2D(x + 1, y));
+        if (y > 0) neighbours.add(new Vector2D(x, y - 1));
+        if (y < height - 1) neighbours.add(new Vector2D(x, y + 1));
 
         // Add diagonal neighbours
         if (way8) {
-            if (x > 0 && y > 0) neighbours.add(new Vector2D(x-1, y-1));
-            if (x < width-1 && y < height-1) neighbours.add(new Vector2D(x+1, y+1));
-            if (x > 0 && y < height-1) neighbours.add(new Vector2D(x-1, y+1));
-            if (x < width-1 && y > 0) neighbours.add(new Vector2D(x+1, y-1));
+            if (x > 0 && y > 0) neighbours.add(new Vector2D(x - 1, y - 1));
+            if (x < width - 1 && y < height - 1) neighbours.add(new Vector2D(x + 1, y + 1));
+            if (x > 0 && y < height - 1) neighbours.add(new Vector2D(x - 1, y + 1));
+            if (x < width - 1 && y > 0) neighbours.add(new Vector2D(x + 1, y - 1));
         }
         return neighbours;
     }
 
     /**
      * Normalizes a value in range [0, 1] given its minimum and maximum possible.
+     *
      * @param a_value - value to normalize
-     * @param a_min - minimum possible
-     * @param a_max - maximum possible
+     * @param a_min   - minimum possible
+     * @param a_max   - maximum possible
      * @return - normalized value
      */
     public static double normalise(double a_value, double a_min, double a_max) {
         if (a_min < a_max)
-            return (a_value - a_min)/(a_max - a_min);
+            return (a_value - a_min) / (a_max - a_min);
         else    // if bounds are invalid, then return same value
             return a_value;
     }
 
     /**
      * Applies random noise to input.
-     * @param input - value to apply noise to.
+     *
+     * @param input   - value to apply noise to.
      * @param epsilon - how much should the noise weigh in returned value.
-     * @param random - how much noise should be applied.
+     * @param random  - how much noise should be applied.
      * @return - new value with noise applied.
      */
     public static double noise(double input, double epsilon, double random) {
@@ -177,12 +196,18 @@ public abstract class Utils {
 
     public static double entropyOf(double... data) {
         double sum = Arrays.stream(data).sum();
-        double[] normalised = Arrays.stream(data).map(d -> d/sum).toArray();
+        double[] normalised = Arrays.stream(data).map(d -> d / sum).toArray();
         return Arrays.stream(normalised).map(d -> -d * Math.log(d)).sum();
     }
 
     public static <T> Map<T, Double> normaliseMap(Map<T, ? extends Number> input) {
+        int lessThanZero = (int) input.values().stream().filter(n -> n.doubleValue() < 0.0).count();
+        if (lessThanZero > 0) throw new AssertionError("Probability has negative values!");
         double sum = input.values().stream().mapToDouble(Number::doubleValue).sum();
+        if (sum == 0.0) {
+            // the sum is zero, with no negative values. Hence all values are zero, and we return a uniform distribution.
+            return input.keySet().stream().collect(toMap(key -> key, key -> 1.0 / input.size()));
+        }
         return input.keySet().stream().collect(toMap(key -> key, key -> input.get(key).doubleValue() / sum));
     }
 
@@ -196,7 +221,7 @@ public abstract class Utils {
                 return (T) Double.valueOf(rawString);
             } else if (defaultValue instanceof Boolean) {
                 return (T) Boolean.valueOf(rawString);
-            } else if (defaultValue instanceof String){
+            } else if (defaultValue instanceof String) {
                 return (T) rawString;
             } else {
                 throw new AssertionError("Unexpected type of defaultValue : " + defaultValue.getClass());

--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -172,6 +172,12 @@ public abstract class Utils {
         return (input + epsilon) * (1.0 + epsilon * (random - 0.5));
     }
 
+    public static double entropyOf(double... data) {
+        double sum = Arrays.stream(data).sum();
+        double[] normalised = Arrays.stream(data).map(d -> d/sum).toArray();
+        return Arrays.stream(normalised).map(d -> -d * Math.log(d)).sum();
+    }
+
     public static <T> T getArg(String[] args, String name, T defaultValue) {
         Optional<String> raw = Arrays.stream(args).filter(i -> i.toLowerCase().startsWith(name.toLowerCase() + "=")).findFirst();
         if (raw.isPresent()) {

--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -9,6 +9,9 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
 import java.util.List;
+import java.util.function.Function;
+
+import static java.util.stream.Collectors.toMap;
 
 public abstract class Utils {
 
@@ -176,6 +179,11 @@ public abstract class Utils {
         double sum = Arrays.stream(data).sum();
         double[] normalised = Arrays.stream(data).map(d -> d/sum).toArray();
         return Arrays.stream(normalised).map(d -> -d * Math.log(d)).sum();
+    }
+
+    public static <T> Map<T, Double> normaliseMap(Map<T, ? extends Number> input) {
+        double sum = input.values().stream().mapToDouble(Number::doubleValue).sum();
+        return input.keySet().stream().collect(toMap(key -> key, key -> input.get(key).doubleValue() / sum));
     }
 
     public static <T> T getArg(String[] args, String name, T defaultValue) {


### PR DESCRIPTION
Major change here is a set of MCTS enhancements to implement various algorithmic variants from the literature. This has involved some significant 'refactoring' of SingleTreeNode in particular. The major design point is that child nodes are no longer kept in an array with a fixed order, but in a Map keyed by the AbstractAction that leads to the node.

MCTSParams has also had a fair amount added to it:
1) SelectionPolicy can be ROBUST or SIMPLE. ROBUST (the old default) picks the final action based on the number of visits, while SIMPLE picks the action with the highest mean value.

2) RolloutsEnabled has been subsumed into RolloutLength. RolloutLength ==0 implies no rollouts.

3) OpenLoop can be FALSE or TRUE. FALSE is the old default, which assumes deterministic environments and does not advance the GameState as the Tree is descended. TRUE now supports OpenLoop MCTS, in which the game state is advanced on every iteration as we extend the tree. (For this reason I have added a copyCount as well as fmCallsCount, and for the moment set the fmCallsBudget to apply to the sum of the two; the old code was advancing fmCallsCount as the tree was descended, even though the FM was never called.)

4) OpponentTreePolicy has 3 values SelfOnly, Paranoid, Paranoid2. SelfOnly means that we ignore our opponents in the Tree, and only construct this using our actions. Paranoid2 is the original version - assuming that opponents are attempting to minimise our score. Paranoid is my version of this - I suspect, subject to feedback/review - that the Exploration bonus was misapplied in Paranoid2.

5) I have split RolloutLength into two parts: MaxTreeDepth and RolloutLength. MaxTreeDepth limits the depth of the tree (you'd never have guessed!), while RolloutLength now applies purely to the rollout outside the tree. This does mean that currently you cannot restrain  the sum of the two to a specific value - but it does mean that Monte Carlo Search is now supported with MaxTreeDepth=1, RolloutLength = High.

6) Redeterminise can be TRUE or FALSE. (FALSE is the old functionality). TRUE is a very simple form of Information Set MCTS that redeterminised the root game state used for each iteration. We should expect this to be significantly better on stochastic games.

7) TreePolicy can be any of UCB, AlphaGo, EXP3, RegretMatching. UCB is the standard logic, AlphaGo replaces the form of the UCB exploration term with that used by AlphaGo (instead of sqrt(logN / n) it uses sqrt(N) / (1 + n)).
EXP3 and Regret Matching implement the bandit algorithms of the same names instead of UCB. These have an exploration term, which is configured using exploreEpsilon as a new parameter (this is not used outside of these variants).