### PR TITLE
Available action refactor + addition of history to GameState

### DIFF
--- a/src/main/java/core/AbstractForwardModel.java
+++ b/src/main/java/core/AbstractForwardModel.java
@@ -105,6 +105,7 @@ public abstract class AbstractForwardModel {
      */
     public final void next(AbstractGameState currentState, AbstractAction action) {
         if (action != null) {
+            currentState.recordAction(action);
             _next(currentState, action);
         } else {
             if (VERBOSE) {

--- a/src/main/java/core/AbstractForwardModel.java
+++ b/src/main/java/core/AbstractForwardModel.java
@@ -19,7 +19,6 @@ public abstract class AbstractForwardModel {
      * @param firstState - initial state.
      */
     protected void abstractSetup(AbstractGameState firstState) {
-        firstState.availableActions = new ArrayList<>();
         firstState.gameStatus = Utils.GameResult.GAME_ONGOING;
         firstState.playerResults = new Utils.GameResult[firstState.getNPlayers()];
         Arrays.fill(firstState.playerResults, Utils.GameResult.GAME_ONGOING);
@@ -83,8 +82,9 @@ public abstract class AbstractForwardModel {
             gameState.setPlayerResult(Utils.GameResult.DISQUALIFY, gameState.getCurrentPlayer());
             gameState.turnOrder.endPlayerTurn(gameState);
         } else {
-            int randomAction = new Random(gameState.getGameParameters().getRandomSeed()).nextInt(gameState.getActions().size());
-            next(gameState, gameState.getActions().get(randomAction));
+            List<AbstractAction> possibleActions = computeAvailableActions(gameState);
+            int randomAction = new Random(gameState.getGameParameters().getRandomSeed()).nextInt(possibleActions.size());
+            next(gameState, possibleActions.get(randomAction));
         }
     }
 
@@ -104,7 +104,7 @@ public abstract class AbstractForwardModel {
      * @param action - action requested to be played by a player.
      */
     public final void next(AbstractGameState currentState, AbstractAction action) {
-        if (action != null && currentState.getActions().contains(action)) {
+        if (action != null) {
             _next(currentState, action);
         } else {
             if (VERBOSE) {
@@ -120,9 +120,7 @@ public abstract class AbstractForwardModel {
      * @return - the list of actions available.
      */
     public final List<AbstractAction> computeAvailableActions(AbstractGameState gameState) {
-        List<AbstractAction> actions = _computeAvailableActions(gameState);
-        gameState.setAvailableActions(actions);
-        return actions;
+        return _computeAvailableActions(gameState);
     }
 
     /**

--- a/src/main/java/core/AbstractGUI.java
+++ b/src/main/java/core/AbstractGUI.java
@@ -10,6 +10,7 @@ import java.awt.*;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
+import java.util.stream.Collectors;
 
 @SuppressWarnings("rawtypes")
 public abstract class AbstractGUI extends JFrame {
@@ -24,6 +25,9 @@ public abstract class AbstractGUI extends JFrame {
     protected int maxActionSpace;
     protected ActionController ac;
     protected JLabel gameStatus, playerStatus, turnOwner, turn, currentPlayer, gamePhase;
+    protected JTextPane historyInfo;
+    protected JScrollPane historyContainer;
+    private int actionsAtLastUpdate;
     private WindowInput wi;
 
     public AbstractGUI(ActionController ac, int maxActionSpace) {
@@ -35,6 +39,7 @@ public abstract class AbstractGUI extends JFrame {
         turnOwner = new JLabel();
         turn = new JLabel();
         currentPlayer = new JLabel();
+        historyInfo = new JTextPane();
 
         this.wi = new WindowInput();
         addWindowListener(wi);
@@ -134,11 +139,16 @@ public abstract class AbstractGUI extends JFrame {
         gameInfo.add(turn);
         gameInfo.add(currentPlayer);
 
-        gameInfo.setPreferredSize(new Dimension(width, height));
+        gameInfo.setPreferredSize(new Dimension(width/2 - 10, height));
 
         JPanel wrapper = new JPanel();
+        wrapper.setLayout(new FlowLayout());
         wrapper.add(gameInfo);
-        wrapper.setLayout(new GridBagLayout());
+
+        historyInfo.setPreferredSize(new Dimension(width/2 - 10, height));
+        historyContainer = new JScrollPane(historyInfo);
+        historyContainer.setPreferredSize(new Dimension(width/2 - 25, height));
+        wrapper.add(historyContainer);
         return wrapper;
     }
 
@@ -147,6 +157,13 @@ public abstract class AbstractGUI extends JFrame {
      * @param gameState - current game state to be used for the update.
      */
     protected void updateGameStateInfo(AbstractGameState gameState) {
+        List<String> history = gameState.getHistoryAsText();
+        if (history.size() > actionsAtLastUpdate) {
+            // this is to stop the panel updating on every tick during one's own turn
+            actionsAtLastUpdate = history.size();
+            historyInfo.setText(String.join("\n", history));
+            historyInfo.setCaretPosition(historyInfo.getDocument().getLength());
+        }
         gameStatus.setText("Game status: " + gameState.getGameStatus());
         playerStatus.setText(Arrays.toString(gameState.getPlayerResults()));
         gamePhase.setText("Game phase: " + gameState.getGamePhase());

--- a/src/main/java/core/AbstractGUI.java
+++ b/src/main/java/core/AbstractGUI.java
@@ -66,7 +66,7 @@ public abstract class AbstractGUI extends JFrame {
      */
     protected void updateActionButtons(AbstractPlayer player, AbstractGameState gameState) {
         if (gameState.gameStatus == Utils.GameResult.GAME_ONGOING) {
-            List<AbstractAction> actions = gameState.getActions();
+            List<AbstractAction> actions = player.forwardModel.computeAvailableActions(gameState);
             for (int i = 0; i < actions.size(); i++) {
                 actionButtons[i].setVisible(true);
                 actionButtons[i].setButtonAction(actions.get(i), gameState);

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -31,6 +31,7 @@ public abstract class AbstractGameState {
 
     // A record of all actions taken to reach this game state
     private List<AbstractAction> history = new ArrayList<>();
+    private List<String> historyText = new ArrayList<>();
 
     // Status of the game, and status for each player (in cooperative games, the game status is also each player's status)
     protected Utils.GameResult gameStatus;
@@ -62,6 +63,8 @@ public abstract class AbstractGameState {
         playerResults = new Utils.GameResult[getNPlayers()];
         Arrays.fill(playerResults, GAME_ONGOING);
         gamePhase = DefaultGamePhase.Main;
+        history = new ArrayList<>();
+        historyText = new ArrayList<>();
         _reset();
     }
 
@@ -130,6 +133,7 @@ public abstract class AbstractGameState {
         s.data = data;  // Should never be modified
 
         s.history = new ArrayList<>(history);
+        s.historyText = new ArrayList<>(historyText);
             // we do not copy individual actions in history, as these are now dead and should not change
 
         // Update the list of components for ID matching in actions.
@@ -209,6 +213,26 @@ public abstract class AbstractGameState {
      */
     public final ArrayList<Integer> getUnknownComponentsIds(int playerId) {
         return _getUnknownComponentsIds(playerId);
+    }
+
+    /**
+     * Used by ForwardModel.next() to log history (very useful for debugging)
+     *
+     * @param action The action that has just been applied (or is about to be applied) to the game state
+     */
+    protected void recordAction(AbstractAction action) {
+        history.add(action);
+        historyText.add("Player " + this.getCurrentPlayer() + " : " + action.getString(this));
+    }
+
+    /**
+     * @return All actions that have been executed on this state since reset()/initialisation
+     */
+    public List<AbstractAction> getHistory() {
+        return new ArrayList<>(history);
+    }
+    public List<String> getHistoryAsText() {
+        return new ArrayList<>(historyText);
     }
 
     @Override

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -28,10 +28,9 @@ public abstract class AbstractGameState {
     protected final AbstractParameters gameParameters;
     protected TurnOrder turnOrder;
     private Area allComponents;
-    private List<AbstractAction> history = new ArrayList<>();
 
-    // List of actions currently available for the player
-    protected List<AbstractAction> availableActions;
+    // A record of all actions taken to reach this game state
+    private List<AbstractAction> history = new ArrayList<>();
 
     // Status of the game, and status for each player (in cooperative games, the game status is also each player's status)
     protected Utils.GameResult gameStatus;
@@ -59,7 +58,6 @@ public abstract class AbstractGameState {
     void reset() {
         turnOrder.reset();
         allComponents = new Area(-1, "All Components");
-        availableActions = new ArrayList<>();
         gameStatus = GAME_ONGOING;
         playerResults = new Utils.GameResult[getNPlayers()];
         Arrays.fill(playerResults, GAME_ONGOING);
@@ -87,9 +85,6 @@ public abstract class AbstractGameState {
     public final void setMainGamePhase() {
         this.gamePhase = DefaultGamePhase.Main;
     }
-    public final void setAvailableActions(List<AbstractAction> availableActions) {
-        this.availableActions = availableActions;
-    }
 
     // Getters
     public final TurnOrder getTurnOrder(){return turnOrder;}
@@ -99,9 +94,6 @@ public abstract class AbstractGameState {
     public final int getNPlayers() { return turnOrder.nPlayers(); }
     public final Utils.GameResult[] getPlayerResults() { return playerResults; }
     public final boolean isNotTerminal(){ return gameStatus == GAME_ONGOING; }
-    public final List<AbstractAction> getActions() {
-        return Collections.unmodifiableList(availableActions);
-    }
     public final IGamePhase getGamePhase() {
         return gamePhase;
     }
@@ -137,10 +129,6 @@ public abstract class AbstractGameState {
         s.gamePhase = gamePhase;
         s.data = data;  // Should never be modified
 
-        s.availableActions = new ArrayList<>();
-        for (AbstractAction a: availableActions) {
-            s.availableActions.add(a.copy());
-        }
         s.history = new ArrayList<>(history);
             // we do not copy individual actions in history, as these are now dead and should not change
 
@@ -231,16 +219,16 @@ public abstract class AbstractGameState {
         return Objects.equals(gameParameters, gameState.gameParameters) &&
                 Objects.equals(turnOrder, gameState.turnOrder) &&
                 Objects.equals(allComponents, gameState.allComponents) &&
-                Objects.equals(availableActions, gameState.availableActions) &&
                 gameStatus == gameState.gameStatus &&
                 Arrays.equals(playerResults, gameState.playerResults) &&
                 Objects.equals(gamePhase, gameState.gamePhase) &&
                 _equals(o);
+        // we deliberately exclude history from this equality check
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(gameParameters, turnOrder, allComponents, availableActions, gameStatus, gamePhase, data);
+        int result = Objects.hash(gameParameters, turnOrder, allComponents, gameStatus, gamePhase, data);
         result = 31 * result + Arrays.hashCode(playerResults);
         return result;
     }

--- a/src/main/java/core/AbstractPlayer.java
+++ b/src/main/java/core/AbstractPlayer.java
@@ -32,7 +32,6 @@ public abstract class AbstractPlayer {
     public final AbstractForwardModel getForwardModel() {
         return forwardModel;
     }
-    public final void setForwardModel(AbstractForwardModel fm) {forwardModel = fm;}
 
     /* Methods that should be implemented in subclass */
 

--- a/src/main/java/core/AbstractPlayer.java
+++ b/src/main/java/core/AbstractPlayer.java
@@ -4,6 +4,8 @@ import core.actions.AbstractAction;
 import core.interfaces.IStatisticLogger;
 import utilities.SummaryLogger;
 
+import java.util.List;
+
 public abstract class AbstractPlayer {
 
     protected IStatisticLogger statsLogger = new SummaryLogger();
@@ -30,6 +32,7 @@ public abstract class AbstractPlayer {
     public final AbstractForwardModel getForwardModel() {
         return forwardModel;
     }
+    public final void setForwardModel(AbstractForwardModel fm) {forwardModel = fm;}
 
     /* Methods that should be implemented in subclass */
 
@@ -38,7 +41,7 @@ public abstract class AbstractPlayer {
      * AbstractGameState.getActions()
      * @param gameState observation of the current game state
      */
-    public abstract AbstractAction getAction(AbstractGameState gameState);
+    public abstract AbstractAction getAction(AbstractGameState gameState, List<AbstractAction> possibleActions);
 
     /* Methods that can be implemented in subclass */
 

--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -251,13 +251,13 @@ public class Game {
                     } else {
                         if (currentPlayer instanceof HumanGUIPlayer && gui != null) {
                             while (action == null && gui.isWindowOpen()) {
-                                action = currentPlayer.getAction(observation);
+                                action = currentPlayer.getAction(observation, observedActions);
                                 updateGUI(gui);
                             }
                         } else {
                             // Get action from player, and time it
                             s = System.nanoTime();
-                            action = currentPlayer.getAction(observation);
+                            action = currentPlayer.getAction(observation, observedActions);
                             agentTime += (System.nanoTime() - s);
                             nDecisions++;
                         }
@@ -676,6 +676,7 @@ public class Game {
 
         /* 3. Set up players for the game */
         ArrayList<AbstractPlayer> players = new ArrayList<>();
+
         players.add(new RandomPlayer());
         players.add(new RMHCPlayer());
         players.add(new MCTSPlayer());
@@ -696,7 +697,7 @@ public class Game {
         ArrayList<GameType> games = new ArrayList<>(Arrays.asList(GameType.values()));
 //        games.remove(LoveLetter);
         games.remove(Pandemic);
-//        games.remove(TicTacToe);
+        games.remove(TicTacToe);
         runMany(games, players, null, 100, ac, false, true);
 //        runMany(new ArrayList<GameType>() {{add(Uno);}}, players, null, 1000, null, false, false);
     }

--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -669,7 +669,7 @@ public class Game {
      */
     public static void main(String[] args) {
         /* 1. Action controller for GUI interactions. If set to null, running without visuals. */
-        ActionController ac = null;//new ActionController(); //null;
+        ActionController ac = new ActionController(); //null;
 
         /* 2. Game seed */
         long seed = System.currentTimeMillis(); //0;
@@ -677,15 +677,15 @@ public class Game {
         /* 3. Set up players for the game */
         ArrayList<AbstractPlayer> players = new ArrayList<>();
 
-        players.add(new RandomPlayer());
+//        players.add(new RandomPlayer());
         players.add(new RMHCPlayer());
         players.add(new MCTSPlayer());
         players.add(new OSLAPlayer());
-//        players.add(new HumanGUIPlayer(ac));
+        players.add(new HumanGUIPlayer(ac));
 //        players.add(new HumanConsolePlayer());
 
         /* 4. Run! */
-//        runOne(ExplodingKittens, players, seed, ac, false);
+        runOne(LoveLetter, players, seed, ac, false);
 //        runMany(GameType.Category.Strategy.getAllGames(), players, null, 50, null, false);
 
 //        ArrayList<GameType> games = new ArrayList<>();
@@ -694,11 +694,11 @@ public class Game {
 //        games.add(LoveLetter);
 //        runMany(games, players, null, 50, null, false, false);
 
-        ArrayList<GameType> games = new ArrayList<>(Arrays.asList(GameType.values()));
+//        ArrayList<GameType> games = new ArrayList<>(Arrays.asList(GameType.values()));
 //        games.remove(LoveLetter);
-        games.remove(Pandemic);
-        games.remove(TicTacToe);
-        runMany(games, players, null, 100, ac, false, true);
+//        games.remove(Pandemic);
+//        games.remove(TicTacToe);
+//        runMany(games, players, null, 100, ac, false, true);
 //        runMany(new ArrayList<GameType>() {{add(Uno);}}, players, null, 1000, null, false, false);
     }
 }

--- a/src/main/java/evaluation/testplayers/RandomTestPlayer.java
+++ b/src/main/java/evaluation/testplayers/RandomTestPlayer.java
@@ -34,9 +34,7 @@ public class RandomTestPlayer extends AbstractPlayer {
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState gs ) {
-        List<AbstractAction> actions = gs.getActions();
-
+    public AbstractAction getAction(AbstractGameState gs, List<AbstractAction> actions ) {
         // Iterate through all actions available to gather statistics
         HashSet<AbstractGameState> states = new HashSet<>();
         states.add(gs.copy());

--- a/src/main/java/games/explodingkittens/gui/ExplodingKittensGUI.java
+++ b/src/main/java/games/explodingkittens/gui/ExplodingKittensGUI.java
@@ -44,7 +44,7 @@ public class ExplodingKittensGUI extends AbstractGUI {
     Border[] playerViewBorders;
 
     public ExplodingKittensGUI(Game game, ActionController ac, int humanID) {
-        super(ac, 15);
+        super(ac, 25);
         this.humanID = humanID;
 
         if (game != null) {
@@ -58,7 +58,7 @@ public class ExplodingKittensGUI extends AbstractGUI {
                 int nHorizAreas = 1 + (nPlayers <= 3 ? 2 : nPlayers == 4 ? 3 : nPlayers <= 8 ? 4 : 5);
                 double nVertAreas = 5;
                 this.width = playerAreaWidth * nHorizAreas;
-                this.height = (int) (playerAreaHeight * nVertAreas);
+                this.height = (int) (playerAreaHeight * nVertAreas) + 20;
 
                 ExplodingKittensGameState ekgs = (ExplodingKittensGameState) gameState;
                 ExplodingKittensParameters ekgp = (ExplodingKittensParameters) gameState.getGameParameters();

--- a/src/main/java/games/pandemic/gui/PandemicGUI.java
+++ b/src/main/java/games/pandemic/gui/PandemicGUI.java
@@ -311,7 +311,7 @@ public class PandemicGUI extends AbstractGUI {
 
     protected void updateActionButtons(AbstractPlayer player, AbstractGameState gameState) {
         int id = player.getPlayerID();
-        List<AbstractAction> actions = gameState.getActions();
+        List<AbstractAction> actions = player.getForwardModel().computeAvailableActions(gameState);
         int k = 0;
 
         Set<String> highlights = boardView.getHighlights().keySet();

--- a/src/main/java/games/tictactoe/gui/TicTacToeGUI.java
+++ b/src/main/java/games/tictactoe/gui/TicTacToeGUI.java
@@ -52,7 +52,7 @@ public class TicTacToeGUI extends AbstractGUI {
     @Override
     protected void updateActionButtons(AbstractPlayer player, AbstractGameState gameState) {
         if (gameState.getGameStatus() == Utils.GameResult.GAME_ONGOING) {
-            List<AbstractAction> actions = gameState.getActions();
+            List<AbstractAction> actions = player.getForwardModel().computeAvailableActions(gameState);
             ArrayList<Rectangle> highlight = view.getHighlight();
 
             int start = actions.size();

--- a/src/main/java/games/uno/gui/UnoDeckView.java
+++ b/src/main/java/games/uno/gui/UnoDeckView.java
@@ -107,7 +107,7 @@ public class UnoDeckView extends ComponentView {
      */
     public void drawDeck(Graphics2D g, Rectangle rect) {
         int size = g.getFont().getSize();
-        Deck<UnoCard> deck = (Deck<UnoCard>) component;
+        @SuppressWarnings("unchecked") Deck<UnoCard> deck = (Deck<UnoCard>) component;
 
         if (deck != null) {
             // Draw cards, 0 index on top

--- a/src/main/java/players/human/HumanConsolePlayer.java
+++ b/src/main/java/players/human/HumanConsolePlayer.java
@@ -12,8 +12,7 @@ import java.util.Scanner;
 public class HumanConsolePlayer extends AbstractPlayer {
 
     @Override
-    public AbstractAction getAction(AbstractGameState observation) {
-        List<AbstractAction> actions = observation.getActions();
+    public AbstractAction getAction(AbstractGameState observation, List<AbstractAction> actions) {
 
         if (observation instanceof IPrintable)
             ((IPrintable) observation).printToConsole();

--- a/src/main/java/players/human/HumanGUIPlayer.java
+++ b/src/main/java/players/human/HumanGUIPlayer.java
@@ -4,6 +4,8 @@ import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.actions.AbstractAction;
 
+import java.util.List;
+
 
 public class HumanGUIPlayer extends AbstractPlayer {
     ActionController ac;
@@ -13,7 +15,7 @@ public class HumanGUIPlayer extends AbstractPlayer {
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState observation) {
+    public AbstractAction getAction(AbstractGameState observation, List<AbstractAction> actions) {
         return ac.getAction();
     }
 }

--- a/src/main/java/players/mcts/BasicMCTSPlayer.java
+++ b/src/main/java/players/mcts/BasicMCTSPlayer.java
@@ -48,13 +48,9 @@ public class BasicMCTSPlayer extends AbstractPlayer {
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState gameState) {
-        // Gather all available actions:
-        List<AbstractAction> allActions = gameState.getActions();
-
+    public AbstractAction getAction(AbstractGameState gameState, List<AbstractAction> allActions) {
         // Search for best action from the root
-        BasicTreeNode root = new BasicTreeNode(this, allActions, rnd);
-        root.setRootGameState(root, gameState);
+        BasicTreeNode root = new BasicTreeNode(this, null, gameState, rnd);
 
         // mctsSearch does all of the hard work
         root.mctsSearch();

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -27,8 +27,7 @@ public class MCTSPlayer extends AbstractPlayer {
     }
 
     public MCTSPlayer(long seed) {
-        this.params = new MCTSParams(seed);
-        rnd = new Random(seed);
+        this(new MCTSParams(seed), "MCTSPlayer");
     }
 
     public MCTSPlayer(MCTSParams params) {
@@ -60,13 +59,9 @@ public class MCTSPlayer extends AbstractPlayer {
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState gameState) {
-        // Gather all available actions:
-        List<AbstractAction> allActions = gameState.getActions();
-
+    public AbstractAction getAction(AbstractGameState gameState, List<AbstractAction> actions) {
         // Search for best action from the root
-        SingleTreeNode root = new SingleTreeNode(this, allActions, rnd);
-        root.setRootGameState(root, gameState);
+        SingleTreeNode root = new SingleTreeNode(this, null, gameState, rnd);
         root.mctsSearch(getStatsLogger());
 
         if (debug)

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -402,28 +402,6 @@ class SingleTreeNode {
     }
 
     /**
-     * When in open loop, it is entirely possible that on a transition to a new state we have actions that were
-     * not previously possible. (Especially in stochastic games, where different iterations may have different
-     * random draws; but this can also happen in deterministic games if we model the opponent moves in their own trees
-     * for example.)
-     *
-     * @param actions The new set of actions that are valid on a new transition to this node
-     */
-    private void checkActions(List<AbstractAction> actions) {
-        // we run through the actions, and add any new ones not currently in the list
-        for (AbstractAction action : actions) {
-            if (!children.containsKey(action)) {
-                children.put(action, null); // mark a new node to be expanded
-                // This *does* rely on a good equals method being implemented for Actions
-            }
-        }
-        // TODO: This does not yet take account of cases where we have rarely possible actions. Where the
-        // action frequency can be very variable we should take this into account (see Cowling et al. 2012 I think)
-        // This boils down to keeping track of how many times the action was available out of the total visits to the
-        // node.
-    }
-
-    /**
      * Perform a Monte Carlo rollout from this node.
      *
      * @return - value of rollout.

--- a/src/main/java/players/rmhc/Individual.java
+++ b/src/main/java/players/rmhc/Individual.java
@@ -103,7 +103,7 @@ public class Individual implements Comparable {
             if (gs.isNotTerminal()) {
                 // Copy the game state
                 AbstractGameState gsCopy = gs.copy();
-                List<AbstractAction> currentActions = gsCopy.getActions();
+                List<AbstractAction> currentActions = fm.computeAvailableActions(gsCopy);
                 AbstractAction action = null;
                 if (currentActions.size() > 0) {
                     action = currentActions.get(gen.nextInt(currentActions.size()));
@@ -112,8 +112,6 @@ public class Individual implements Comparable {
                 // Advance game state with random action
                 fm.next(gsCopy, action);
                 fmCalls ++;
-                // Compute available actions and store this state
-                fm.computeAvailableActions(gsCopy);
 
                 // If it's my turn, store this in the individual
                 boolean iAmMoving = (gameStates[i].getCurrentPlayer() == playerID);

--- a/src/main/java/players/rmhc/RMHCPlayer.java
+++ b/src/main/java/players/rmhc/RMHCPlayer.java
@@ -54,7 +54,7 @@ public class RMHCPlayer extends AbstractPlayer {
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState stateObs){
+    public AbstractAction getAction(AbstractGameState stateObs, List<AbstractAction> actions){
         ElapsedCpuTimer timer = new ElapsedCpuTimer();  // New timer for this game tick
         avgTimeTaken = 0;
         acumTimeTaken = 0;

--- a/src/main/java/players/simple/OSLAPlayer.java
+++ b/src/main/java/players/simple/OSLAPlayer.java
@@ -1,5 +1,6 @@
 package players.simple;
 
+import core.AbstractForwardModel;
 import core.actions.AbstractAction;
 import core.AbstractPlayer;
 import core.AbstractGameState;
@@ -17,31 +18,28 @@ public class OSLAPlayer extends AbstractPlayer {
     // Heuristics used for the agent
     IStateHeuristic heuristic;
 
-    public OSLAPlayer(){
-        this.random = new Random();
+    public OSLAPlayer(Random random)  {
+        this.random = random;
     }
 
-    public OSLAPlayer(Random random)
-    {
-        this.random = random;
+    public OSLAPlayer(){
+        this(new Random());
     }
 
     public OSLAPlayer(IStateHeuristic heuristic){
-        this.heuristic = heuristic;
-        this.random = new Random();
+        this(heuristic, new Random());
     }
 
     public OSLAPlayer(IStateHeuristic heuristic, Random random){
+        this(random);
         this.heuristic = heuristic;
-        this.random = random;
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState gs ) {
+    public AbstractAction getAction(AbstractGameState gs, List<AbstractAction> actions) {
 
         double maxQ = Double.NEGATIVE_INFINITY;
         AbstractAction bestAction = null;
-        List<AbstractAction> actions = gs.getActions();
 
         for (AbstractAction action : actions) {
             AbstractGameState gsCopy = gs.copy();

--- a/src/main/java/players/simple/RandomPlayer.java
+++ b/src/main/java/players/simple/RandomPlayer.java
@@ -1,5 +1,6 @@
 package players.simple;
 
+import core.AbstractForwardModel;
 import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.actions.AbstractAction;
@@ -14,8 +15,7 @@ public class RandomPlayer extends AbstractPlayer {
      */
     private final Random rnd;
 
-    public RandomPlayer(Random rnd)
-    {
+    public RandomPlayer(Random rnd) {
         this.rnd = rnd;
     }
 
@@ -25,9 +25,8 @@ public class RandomPlayer extends AbstractPlayer {
     }
 
     @Override
-    public AbstractAction getAction(AbstractGameState observation) {
-        int randomAction = rnd.nextInt(observation.getActions().size());
-        List<AbstractAction> actions = observation.getActions();
+    public AbstractAction getAction(AbstractGameState observation, List<AbstractAction> actions) {
+        int randomAction = rnd.nextInt(actions.size());
         return actions.get(randomAction);
     }
 

--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -211,6 +211,7 @@ public abstract class Utils {
         return input.keySet().stream().collect(toMap(key -> key, key -> input.get(key).doubleValue() / sum));
     }
 
+    @SuppressWarnings("unchecked")
     public static <T> T getArg(String[] args, String name, T defaultValue) {
         Optional<String> raw = Arrays.stream(args).filter(i -> i.toLowerCase().startsWith(name.toLowerCase() + "=")).findFirst();
         if (raw.isPresent()) {


### PR DESCRIPTION
This stems from a discussion/brainstorm with @rdgain and @martinballa.

The main idea is to avoid storing the AvailableActions on the AbstractGameState, and instead use ForwardModel to calculate these when needed. This was on the basis that the actions are not a core part of GameState, and this was just being used as a storage point with a pattern of:
- ForwardModel._computeAvailableActions(GameState) 
- player.getAction(GameState)

The first step is essential, but its effect is not directly visible. The new set up is:
- actions = ForwardModel._computeAvailableActions(GameState) 
- player.getAction(GameState, actions)

This makes the dependency explicit - and also allows situations where we want to restrict the acitons available for some reason.

The second change is to add a history of all actions taken to the GameState. This has also been added to the AbstractGUI as a new panel next to the GameInfo panel at the top of the screen. The idea is that this is tremendously helpful for debugging.