### PR TITLE
IComponentContainer and Heuristic tuning

### DIFF
--- a/data/pandemic/decks.json
+++ b/data/pandemic/decks.json
@@ -1,6 +1,7 @@
  [
    {
      "name": ["String","Cities"],
+     "visibility" : "HIDDEN_TO_ALL",
      "cards":
      [
       {
@@ -343,6 +344,7 @@
    },
    {
      "name": ["String", "Infections"],
+     "visibility" : "HIDDEN_TO_ALL",
      "cards":
      [
        {
@@ -588,8 +590,9 @@
      ]
    },
    {
-      "name": ["String","Events"],
-      "cards":
+     "name": ["String","Events"],
+     "visibility" : "HIDDEN_TO_ALL",
+     "cards":
       [
        {
        "name": ["String","Resilient Population"],
@@ -615,6 +618,7 @@
    },
    {
      "name": ["String", "Player Roles"],
+     "visibility" : "VISIBLE_TO_ALL",
      "cards":
      [
        {

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -9,7 +9,10 @@ import core.interfaces.IGamePhase;
 import core.turnorders.TurnOrder;
 import utilities.Utils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
 
 import static java.util.stream.Collectors.toList;
 import static utilities.Utils.GameResult.GAME_ONGOING;
@@ -260,6 +263,16 @@ public abstract class AbstractGameState {
                 case VISIBLE_TO_OWNER:
                     if (((Component) container).getOwnerId() != player)
                         retValue.addAll(container.getComponents().stream().map(Component::getComponentID).collect(toList()));
+                    break;
+                case FIRST_VISIBLE_TO_ALL:
+                    // add everything as unseen, and then remove the first element
+                    retValue.addAll(container.getComponents().stream().map(Component::getComponentID).collect(toList()));
+                    retValue.remove(container.getComponents().get(0).getComponentID());
+                    break;
+                case LAST_VISIBLE_TO_ALL:
+                    // add in the ID of the last item only
+                    int length = container.getComponents().size();
+                    retValue.add(container.getComponents().get(length - 1).getComponentID());
                     break;
                 case MIXED_VISIBILITY:
                     throw new AssertionError("If something uses this visibility mode, then you need to also add code to this method please!");

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -9,10 +9,7 @@ import core.interfaces.IGamePhase;
 import core.turnorders.TurnOrder;
 import utilities.Utils;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-import java.util.Objects;
+import java.util.*;
 
 import static java.util.stream.Collectors.toList;
 import static utilities.Utils.GameResult.GAME_ONGOING;
@@ -139,6 +136,7 @@ public abstract class AbstractGameState {
     }
 
     public final Area getAllComponents() {
+        addAllComponents(); // otherwise the list of allComponents is only ever updated when we copy the state!
         return allComponents;
     }
 
@@ -320,7 +318,7 @@ public abstract class AbstractGameState {
         // used correctly. In this situation there should be no need for any extra game-specific coding.
         // If there is, then use _getUnknownComponentsIds
         List<Component> everything = getAllTopLevelComponents();
-        ArrayList<Integer> retValue = new ArrayList<>();
+        List<Integer> retValue = new ArrayList<>();
 
         for (Component c : everything) {
             if (c instanceof IComponentContainer<?>)

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -261,7 +261,7 @@ public abstract class AbstractGameState {
                     if (((Component) container).getOwnerId() != player)
                         retValue.addAll(container.getComponents().stream().map(Component::getComponentID).collect(toList()));
                     break;
-                case ITS_COMPLICATED:
+                case MIXED_VISIBILITY:
                     throw new AssertionError("If something uses this visibility mode, then you need to also add code to this method please!");
             }
         }

--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -34,4 +34,8 @@ public class CoreConstants {
     public enum GameEvents {
         GAME_OVER, ROUND_OVER, TURN_OVER, ACTION_CHOSEN
     }
+
+    public enum VisibilityMode {
+        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, ITS_COMPLICATED
+    }
 }

--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -43,6 +43,6 @@ public class CoreConstants {
      * this should cover almost all future eventualities.
      */
     public enum VisibilityMode {
-        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, MIXED_VISIBILITY
+        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, FIRST_VISIBLE_TO_ALL, LAST_VISIBLE_TO_ALL, MIXED_VISIBILITY
     }
 }

--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -35,7 +35,14 @@ public class CoreConstants {
         GAME_OVER, ROUND_OVER, TURN_OVER, ACTION_CHOSEN
     }
 
+    /**
+     * Used in Components that contain other Components (see IComponentContainer) to mark which players can see the
+     * contents.
+     * MIXED_VISIBILITY is an indicator that none of the previous three apply, and that the IComponentContainer
+     * will need to implement more sophisticated logic. This is done for example in PartialObservableDeck - and
+     * this should cover almost all future eventualities.
+     */
     public enum VisibilityMode {
-        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, ITS_COMPLICATED
+        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, MIXED_VISIBILITY
     }
 }

--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -4,12 +4,9 @@ import core.actions.AbstractAction;
 import core.interfaces.IGameListener;
 import core.interfaces.IPrintable;
 import core.turnorders.ReactiveTurnOrder;
-import evaluation.GameLogger;
 import games.GameType;
-import players.PlayerConstants;
 import players.human.ActionController;
 import players.human.HumanGUIPlayer;
-import players.mcts.MCTSEnums;
 import players.mcts.MCTSParams;
 import players.mcts.MCTSPlayer;
 import players.rmhc.RMHCPlayer;
@@ -21,7 +18,6 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static core.CoreConstants.*;
 import static games.GameType.*;
-import static java.util.stream.Collectors.*;
 
 public class Game {
 
@@ -532,12 +528,12 @@ public class Game {
         int nPlayers = players.size();
 
         // Save win rate statistics over all games
-        StatSummary[] overall = new StatSummary[nPlayers];
+        TAGStatSummary[] overall = new TAGStatSummary[nPlayers];
         String[] agentNames = new String[nPlayers];
         for (int i = 0; i < nPlayers; i++) {
             String[] split = players.get(i).getClass().toString().split("\\.");
             String agentName = split[split.length - 1] + "-" + i;
-            overall[i] = new StatSummary("Overall " + agentName);
+            overall[i] = new TAGStatSummary("Overall " + agentName);
             agentNames[i] = agentName;
         }
 
@@ -545,9 +541,9 @@ public class Game {
         for (GameType gt : gamesToPlay) {
 
             // Save win rate statistics over all repetitions of this game
-            StatSummary[] statSummaries = new StatSummary[nPlayers];
+            TAGStatSummary[] statSummaries = new TAGStatSummary[nPlayers];
             for (int i = 0; i < nPlayers; i++) {
-                statSummaries[i] = new StatSummary("{Game: " + gt.name() + "; Player: " + agentNames[i] + "}");
+                statSummaries[i] = new TAGStatSummary("{Game: " + gt.name() + "; Player: " + agentNames[i] + "}");
             }
 
             // Play n repetitions of this game and record player results
@@ -609,18 +605,18 @@ public class Game {
         int nPlayers = players.size();
 
         // Save win rate statistics over all games
-        StatSummary[] overall = new StatSummary[nPlayers];
+        TAGStatSummary[] overall = new TAGStatSummary[nPlayers];
         for (int i = 0; i < nPlayers; i++) {
-            overall[i] = new StatSummary("Overall Player " + i);
+            overall[i] = new TAGStatSummary("Overall Player " + i);
         }
 
         // For each game...
         for (GameType gt : gamesToPlay) {
 
             // Save win rate statistics over all repetitions of this game
-            StatSummary[] statSummaries = new StatSummary[nPlayers];
+            TAGStatSummary[] statSummaries = new TAGStatSummary[nPlayers];
             for (int i = 0; i < nPlayers; i++) {
-                statSummaries[i] = new StatSummary("Game: " + gt.name() + "; Player: " + i);
+                statSummaries[i] = new TAGStatSummary("Game: " + gt.name() + "; Player: " + i);
             }
 
             // Play n repetitions of this game and record player results
@@ -655,7 +651,7 @@ public class Game {
      * @param statSummaries - object recording statistics
      * @param game          - finished game
      */
-    public static void recordPlayerResults(StatSummary[] statSummaries, Game game) {
+    public static void recordPlayerResults(TAGStatSummary[] statSummaries, Game game) {
         int nPlayers = statSummaries.length;
         Utils.GameResult[] results = game.getGameState().getPlayerResults();
         for (int p = 0; p < nPlayers; p++) {

--- a/src/main/java/core/actions/RearrangeDeckOfCards.java
+++ b/src/main/java/core/actions/RearrangeDeckOfCards.java
@@ -1,12 +1,14 @@
 package core.actions;
 
+import core.AbstractGameState;
 import core.components.Card;
 import core.components.Deck;
-import core.AbstractGameState;
 
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Objects;
+
+import static core.CoreConstants.VisibilityMode;
 
 
 public class RearrangeDeckOfCards extends DrawCard {
@@ -47,7 +49,7 @@ public class RearrangeDeckOfCards extends DrawCard {
         for (int value : newCardOrder) {
             cards[value] = rd.draw();
         }
-        Deck<Card> draws = new Deck<>("Temp Draws from: " + rd.getComponentName());
+        Deck<Card> draws = new Deck<>("Temp Draws from: " + rd.getComponentName(), VisibilityMode.HIDDEN_TO_ALL);
         draws.setComponents(new ArrayList<>(Arrays.asList(cards)));
         //return result & rd.add(draws);
         return result & rd.add(draws, 0);

--- a/src/main/java/core/components/Area.java
+++ b/src/main/java/core/components/Area.java
@@ -1,5 +1,7 @@
 package core.components;
 
+import core.CoreConstants;
+import core.interfaces.IComponentContainer;
 import utilities.Utils;
 
 import java.util.*;
@@ -7,7 +9,7 @@ import java.util.*;
 /**
  * An Area is a collection of components such as Decks, Token, Dices, Cards and Boards, mapping to their IDs.
  */
-public class Area extends Component {
+public class Area extends Component implements IComponentContainer<Component> {
 
     // Collection of components stored in this area, mapping to their IDs
     protected HashMap<Integer, Component> components;
@@ -45,8 +47,18 @@ public class Area extends Component {
      * Retrieve the collection of components in this area.
      * @return - HashMap, components mapped to their IDs
      */
-    public HashMap<Integer, Component> getComponents() {
+    public HashMap<Integer, Component> getComponentsMap() {
         return this.components;
+    }
+
+    @Override
+    public CoreConstants.VisibilityMode getVisibilityMode() {
+        return CoreConstants.VisibilityMode.VISIBLE_TO_ALL;
+    }
+
+    @Override
+    public List<Component> getComponents() {
+        return new ArrayList<>(components.values());
     }
 
     /**
@@ -72,9 +84,12 @@ public class Area extends Component {
      * @param component - component to add to the collection.
      */
     public void putComponent(Component component) {
-        if (component instanceof Deck) putComponents((Deck<? extends Component>)component);
-        else if (component instanceof Area) putComponents((Area)component);
-        else this.components.put(component.getComponentID(), component);
+        this.components.put(component.getComponentID(), component);
+        if (component instanceof IComponentContainer) {
+            for (Component nestedC : ((IComponentContainer<?>) component).getComponents()) {
+                putComponent(nestedC);
+            }
+        }
     }
 
     /**
@@ -83,28 +98,6 @@ public class Area extends Component {
      */
     public void putComponents(List<? extends Component> components) {
         for (Component c: components) {
-            putComponent(c);
-        }
-    }
-
-    /**
-     * Adds all components from a deck to the collection, using their own component IDs as the keys in the map.
-     * @param deck - deck to add to the collection.
-     */
-    public <T extends Component> void putComponents(Deck<T> deck) {
-        this.components.put(deck.getComponentID(), deck);
-        for (Component c: deck.getComponents()) {
-            putComponent(c);
-        }
-    }
-
-    /**
-     * Adds all components in an area to the collection, using their own component IDs as the keys in the map.
-     * @param area - area to add to the collection.
-     */
-    public void putComponents(Area area) {
-        this.components.put(area.getComponentID(), area);
-        for (Component c: area.components.values()) {
             putComponent(c);
         }
     }

--- a/src/main/java/core/components/Deck.java
+++ b/src/main/java/core/components/Deck.java
@@ -1,50 +1,52 @@
 package core.components;
 
-import java.io.FileReader;
-import java.io.IOException;
-import java.util.*;
-import java.util.function.Function;
-import java.util.stream.Stream;
-
+import core.interfaces.IComponentContainer;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
-
 import utilities.Utils.ComponentType;
+
+import java.io.FileReader;
+import java.io.IOException;
+import java.util.*;
+
+import static core.CoreConstants.VisibilityMode;
 
 /**
  * Class for a deck of components.
  * A deck is defined as a "group of components". Examples of decks are:
- *   * A hand of components
- *   * A deck to draw from
- *   * components played on the player's area
- *   * Discomponent pile
+ * * A hand of components
+ * * A deck to draw from
+ * * components played on the player's area
+ * * Discomponent pile
  */
-public class Deck<T extends Component> extends Component {
+public class Deck<T extends Component> extends Component implements IComponentContainer<T> {
 
     protected int capacity;  // Capacity of the deck (maximum number of elements)
     protected ArrayList<T> components;  // List of components in this deck
+    protected VisibilityMode visibility;
 
-    public Deck(String name) {
-        this(name, -1);
+    public Deck(String name, VisibilityMode visibility) {
+        this(name, -1, visibility);
     }
 
-    public Deck(String name, int ownerId)
-    {
+    public Deck(String name, int ownerId, VisibilityMode visibility) {
         super(ComponentType.DECK, name);
         this.components = new ArrayList<>();
         this.ownerId = ownerId;
         this.capacity = -1;
+        this.visibility = visibility;
     }
 
-    protected Deck(String name, int ownerId, int ID)
-    {
+    protected Deck(String name, int ownerId, int ID, VisibilityMode visibility) {
         super(ComponentType.DECK, name, ID);
         this.components = new ArrayList<>();
         this.capacity = -1;
+        this.ownerId = ownerId;
+        this.visibility = visibility;
     }
-    
+
     /**
      * Draws the first component of the deck
      * @return the first component of the deck
@@ -95,18 +97,17 @@ public class Deck<T extends Component> extends Component {
     /**
      * Peeks (without drawing) amount components of the deck starting from component idx
      * @return The components peeked, following the order of the deck. If there are not
-     * enough components to be picked, the array will only contain those available. If no
-     * components are available, returns an empty array.
+     * enough components to be picked, the List will only contain those available. If no
+     * components are available, returns an empty List.
      */
-    public T[] peek(int idx, int amount) {
+    public List<T> peek(int idx, int amount) {
         ArrayList<T> components = new ArrayList<>();
-        for(int i = idx; i < idx+amount; ++i)
-        {
+        for (int i = idx; i < idx + amount; ++i) {
             T c = peek(i);
-            if(c != null)
+            if (c != null)
                 components.add(c);
         }
-        return (T[]) components.toArray();
+        return components;
     }
 
     /**
@@ -237,34 +238,9 @@ public class Deck<T extends Component> extends Component {
     /**
      * @return all the components in this deck.
      */
+    @Override
     public List<T> getComponents() {
         return components;
-    }
-
-    public Stream<T> stream() {
-        return components.stream();
-    }
-    public double sumDouble(Function<T, Double> lambda) {
-        double retValue = 0.0;
-        for (T c : components) {
-            retValue += lambda.apply(c);
-        }
-        return retValue;
-    }
-    public int sumInt(Function<T, Integer> lambda) {
-        int retValue = 0;
-        for (T c : components) {
-            retValue += lambda.apply(c);
-        }
-        return retValue;
-    }
-
-
-    /**
-     * @return the size of this deck (number of components in it).
-     */
-    public int getSize() {
-        return components.size();
     }
     
     /**
@@ -319,13 +295,22 @@ public class Deck<T extends Component> extends Component {
         return components.get(idx);
     }
 
+    @Override
+    public VisibilityMode getVisibilityMode() {
+        return visibility;
+    }
+
+    public void setVisibility(VisibilityMode mode) {
+        visibility = mode;
+    }
+
     /**
      * Creates a copy of this deck.
+     *
      * @return - a new Deck with the same properties.
      */
-    public Deck<T> copy()
-    {
-        Deck<T> dp = new Deck<>(componentName, ownerId, componentID);
+    public Deck<T> copy() {
+        Deck<T> dp = new Deck<>(componentName, ownerId, componentID, visibility);
         copyTo(dp);
         return dp;
     }
@@ -373,11 +358,11 @@ public class Deck<T extends Component> extends Component {
      * @param deck - deck to load in JSON format
      */
     public static Deck<Card> loadDeckOfCards(JSONObject deck) {
-        Deck<Card> newDeck = new Deck<>((String) ( (JSONArray) deck.get("name")).get(1), -1);
+        Deck<Card> newDeck = new Deck<>((String) ((JSONArray) deck.get("name")).get(1), VisibilityMode.HIDDEN_TO_ALL);
+        newDeck.setVisibility(VisibilityMode.valueOf((String) deck.get("visibility")));
         JSONArray deckcards = (JSONArray) deck.get("cards");
 
-        for(Object o : deckcards)
-        {
+        for (Object o : deckcards) {
             // Add nodes to board nodes
             JSONObject jsoncard = (JSONObject) o;
             Card newcard = (Card) parseComponent(new Card(), jsoncard);

--- a/src/main/java/core/components/GraphBoard.java
+++ b/src/main/java/core/components/GraphBoard.java
@@ -1,5 +1,7 @@
 package core.components;
 
+import core.CoreConstants;
+import core.interfaces.IComponentContainer;
 import core.properties.*;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -15,7 +17,7 @@ import java.util.*;
 import static core.CoreConstants.imgHash;
 import static core.CoreConstants.nameHash;
 
-public class GraphBoard extends Component {
+public class GraphBoard extends Component implements IComponentContainer<BoardNode> {
 
     // List of nodes in the board graph
     protected List<BoardNode> boardNodes;
@@ -259,5 +261,15 @@ public class GraphBoard extends Component {
     @Override
     public final int hashCode() {
         return Objects.hash(componentID, boardNodes);
+    }
+
+    @Override
+    public List<BoardNode> getComponents() {
+        return getBoardNodes();
+    }
+
+    @Override
+    public CoreConstants.VisibilityMode getVisibilityMode() {
+        return CoreConstants.VisibilityMode.VISIBLE_TO_ALL;
     }
 }

--- a/src/main/java/core/components/GridBoard.java
+++ b/src/main/java/core/components/GridBoard.java
@@ -1,5 +1,7 @@
 package core.components;
 
+import core.CoreConstants;
+import core.interfaces.IComponentContainer;
 import core.properties.PropertyString;
 import core.properties.PropertyVector2D;
 import org.json.simple.JSONArray;
@@ -14,11 +16,12 @@ import java.io.FileReader;
 import java.io.IOException;
 import java.lang.reflect.Array;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static core.CoreConstants.imgHash;
 import static utilities.Utils.getNeighbourhood;
 
-public class GridBoard<T> extends Component {
+public class GridBoard<T> extends Component implements IComponentContainer<Token> {
 
     private int width;  // Width of the board
     private int height;  // Height of the board
@@ -400,5 +403,19 @@ public class GridBoard<T> extends Component {
     @Override
     public final int hashCode() {
         return Objects.hash(componentID) + 5 * Arrays.hashCode(flattenGrid());
+    }
+
+    @Override
+    public List<Token> getComponents() {
+        // TODO: This is a bit of a hack, and the ID of each new Token will be different every time this is called
+        // However, this is only used in GameReport at the moment.
+        // Ideally <T extends Component> in the Class signature would solve this problem...but left for the future
+        // and I know Raluca is thinking about refactoring this anyway for performance reasons
+        return Arrays.stream(flattenGrid()).map(node -> new Token(node.toString())).collect(Collectors.toList());
+    }
+
+    @Override
+    public CoreConstants.VisibilityMode getVisibilityMode() {
+        return CoreConstants.VisibilityMode.VISIBLE_TO_ALL;
     }
 }

--- a/src/main/java/core/components/GridBoard.java
+++ b/src/main/java/core/components/GridBoard.java
@@ -1,5 +1,7 @@
 package core.components;
 
+import core.CoreConstants;
+import core.interfaces.IComponentContainer;
 import core.properties.PropertyString;
 import core.properties.PropertyVector2D;
 import org.json.simple.JSONArray;
@@ -13,11 +15,12 @@ import utilities.Vector2D;
 import java.io.FileReader;
 import java.io.IOException;
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static core.CoreConstants.imgHash;
 import static utilities.Utils.getNeighbourhood;
 
-public class GridBoard<T extends Component> extends Component {
+public class GridBoard<T extends Component> extends Component implements IComponentContainer<T> {
 
     private int width;  // Width of the board
     private int height;  // Height of the board
@@ -385,5 +388,15 @@ public class GridBoard<T extends Component> extends Component {
     @Override
     public final int hashCode() {
         return Objects.hash(componentID) + 5 * Arrays.hashCode(flattenGrid());
+    }
+
+    @Override
+    public List<T> getComponents() {
+        return Arrays.stream(flattenGrid()).map( component -> (T) component).collect(Collectors.toList());
+    }
+
+    @Override
+    public CoreConstants.VisibilityMode getVisibilityMode() {
+        return CoreConstants.VisibilityMode.VISIBLE_TO_ALL;
     }
 }

--- a/src/main/java/core/components/PartialObservableDeck.java
+++ b/src/main/java/core/components/PartialObservableDeck.java
@@ -33,7 +33,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
     }
 
     public PartialObservableDeck(String id, int ownerID, boolean[] defaultVisibility) {
-        super(id, ownerID, VisibilityMode.ITS_COMPLICATED);
+        super(id, ownerID, VisibilityMode.MIXED_VISIBILITY);
         this.deckVisibility = defaultVisibility;
     }
 
@@ -46,7 +46,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
     }
 
     private PartialObservableDeck(String name, int ownerID, boolean[] defaultVisibility, int ID) {
-        super(name, ownerID, ID, VisibilityMode.ITS_COMPLICATED);
+        super(name, ownerID, ID, VisibilityMode.MIXED_VISIBILITY);
         this.deckVisibility = defaultVisibility;
     }
 

--- a/src/main/java/core/components/PartialObservableDeck.java
+++ b/src/main/java/core/components/PartialObservableDeck.java
@@ -1,8 +1,12 @@
 package core.components;
 
+import core.CoreConstants.VisibilityMode;
 import utilities.Pair;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Random;
 
 import static core.CoreConstants.PARTIAL_OBSERVABLE;
 
@@ -29,7 +33,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
     }
 
     public PartialObservableDeck(String id, int ownerID, boolean[] defaultVisibility) {
-        super(id, ownerID);
+        super(id, ownerID, VisibilityMode.ITS_COMPLICATED);
         this.deckVisibility = defaultVisibility;
     }
 
@@ -42,7 +46,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
     }
 
     private PartialObservableDeck(String name, int ownerID, boolean[] defaultVisibility, int ID) {
-        super(name, ownerID, ID);
+        super(name, ownerID, ID, VisibilityMode.ITS_COMPLICATED);
         this.deckVisibility = defaultVisibility;
     }
 

--- a/src/main/java/core/interfaces/IComponentContainer.java
+++ b/src/main/java/core/interfaces/IComponentContainer.java
@@ -1,0 +1,53 @@
+package core.interfaces;
+
+import core.CoreConstants;
+import core.components.Component;
+
+import java.util.List;
+import java.util.function.Function;
+import java.util.stream.Stream;
+
+/**
+ * An interface to be used on any Component that contains other Components.
+ * The interface is 'read-only', and deliberately avoids specifying add/remove type methods, and has two purposes:
+ *
+ * i) To be used to gather information about game states for game metrics and comparisons (see GameReport as example)
+ * ii) To indicate who can see the contents of the Container (Everyone, No-one, just the Owner)?
+ * iii) As a holder of a few useful stream-related default methods - these are all read-only methods.
+ *
+ * @param <T> The Type of Component that the Container holds
+ */
+public interface IComponentContainer<T extends Component> {
+
+    /**
+     * @return A list of all the Components in the Container
+     */
+    List<T> getComponents();
+
+    CoreConstants.VisibilityMode getVisibilityMode();
+
+    default Stream<T> stream() {
+        return getComponents().stream();
+    }
+    /**
+     * @return the size of this deck (number of components in it).
+     */
+    default int getSize() {
+        return getComponents().size();
+    }
+
+    default double sumDouble(Function<T, Double> lambda) {
+        double retValue = 0.0;
+        for (T c : getComponents()) {
+            retValue += lambda.apply(c);
+        }
+        return retValue;
+    }
+    default int sumInt(Function<T, Integer> lambda) {
+        int retValue = 0;
+        for (T c : getComponents()) {
+            retValue += lambda.apply(c);
+        }
+        return retValue;
+    }
+}

--- a/src/main/java/core/interfaces/IStatisticLogger.java
+++ b/src/main/java/core/interfaces/IStatisticLogger.java
@@ -1,6 +1,6 @@
 package core.interfaces;
 
-import utilities.StatSummary;
+import utilities.TAGStatSummary;
 import utilities.SummaryLogger;
 
 import java.lang.reflect.Constructor;
@@ -35,7 +35,7 @@ public interface IStatisticLogger {
      *
      * @return A summary of the data
      */
-    Map<String, StatSummary> summary();
+    Map<String, TAGStatSummary> summary();
 
 
     static IStatisticLogger createLogger(String loggerClass, String logFile) {

--- a/src/main/java/evaluation/GameReport.java
+++ b/src/main/java/evaluation/GameReport.java
@@ -10,7 +10,7 @@ import players.simple.RandomPlayer;
 import utilities.BoxPlot;
 import utilities.LineChart;
 import utilities.Pair;
-import utilities.StatSummary;
+import utilities.TAGStatSummary;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -29,17 +29,17 @@ public class GameReport {
      * @param nPlayers - number of players taking part in this test.
      * @param lc       - line chart to add this data to, can be null if only printing required
      */
-    public static StatSummary actionSpace(GameType game, int nPlayers, LineChart lc) {
+    public static TAGStatSummary actionSpace(GameType game, int nPlayers, LineChart lc) {
         if (VERBOSE) {
             System.out.println("--------------------\nAction Space Test: " + game.name() + " [" + nPlayers + " players]\n--------------------");
         }
 
-        StatSummary actionSpace = new StatSummary(game.name() + "-" + nPlayers + "p");
-        StatSummary actionSpaceOnePerRep = new StatSummary(game.name() + "-" + nPlayers + "p");
-        ArrayList<StatSummary> sumData = new ArrayList<>();
+        TAGStatSummary actionSpace = new TAGStatSummary(game.name() + "-" + nPlayers + "p");
+        TAGStatSummary actionSpaceOnePerRep = new TAGStatSummary(game.name() + "-" + nPlayers + "p");
+        ArrayList<TAGStatSummary> sumData = new ArrayList<>();
 
         for (int i = 0; i < nRep; i++) {
-            StatSummary ss = new StatSummary();
+            TAGStatSummary ss = new TAGStatSummary();
 
             Game g = game.createGameInstance(nPlayers);
             List<AbstractPlayer> players = new ArrayList<>();
@@ -56,7 +56,7 @@ public class GameReport {
                     ss.add(size);
 
                     if (j >= sumData.size()) {
-                        sumData.add(new StatSummary(nPlayers + "-" + j));
+                        sumData.add(new TAGStatSummary(nPlayers + "-" + j));
                     }
                     sumData.get(j).add(size);
                 }
@@ -95,13 +95,13 @@ public class GameReport {
      * @param game     - game to test.
      * @param nPlayers - number of players taking part in this test.
      */
-    public static Pair<Integer, StatSummary> generalTest(GameType game, int nPlayers) {
+    public static Pair<Integer, TAGStatSummary> generalTest(GameType game, int nPlayers) {
         if (VERBOSE) {
             System.out.println("--------------------\nGeneral Test: " + game.name() + " [" + nPlayers + " players]\n--------------------");
         }
 
         Game g = game.createGameInstance(nPlayers);
-        Pair<Integer, StatSummary> ret = null;
+        Pair<Integer, TAGStatSummary> ret = null;
         if (g != null) {
             AbstractGameState gs = g.getGameState();
             if (VERBOSE) {
@@ -109,7 +109,7 @@ public class GameReport {
             }
 
             // TODO: run games
-            StatSummary ss = new StatSummary();
+            TAGStatSummary ss = new TAGStatSummary();
             for (int i = 0; i < nPlayers; i++) {
                 ss.add(gs.getUnknownComponentsIds(i).size());
             }
@@ -136,19 +136,19 @@ public class GameReport {
      * @param game     - game to test.
      * @param nPlayers - number of players taking part in this test.
      */
-    public static StatSummary[] gameSpeed(GameType game, int nPlayers) {
+    public static TAGStatSummary[] gameSpeed(GameType game, int nPlayers) {
         if (VERBOSE) {
             System.out.println("--------------------\nSpeed Test: " + game.name() + " [" + nPlayers + " players]\n--------------------");
         }
 
-        StatSummary[] ret = new StatSummary[4];
-        StatSummary nextT = new StatSummary();
+        TAGStatSummary[] ret = new TAGStatSummary[4];
+        TAGStatSummary nextT = new TAGStatSummary();
         ret[0] = nextT;
-        StatSummary copyT = new StatSummary();
+        TAGStatSummary copyT = new TAGStatSummary();
         ret[1] = copyT;
-        StatSummary actionT = new StatSummary();
+        TAGStatSummary actionT = new TAGStatSummary();
         ret[2] = actionT;
-        StatSummary setupT = new StatSummary();
+        TAGStatSummary setupT = new TAGStatSummary();
         ret[3] = setupT;
 
         for (int i = 0; i < nRep; i++) {
@@ -194,16 +194,16 @@ public class GameReport {
      * @param game     - game to test.
      * @param nPlayers - number of players taking part in this test.
      */
-    public static StatSummary[] gameLength(GameType game, int nPlayers) {
+    public static TAGStatSummary[] gameLength(GameType game, int nPlayers) {
         if (VERBOSE) {
             System.out.println("--------------------\nGame Length Test: " + game.name() + " [" + nPlayers + " players]\n--------------------");
         }
 
-        StatSummary[] ret = new StatSummary[4];
-        StatSummary nDecisions = new StatSummary();
-        StatSummary nTicks = new StatSummary();
-        StatSummary nRounds = new StatSummary();
-        StatSummary nActionsPerTurn = new StatSummary();
+        TAGStatSummary[] ret = new TAGStatSummary[4];
+        TAGStatSummary nDecisions = new TAGStatSummary();
+        TAGStatSummary nTicks = new TAGStatSummary();
+        TAGStatSummary nRounds = new TAGStatSummary();
+        TAGStatSummary nActionsPerTurn = new TAGStatSummary();
         ret[0] = nDecisions;
         ret[1] = nTicks;
         ret[2] = nRounds;
@@ -250,13 +250,13 @@ public class GameReport {
      * @param game     - game to test.
      * @param nPlayers - number of players taking part in this test.
      */
-    public static Pair<StatSummary, StatSummary> playerObservationTest(GameType game, int nPlayers) {
+    public static Pair<TAGStatSummary, TAGStatSummary> playerObservationTest(GameType game, int nPlayers) {
         if (VERBOSE) {
             System.out.println("--------------------\nPlayer Observation Test: " + game.name() + " [" + nPlayers + " players]\n--------------------");
         }
 
-        StatSummary rs = new StatSummary("Reward Sparsity");
-        StatSummary bf = new StatSummary("Branching Factor");
+        TAGStatSummary rs = new TAGStatSummary("Reward Sparsity");
+        TAGStatSummary bf = new TAGStatSummary("Branching Factor");
         for (int i = 0; i < nRep; i++) {
             Game g = game.createGameInstance(nPlayers);
             List<AbstractPlayer> players = new ArrayList<>();
@@ -309,7 +309,7 @@ public class GameReport {
 
             for (GameType gt : games) {
                 if (gt.getMinPlayers() > p && gt.getMaxPlayers() < p) continue;
-                StatSummary ss = actionSpace(gt, p, lc);
+                TAGStatSummary ss = actionSpace(gt, p, lc);
 
                 bp.addSeries(ss.getElements(), gt.name());
                 lc.setVisible(true);
@@ -332,7 +332,7 @@ public class GameReport {
             bp.setVisible(false);
 
             for (int p = gt.getMinPlayers(); p <= gt.getMaxPlayers(); p++) {
-                StatSummary ss = actionSpace(gt, p, lc);
+                TAGStatSummary ss = actionSpace(gt, p, lc);
 
                 bp.addSeries(ss.getElements(), p + "p");
                 lc.setVisible(true);
@@ -376,41 +376,41 @@ public class GameReport {
             if (gt == ColtExpress) continue;
             //     if (gt == Dominion) continue;
 
-            StatSummary as = new StatSummary("Action space size (" + gt.name() + ")");
-            StatSummary ss = new StatSummary("State size (" + gt.name() + ")");
-            StatSummary hidi = new StatSummary("Hidden info size (" + gt.name() + ")");
-            StatSummary cp = new StatSummary("GS.copy() (" + gt.name() + ") exe/sec");
-            StatSummary sp = new StatSummary("FM.setup() (" + gt.name() + ") exe/sec");
-            StatSummary ne = new StatSummary("FM.next() (" + gt.name() + ") exe/sec");
-            StatSummary ac = new StatSummary("FM.actions() (" + gt.name() + ") exe/sec");
-            StatSummary nd = new StatSummary("#decisions (" + gt.name() + ")");
-            StatSummary nt = new StatSummary("#ticks (" + gt.name() + ")");
-            StatSummary nr = new StatSummary("#rounds (" + gt.name() + ")");
-            StatSummary napt = new StatSummary("#apt (" + gt.name() + ")");
-            StatSummary rs = new StatSummary("Reward Sparsity (" + gt.name() + ")");
-            StatSummary bf = new StatSummary("Branching Factor (" + gt.name() + ")");
+            TAGStatSummary as = new TAGStatSummary("Action space size (" + gt.name() + ")");
+            TAGStatSummary ss = new TAGStatSummary("State size (" + gt.name() + ")");
+            TAGStatSummary hidi = new TAGStatSummary("Hidden info size (" + gt.name() + ")");
+            TAGStatSummary cp = new TAGStatSummary("GS.copy() (" + gt.name() + ") exe/sec");
+            TAGStatSummary sp = new TAGStatSummary("FM.setup() (" + gt.name() + ") exe/sec");
+            TAGStatSummary ne = new TAGStatSummary("FM.next() (" + gt.name() + ") exe/sec");
+            TAGStatSummary ac = new TAGStatSummary("FM.actions() (" + gt.name() + ") exe/sec");
+            TAGStatSummary nd = new TAGStatSummary("#decisions (" + gt.name() + ")");
+            TAGStatSummary nt = new TAGStatSummary("#ticks (" + gt.name() + ")");
+            TAGStatSummary nr = new TAGStatSummary("#rounds (" + gt.name() + ")");
+            TAGStatSummary napt = new TAGStatSummary("#apt (" + gt.name() + ")");
+            TAGStatSummary rs = new TAGStatSummary("Reward Sparsity (" + gt.name() + ")");
+            TAGStatSummary bf = new TAGStatSummary("Branching Factor (" + gt.name() + ")");
 
             for (int i = gt.getMinPlayers(); i <= gt.getMaxPlayers(); i++) {
                 System.out.println(gt.name() + " " + i);
                 as.add(actionSpace(gt, i, null));
 
-                Pair<Integer, StatSummary> ret = generalTest(gt, i);
+                Pair<Integer, TAGStatSummary> ret = generalTest(gt, i);
                 ss.add(ret.a);
                 hidi.add(ret.b);
 
-                StatSummary[] rett = gameSpeed(gt, i);
+                TAGStatSummary[] rett = gameSpeed(gt, i);
                 cp.add(rett[0]);
                 sp.add(rett[1]);
                 ne.add(rett[2]);
                 ac.add(rett[3]);
 
-                StatSummary[] rettt = gameLength(gt, i);
+                TAGStatSummary[] rettt = gameLength(gt, i);
                 nd.add(rettt[0]);
                 nt.add(rettt[1]);
                 nr.add(rettt[2]);
                 napt.add(rettt[3]);
 
-                Pair<StatSummary, StatSummary> retttt = playerObservationTest(gt, i);
+                Pair<TAGStatSummary, TAGStatSummary> retttt = playerObservationTest(gt, i);
                 rs.add(retttt.a);
                 bf.add(retttt.b);
             }

--- a/src/main/java/evaluation/GameReportII.java
+++ b/src/main/java/evaluation/GameReportII.java
@@ -173,6 +173,12 @@ public class GameReportII {
             data.put("ScoreMax", sc.max());
             data.put("ScoreMin", sc.min());
             data.put("ScoreVarCoeff", Math.abs(sc.sd() / sc.mean()));
+            TAGStatSummary scoreDelta = scores.size() > 1 ?
+                    IntStream.range(0, scores.size() - 1)
+                            .mapToObj(i -> !scores.get(i + 1).equals(scores.get(i)) ? 1.0 : 0.0)
+                            .collect(new TAGSummariser())
+                    : new TAGStatSummary();
+            data.put("ScoreDelta", scoreDelta.mean()); // percentage of actions that lead to a change in score
             TAGStatSummary stateSize = components.stream().collect(new TAGSummariser());
             data.put("StateSizeMedian", stateSize.median());
             data.put("StateSizeMean", stateSize.mean());
@@ -187,7 +193,6 @@ public class GameReportII {
             data.put("HiddenInfoVarCoeff", Math.abs(visibility.sd() / visibility.mean()));
             return data;
         }
-
     }
 
     private static void preGameProcessing(Game game, Map<String, Object> data) {

--- a/src/main/java/evaluation/GameReportII.java
+++ b/src/main/java/evaluation/GameReportII.java
@@ -16,10 +16,8 @@ import players.PlayerFactory;
 import utilities.*;
 
 import java.util.*;
-import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import static java.util.stream.Collectors.summarizingInt;
 import static java.util.stream.Collectors.toList;
 import static utilities.Utils.getArg;
 
@@ -155,19 +153,19 @@ public class GameReportII {
 //            IntSummaryStatistics bf = branchingByStates.stream().mapToInt(i -> i).summaryStatistics();
 //            data.put("BranchingFactor", bf.getAverage());
 //            data.put("MaxBranchingFactor", bf.getMax());
-            StatSummary sc = scores.stream().collect(new TAGSummariser());
+            TAGStatSummary sc = scores.stream().collect(new TAGSummariser());
             data.put("ScoreMedian", sc.median());
             data.put("ScoreMean", sc.mean());
             data.put("ScoreMax", sc.max());
             data.put("ScoreMin", sc.min());
             data.put("ScoreVarCoeff", Math.abs(sc.sd() / sc.mean()));
-            StatSummary stateSize = components.stream().collect(new TAGSummariser());
+            TAGStatSummary stateSize = components.stream().collect(new TAGSummariser());
             data.put("StateSizeMedian", stateSize.median());
             data.put("StateSizeMean", stateSize.mean());
             data.put("StateSizeMax", stateSize.max());
             data.put("StateSizeMin", stateSize.min());
             data.put("StateSizeVarCoeff", Math.abs(stateSize.sd() / stateSize.mean()));
-            StatSummary visibility = visibilityOnTurn.stream().collect(new TAGSummariser());
+            TAGStatSummary visibility = visibilityOnTurn.stream().collect(new TAGSummariser());
             data.put("HiddenInfoMedian", visibility.median());
             data.put("HiddenInfoMean", visibility.mean());
             data.put("HiddenInfoMax", visibility.max());
@@ -257,7 +255,7 @@ public class GameReportII {
 
         //    Retrieves a list with one entry per game tick, each a pair (active player ID, # actions)
         List<Pair<Integer, Integer>> actionSpaceRecord = game.getActionSpaceSize();
-        StatSummary stats = actionSpaceRecord.stream()
+        TAGStatSummary stats = actionSpaceRecord.stream()
                 .map(r -> r.b)
                 .filter(size -> size > 1)
                 .collect(new TAGSummariser());

--- a/src/main/java/evaluation/ITPSearchSpace.java
+++ b/src/main/java/evaluation/ITPSearchSpace.java
@@ -114,7 +114,7 @@ public class ITPSearchSpace extends AgentSearchSpace<Object> {
                             throw new AssertionError("We have a problem with null data in JSON file using key " + key);
                         itp.setParameterValue(key, data);
                     }
-                } else {
+                } else if (!baseKey.equals("class")){
                     System.out.println("Unexpected key in JSON when loading ITPSearchSpace : " + baseKey);
                 }
             }

--- a/src/main/java/evaluation/testplayers/RandomTestPlayer.java
+++ b/src/main/java/evaluation/testplayers/RandomTestPlayer.java
@@ -3,7 +3,7 @@ package evaluation.testplayers;
 import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.actions.AbstractAction;
-import utilities.StatSummary;
+import utilities.TAGStatSummary;
 
 import java.util.HashSet;
 import java.util.List;
@@ -19,9 +19,9 @@ public class RandomTestPlayer extends AbstractPlayer {
     // Random generator for action selection
     private Random random;
     // Record of branching factor
-    private StatSummary bf;
+    private TAGStatSummary bf;
     // Scores observed during the game
-    private StatSummary scores;
+    private TAGStatSummary scores;
 
     public RandomTestPlayer() {
         this(new Random());
@@ -29,8 +29,8 @@ public class RandomTestPlayer extends AbstractPlayer {
 
     public RandomTestPlayer(Random random) {
         this.random = random;
-        scores = new StatSummary();
-        bf = new StatSummary();
+        scores = new TAGStatSummary();
+        bf = new TAGStatSummary();
     }
 
     @Override
@@ -50,11 +50,11 @@ public class RandomTestPlayer extends AbstractPlayer {
         return actions.get(random.nextInt(actions.size()));
     }
 
-    public StatSummary getBranchingFactor() {
+    public TAGStatSummary getBranchingFactor() {
         return bf;
     }
 
-    public StatSummary getScores() {
+    public TAGStatSummary getScores() {
         return scores;
     }
 }

--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -87,7 +87,7 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
     }
 
     private void setupRounds(ColtExpressGameState cegs, ColtExpressParameters cep){
-        cegs.rounds = new PartialObservableDeck<>("Rounds", -1);
+        cegs.rounds = new PartialObservableDeck<>("Rounds", -1, cegs.getNPlayers());
 
         // Add random round cards
         ArrayList<Integer> availableRounds = new ArrayList<>();
@@ -100,6 +100,10 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
             cegs.rounds.add(cegs.getRoundCard(cep, choice, cegs.getNPlayers()));
             availableRounds.remove(Integer.valueOf(choice));
         }
+        // set first card to be visible
+        boolean[] allTrue = new boolean[cegs.getNPlayers()];
+        Arrays.fill(allTrue, true);
+        cegs.rounds.setVisibilityOfComponent(0, allTrue);
 
         // Add 1 random end round card
         cegs.rounds.add(cegs.getRandomEndRoundCard(cep, cegs.getTurnOrder().getRoundCounter()));

--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -65,7 +65,7 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
 
             cegs.playerHandCards.add(playerHand);
 
-            Deck<Loot> loot = new Deck<>("playerLoot" + playerIndex, playerIndex, VisibilityMode.VISIBLE_TO_OWNER);
+            Deck<Loot> loot = new Deck<>("playerLoot" + playerIndex, playerIndex, VisibilityMode.VISIBLE_TO_ALL);
             for (Group<LootType, Integer, Integer> e: cep.playerStartLoot) {
                 LootType lootType = e.a;
                 int value = e.b;

--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -1,25 +1,26 @@
 package games.coltexpress;
 
-import core.AbstractGameState;
 import core.AbstractForwardModel;
+import core.AbstractGameState;
 import core.actions.AbstractAction;
 import core.actions.DoNothing;
 import core.actions.DrawCard;
 import core.components.Deck;
 import core.components.PartialObservableDeck;
 import core.interfaces.IGamePhase;
+import games.coltexpress.ColtExpressTypes.CharacterType;
+import games.coltexpress.ColtExpressTypes.LootType;
 import games.coltexpress.actions.*;
 import games.coltexpress.cards.ColtExpressCard;
-import games.coltexpress.components.Loot;
-import games.coltexpress.ColtExpressTypes.*;
-import utilities.Group;
 import games.coltexpress.components.Compartment;
+import games.coltexpress.components.Loot;
+import utilities.Group;
 import utilities.Utils;
-
-import static core.CoreConstants.VERBOSE;
 
 import java.util.*;
 
+import static core.CoreConstants.VERBOSE;
+import static core.CoreConstants.VisibilityMode;
 import static games.coltexpress.ColtExpressGameState.ColtExpressGamePhase.PlanActions;
 
 public class ColtExpressForwardModel extends AbstractForwardModel {
@@ -51,7 +52,7 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
             if (characterType == CharacterType.Belle)
                 cegs.playerPlayingBelle = playerIndex;
 
-            Deck<ColtExpressCard> playerCards = new Deck<>("playerCards" + playerIndex, playerIndex);
+            Deck<ColtExpressCard> playerCards = new Deck<>("playerCards" + playerIndex, playerIndex, VisibilityMode.HIDDEN_TO_ALL);
             for (ColtExpressCard.CardType type : cep.cardCounts.keySet()){
                 for (int j = 0; j < cep.cardCounts.get(type); j++) {
                     playerCards.add(new ColtExpressCard(playerIndex, type));
@@ -60,12 +61,11 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
             cegs.playerDecks.add(playerCards);
             playerCards.shuffle(new Random(cep.getRandomSeed()+playerIndex));
 
-            Deck<ColtExpressCard> playerHand = new Deck<>(
-                    "playerHand" + playerIndex, playerIndex);
+            Deck<ColtExpressCard> playerHand = new Deck<>("playerHand" + playerIndex, playerIndex, VisibilityMode.VISIBLE_TO_OWNER);
 
             cegs.playerHandCards.add(playerHand);
 
-            Deck<Loot> loot = new Deck<>("playerLoot" + playerIndex, playerIndex);
+            Deck<Loot> loot = new Deck<>("playerLoot" + playerIndex, playerIndex, VisibilityMode.VISIBLE_TO_OWNER);
             for (Group<LootType, Integer, Integer> e: cep.playerStartLoot) {
                 LootType lootType = e.a;
                 int value = e.b;
@@ -87,7 +87,7 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
     }
 
     private void setupRounds(ColtExpressGameState cegs, ColtExpressParameters cep){
-        cegs.rounds = new Deck<>("Rounds", -1);
+        cegs.rounds = new PartialObservableDeck<>("Rounds", -1);
 
         // Add random round cards
         ArrayList<Integer> availableRounds = new ArrayList<>();

--- a/src/main/java/games/coltexpress/ColtExpressGameState.java
+++ b/src/main/java/games/coltexpress/ColtExpressGameState.java
@@ -58,10 +58,6 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
         List<Component> components = new ArrayList<>();
         components.add(plannedActions);
         components.addAll(trainCompartments);
-
-        components.addAll(trainCompartments);
-        // we now support recursion of Decks (or any Container)
-
         components.addAll(playerHandCards);
         components.addAll(playerDecks);
         components.addAll(playerLoot);
@@ -218,7 +214,7 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
         playerPlayingBelle = -1;
         plannedActions = null;
         trainCompartments = new LinkedList<>();
-        rounds = new PartialObservableDeck<>("Rounds", -1);
+        rounds = new PartialObservableDeck<>("Rounds", -1, getNPlayers());
         gamePhase = ColtExpressGamePhase.PlanActions;
     }
 

--- a/src/main/java/games/coltexpress/ColtExpressTurnOrder.java
+++ b/src/main/java/games/coltexpress/ColtExpressTurnOrder.java
@@ -1,9 +1,11 @@
 package games.coltexpress;
 
 import core.AbstractGameState;
+import core.CoreConstants;
 import games.coltexpress.cards.RoundCard;
 import core.turnorders.TurnOrder;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 import static utilities.Utils.GameResult.GAME_END;
@@ -58,7 +60,10 @@ public class ColtExpressTurnOrder extends TurnOrder {
      * @param round - round card.
      * @param turn - turn index (of turn type array in round card).
      */
-    private void initTurn(RoundCard round, int turn){
+    private void initTurn(RoundCard round, int turn, ColtExpressGameState state){
+        boolean[] allTrue = new boolean[nPlayers];
+        Arrays.fill(allTrue, true);
+        state.rounds.setVisibilityOfComponent(roundCounter, allTrue);
         currentTurnType = round.getTurnTypes()[turn];
         switch (round.getTurnTypes()[turn]){
             case NormalTurn:
@@ -126,6 +131,8 @@ public class ColtExpressTurnOrder extends TurnOrder {
      */
     @Override
     public void endRound(AbstractGameState gameState) {
+        listeners.forEach(l -> l.onEvent(CoreConstants.GameEvents.ROUND_OVER, gameState, null));
+
         turnCounter = 0;
         fullPlayerTurnCounter++;
         moveToNextPlayer(gameState, nextPlayer(gameState));
@@ -134,7 +141,7 @@ public class ColtExpressTurnOrder extends TurnOrder {
         RoundCard currentRoundCard = cegs.getRounds().get(roundCounter);
         if (fullPlayerTurnCounter < currentRoundCard.getTurnTypes().length) {
             // Initialize next full player turn
-            initTurn(currentRoundCard, fullPlayerTurnCounter);
+            initTurn(currentRoundCard, fullPlayerTurnCounter, cegs);
         } else {
             // All turns in this round played, execute the actions
             gameState.setGamePhase(ColtExpressGameState.ColtExpressGamePhase.ExecuteActions);
@@ -155,7 +162,7 @@ public class ColtExpressTurnOrder extends TurnOrder {
             turnCounter = 0;
             fullPlayerTurnCounter = 0;
             turnOwner = firstPlayerOfRound;
-            initTurn(gameState.getRounds().get(roundCounter), 0);
+            initTurn(gameState.getRounds().get(roundCounter), 0, gameState);
             gameState.setGamePhase(ColtExpressGameState.ColtExpressGamePhase.PlanActions);
             gameState.setGameStatus(GAME_ONGOING);
         } else {

--- a/src/main/java/games/coltexpress/actions/CollectMoneyAction.java
+++ b/src/main/java/games/coltexpress/actions/CollectMoneyAction.java
@@ -12,6 +12,8 @@ import games.coltexpress.components.Loot;
 import java.util.Objects;
 import java.util.Random;
 
+import static core.CoreConstants.VisibilityMode;
+
 public class CollectMoneyAction extends DrawCard {
 
     private final int availableLoot;
@@ -33,7 +35,7 @@ public class CollectMoneyAction extends DrawCard {
         }
 
         // Find all loot of type
-        Deck<Loot> possible = new Deck<>("tmp");
+        Deck<Loot> possible = new Deck<>("tmp", VisibilityMode.HIDDEN_TO_ALL);
         Deck<Loot> availableLootDeck = (Deck<Loot>) gameState.getComponentById(availableLoot);
         for (Loot available : availableLootDeck.getComponents()){
             if (available.getLootType() == loot) {

--- a/src/main/java/games/coltexpress/components/Compartment.java
+++ b/src/main/java/games/coltexpress/components/Compartment.java
@@ -28,8 +28,11 @@ public class Compartment extends Component implements IComponentContainer<Deck<L
 
     private Compartment(int nPlayers, int compartmentID, int ID){
         super(Utils.ComponentType.BOARD_NODE, ID);
-        this.lootInside = new Deck<>("lootInside", VisibilityMode.HIDDEN_TO_ALL);
-        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.HIDDEN_TO_ALL);
+        // Technically loot is face-down, and hence not Visible. But...players know which ones are Jewels and StrongBoxes
+        // So all that is actually hidden is which purses are 250 versus 500...on the whole this means that much more information
+        // is known than unknown.
+        this.lootInside = new Deck<>("lootInside", VisibilityMode.VISIBLE_TO_ALL);
+        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.VISIBLE_TO_ALL);
         this.nPlayers = nPlayers;
         this.compartmentID = compartmentID;
         playersInsideCompartment = new HashSet<>();
@@ -39,8 +42,8 @@ public class Compartment extends Component implements IComponentContainer<Deck<L
 
     public Compartment(int nPlayers, int compartmentID, int which, ColtExpressParameters cep){
         super(Utils.ComponentType.BOARD_NODE);
-        this.lootInside = new Deck<>("lootInside", VisibilityMode.HIDDEN_TO_ALL);
-        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.HIDDEN_TO_ALL);
+        this.lootInside = new Deck<>("lootInside", VisibilityMode.VISIBLE_TO_ALL);
+        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.VISIBLE_TO_ALL);
         this.nPlayers = nPlayers;
         this.compartmentID = compartmentID;
         playersInsideCompartment = new HashSet<>();

--- a/src/main/java/games/coltexpress/components/Compartment.java
+++ b/src/main/java/games/coltexpress/components/Compartment.java
@@ -2,14 +2,17 @@ package games.coltexpress.components;
 
 import core.components.Component;
 import core.components.Deck;
+import core.interfaces.IComponentContainer;
 import games.coltexpress.ColtExpressParameters;
 import games.coltexpress.ColtExpressTypes;
 import utilities.Utils;
 
 import java.util.*;
 
+import static core.CoreConstants.VisibilityMode;
 
-public class Compartment extends Component {
+
+public class Compartment extends Component implements IComponentContainer<Deck<Loot>> {
 
     public Deck<Loot> lootInside;
     public Deck<Loot> lootOnTop;
@@ -25,8 +28,8 @@ public class Compartment extends Component {
 
     private Compartment(int nPlayers, int compartmentID, int ID){
         super(Utils.ComponentType.BOARD_NODE, ID);
-        this.lootInside = new Deck<>("lootInside");
-        this.lootOnTop = new Deck<>("lootOntop");
+        this.lootInside = new Deck<>("lootInside", VisibilityMode.HIDDEN_TO_ALL);
+        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.HIDDEN_TO_ALL);
         this.nPlayers = nPlayers;
         this.compartmentID = compartmentID;
         playersInsideCompartment = new HashSet<>();
@@ -36,8 +39,8 @@ public class Compartment extends Component {
 
     public Compartment(int nPlayers, int compartmentID, int which, ColtExpressParameters cep){
         super(Utils.ComponentType.BOARD_NODE);
-        this.lootInside = new Deck<>("lootInside");
-        this.lootOnTop = new Deck<>("lootOntop");
+        this.lootInside = new Deck<>("lootInside", VisibilityMode.HIDDEN_TO_ALL);
+        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.HIDDEN_TO_ALL);
         this.nPlayers = nPlayers;
         this.compartmentID = compartmentID;
         playersInsideCompartment = new HashSet<>();
@@ -152,4 +155,14 @@ public class Compartment extends Component {
         return sb.toString();
     }
 
+    @Override
+    public List<Deck<Loot>> getComponents() {
+        return Arrays.asList(lootInside, lootOnTop);
+    }
+
+    @Override
+    public VisibilityMode getVisibilityMode() {
+        // The Loot is not visible..but the decks are.
+        return VisibilityMode.VISIBLE_TO_ALL;
+    }
 }

--- a/src/main/java/games/diamant/DiamantForwardModel.java
+++ b/src/main/java/games/diamant/DiamantForwardModel.java
@@ -5,14 +5,19 @@ import core.AbstractGameState;
 import core.actions.AbstractAction;
 import core.components.Counter;
 import core.components.Deck;
-import games.diamant.actions.*;
+import games.diamant.actions.ContinueInCave;
+import games.diamant.actions.ExitFromCave;
+import games.diamant.actions.OutOfCave;
 import games.diamant.cards.DiamantCard;
-import games.diamant.components.*;
+import games.diamant.components.ActionsPlayed;
 import utilities.Utils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
+
+import static core.CoreConstants.VisibilityMode.HIDDEN_TO_ALL;
+import static core.CoreConstants.VisibilityMode.VISIBLE_TO_ALL;
 
 public class DiamantForwardModel extends AbstractForwardModel {
     @Override
@@ -32,9 +37,9 @@ public class DiamantForwardModel extends AbstractForwardModel {
             dgs.playerInCave.add(true);
         }
 
-        dgs.mainDeck    = new Deck("MainDeck");
-        dgs.discardDeck = new Deck("DiscardDeck");
-        dgs.path        = new Deck("Path");
+        dgs.mainDeck    = new Deck("MainDeck", HIDDEN_TO_ALL);
+        dgs.discardDeck = new Deck("DiscardDeck", VISIBLE_TO_ALL);
+        dgs.path        = new Deck("Path", VISIBLE_TO_ALL);
         dgs.actionsPlayed = new ActionsPlayed();
 
         createCards(dgs);

--- a/src/main/java/games/diamant/DiamantGameState.java
+++ b/src/main/java/games/diamant/DiamantGameState.java
@@ -6,21 +6,16 @@ import core.components.Component;
 import core.components.Counter;
 import core.components.Deck;
 import core.interfaces.IPrintable;
-import core.turnorders.AlternatingTurnOrder;
 import core.turnorders.SimultaneousTurnOrder;
-import games.diamant.actions.ContinueInCave;
-import games.diamant.actions.ExitFromCave;
-import games.diamant.actions.OutOfCave;
 import games.diamant.cards.DiamantCard;
 import games.diamant.components.ActionsPlayed;
-import games.diamant.components.DiamantTreasureChest;
-import games.diamant.components.DiamantHand;
 
-import java.util.*;
-import java.util.stream.Collectors;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
 
 import static core.CoreConstants.PARTIAL_OBSERVABLE;
-import static java.util.stream.Collectors.*;
 
 public class DiamantGameState extends AbstractGameState implements IPrintable {
     Deck<DiamantCard>          mainDeck;
@@ -145,7 +140,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     @Override
     protected ArrayList<Integer> _getUnknownComponentsIds(int playerId)
     {
-        ArrayList<Integer> ids = mainDeck.getComponents().stream().map(Component::getComponentID).collect(toCollection(ArrayList::new));
+        ArrayList<Integer> ids = new ArrayList<>();
         ids.add(actionsPlayed.getComponentID());
         return ids;
     }

--- a/src/main/java/games/diamant/DiamantHeuristic.java
+++ b/src/main/java/games/diamant/DiamantHeuristic.java
@@ -27,11 +27,11 @@ public class DiamantHeuristic extends TunableParameters implements IStateHeurist
 
     @Override
     public void _reset() {
-        FACTOR_SCORE = (double) getDefaultParameterValue("FACTOR_SCORE");
-        FACTOR_LEADER = (double) getDefaultParameterValue("FACTOR_LEADER");
-        FACTOR_BEHIND = (double) getDefaultParameterValue("FACTOR_BEHIND");
-        FACTOR_AHEAD = (double) getDefaultParameterValue("FACTOR_AHEAD");
-        FACTOR_IN_CAVE = (double) getDefaultParameterValue("FACTOR_IN_CAVE");
+        FACTOR_SCORE = (double) getParameterValue("FACTOR_SCORE");
+        FACTOR_LEADER = (double) getParameterValue("FACTOR_LEADER");
+        FACTOR_BEHIND = (double) getParameterValue("FACTOR_BEHIND");
+        FACTOR_AHEAD = (double) getParameterValue("FACTOR_AHEAD");
+        FACTOR_IN_CAVE = (double) getParameterValue("FACTOR_IN_CAVE");
     }
 
     /**

--- a/src/main/java/games/diamant/DiamantHeuristic.java
+++ b/src/main/java/games/diamant/DiamantHeuristic.java
@@ -1,10 +1,38 @@
 package games.diamant;
 
 import core.AbstractGameState;
+import core.components.Counter;
 import core.interfaces.IStateHeuristic;
+import evaluation.TunableParameters;
 import utilities.Utils;
 
-public class DiamantHeuristic implements IStateHeuristic {
+import java.util.List;
+import java.util.stream.Collectors;
+
+public class DiamantHeuristic extends TunableParameters implements IStateHeuristic {
+
+    double FACTOR_SCORE = 1.0;
+    double FACTOR_LEADER = 0.05;
+    double FACTOR_BEHIND = -0.15;
+    double FACTOR_AHEAD = 0.0;
+    double FACTOR_IN_CAVE = 0.0;
+
+    public DiamantHeuristic() {
+        addTunableParameter("FACTOR_SCORE", 1.0);
+        addTunableParameter("FACTOR_LEADER", 0.05);
+        addTunableParameter("FACTOR_BEHIND", -0.15);
+        addTunableParameter("FACTOR_AHEAD", 0.0);
+        addTunableParameter("FACTOR_IN_CAVE", 0.0);
+    }
+
+    @Override
+    public void _reset() {
+        FACTOR_SCORE = (double) getDefaultParameterValue("FACTOR_SCORE");
+        FACTOR_LEADER = (double) getDefaultParameterValue("FACTOR_LEADER");
+        FACTOR_BEHIND = (double) getDefaultParameterValue("FACTOR_BEHIND");
+        FACTOR_AHEAD = (double) getDefaultParameterValue("FACTOR_AHEAD");
+        FACTOR_IN_CAVE = (double) getDefaultParameterValue("FACTOR_IN_CAVE");
+    }
 
     /**
      * Get the score of a player given the game state
@@ -27,20 +55,54 @@ public class DiamantHeuristic implements IStateHeuristic {
             return 1;
 
         DiamantGameState dgs = (DiamantGameState) gs;
-        int max_ngens = 0;      // small number
-        for (int i = 0; i < dgs.getNPlayers(); i++) {
-            if (i != playerId) {
-                int nGems = dgs.treasureChests.get(i).getValue();
-                if (nGems > max_ngens)
-                    max_ngens = nGems;
-            }
-        }
+        List<Integer> gemsInOrder = dgs.getTreasureChests().stream()
+                .mapToInt(Counter::getValue)
+                .sorted().boxed().collect(Collectors.toList());
+
+        int max_ngens = gemsInOrder.get(dgs.getNPlayers()-1);
+        int min_ngens = gemsInOrder.get(0);
 
         int player_gems = dgs.treasureChests.get(playerId).getValue();
-        double score = player_gems / 139.0; // so is 1.0 if a player has every single gem....
+        double highestExpectedScore = 139.0 / gs.getNPlayers() * 2.0;
+        // 1.0 if a player has every single gem in a 2-player game; 67% of gems in a 3-player; 50% in a 4-player....
+        double score = FACTOR_SCORE * player_gems / highestExpectedScore;
 
-        if (player_gems == max_ngens) score += 0.05;
+        if (player_gems == max_ngens) score += FACTOR_LEADER; // are we in the lead (including co-lead)
+
+        score += FACTOR_BEHIND * (max_ngens - player_gems) / highestExpectedScore;
+
+        score += FACTOR_AHEAD * (player_gems - min_ngens) / highestExpectedScore;
+
+        if (dgs.playerInCave.get(playerId)) score += FACTOR_IN_CAVE;  // are we in the cave...for luck-pushing strategies
 
         return score;
     }
+
+    @Override
+    protected DiamantHeuristic _copy() {
+        DiamantHeuristic retValue = new DiamantHeuristic();
+        retValue.FACTOR_AHEAD = FACTOR_AHEAD;
+        retValue.FACTOR_BEHIND = FACTOR_BEHIND;
+        retValue.FACTOR_LEADER = FACTOR_LEADER;
+        retValue.FACTOR_SCORE = FACTOR_SCORE;
+        retValue.FACTOR_IN_CAVE = FACTOR_IN_CAVE;
+        return retValue;
+    }
+
+    @Override
+    protected boolean _equals(Object o) {
+        if (o instanceof DiamantHeuristic) {
+            DiamantHeuristic other = (DiamantHeuristic) o;
+            return other.FACTOR_IN_CAVE == FACTOR_IN_CAVE && other.FACTOR_SCORE == FACTOR_SCORE &&
+                    other.FACTOR_LEADER == FACTOR_LEADER && other.FACTOR_BEHIND == FACTOR_BEHIND &&
+                    other.FACTOR_AHEAD == FACTOR_AHEAD;
+        }
+        return false;
+    }
+
+    @Override
+    public DiamantHeuristic instantiate() {
+        return _copy();
+    }
+
 }

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -379,7 +379,7 @@ public class DominionGameState extends AbstractGameState {
      * of victory points, etc.
      * If a game does not support this directly, then just return 0.0
      *
-     * @param playerId
+     * @param playerId - id of the player
      * @return - double, score of current state
      */
     @Override

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -11,6 +11,7 @@ import utilities.Utils;
 import java.util.*;
 import java.util.function.Function;
 
+import static core.CoreConstants.*;
 import static java.util.Comparator.*;
 import static java.util.stream.Collectors.*;
 
@@ -253,7 +254,7 @@ public class DominionGameState extends AbstractGameState {
                 allCards = getDeck(deck, playerId);
                 break;
             case ALL:
-                allCards = new Deck<>("temp");
+                allCards = new Deck<>("temp", VisibilityMode.HIDDEN_TO_ALL);
                 allCards.add(playerHands[playerId]);
                 allCards.add(playerDiscards[playerId]);
                 allCards.add(playerDrawPiles[playerId]);
@@ -404,18 +405,6 @@ public class DominionGameState extends AbstractGameState {
     }
 
     /**
-     * Provide a list of component IDs which are hidden in partially observable copies of games.
-     * Depending on the game, in the copies these might be completely missing, or just randomized.
-     *
-     * @param playerId - ID of player observing the state.
-     * @return - list of component IDs unobservable by the given player.
-     */
-    @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<>();
-    }
-
-    /**
      * Resets variables initialised for this game state.
      */
     @Override
@@ -425,14 +414,14 @@ public class DominionGameState extends AbstractGameState {
         playerDiscards = new Deck[playerCount];
         playerTableaux = new Deck[playerCount];
 
-        trashPile = new Deck<>("Trash");
+        trashPile = new Deck<>("Trash", VisibilityMode.VISIBLE_TO_ALL);
         for (int i = 0; i < playerCount; i++) {
             boolean[] handVisibility = new boolean[playerCount];
             handVisibility[i] = true;
             playerHands[i] = new PartialObservableDeck<>("Hand of Player " + i + 1, handVisibility);
             playerDrawPiles[i] = new PartialObservableDeck<>("Drawpile of Player " + i + 1, new boolean[playerCount]);
-            playerDiscards[i] = new Deck<>("Discard of Player " + i + 1);
-            playerTableaux[i] = new Deck<>("Tableau of Player " + i + 1);
+            playerDiscards[i] = new Deck<>("Discard of Player " + i + 1, VisibilityMode.VISIBLE_TO_ALL);
+            playerTableaux[i] = new Deck<>("Tableau of Player " + i + 1, VisibilityMode.VISIBLE_TO_ALL);
         }
     }
 

--- a/src/main/java/games/dominion/actions/IExtendedSequence.java
+++ b/src/main/java/games/dominion/actions/IExtendedSequence.java
@@ -5,15 +5,61 @@ import games.dominion.DominionGameState;
 
 import java.util.*;
 
+/**
+ * An Action (usually) that entails a sequence of linked actions/decisions. This takes temporary control of deciding
+ * which player is currently making a decision (the currentPlayer) from TurnOrder, and of what actions they have
+ * available from ForwardModel.
+ *
+ * ForwardModel will register all actions taken and the current state just before execution of each action in next().
+ *
+ * IExtendedSequence is then responsible for tracking all local state necessary for its set of actions, and marking
+ * itself as complete. (ForwardModel will then detect this, and remove it from the Stack of open actions.)
+ */
 public interface IExtendedSequence {
 
+    /**
+     * Forward Model delegates to this from computeAvailableActions() if this Extended Sequence is currently active.
+     *
+     * @param state The current game state
+     * @return the list of possible actions for the currentPlayer
+     */
     List<AbstractAction> followOnActions(DominionGameState state);
 
+    /**
+     * TurnOrder delegates to this from getCurrentPlayer() if this Extended Sequence is currently active.
+     *
+     * @param state The current game state
+     * @return The player Id whose move it is
+     */
     int getCurrentPlayer(DominionGameState state);
 
+    /**
+     * This is called by ForwardModel whenever an action is about to be taken. It enables the IExtendedSequence
+     * to maintain local state in whichever way is most suitable.
+     *
+     * After this call, the state of IExtendedSequence should be correct ahead of the next decision to be made.
+     *
+     * In some cases there is no need to implement anything in this method - if for example you can tell if all
+     * actions are complete from the state directly, then that can be implemented purely in executionComplete()
+     *
+     * @param state The current game state
+     * @param action The action about to be taken (so the game state has not yet been updated with it)
+     */
     void registerActionTaken(DominionGameState state, AbstractAction action);
 
+    /**
+     * Return true if this extended sequence has now completed and there is nothing left to do.
+     *
+     * @param state The current game state
+     * @return True if all decisions are now complete
+     */
     boolean executionComplete(DominionGameState state);
 
+    /**
+     * Usual copy() standards apply.
+     * NO REFERENCES TO COMPONENTS TO BE KEPT, PRIMITIVE TYPES ONLY.
+     *
+     * @return
+     */
     IExtendedSequence copy();
 }

--- a/src/main/java/games/dominion/cards/DominionCard.java
+++ b/src/main/java/games/dominion/cards/DominionCard.java
@@ -1,13 +1,9 @@
 package games.dominion.cards;
 
 import core.actions.AbstractAction;
-import core.components.*;
-import games.dominion.DominionConstants;
-import games.dominion.DominionGame;
+import core.components.Card;
 import games.dominion.DominionGameState;
 import games.dominion.actions.*;
-
-import java.util.Objects;
 
 public class DominionCard extends Card {
 
@@ -18,30 +14,15 @@ public class DominionCard extends Card {
         this.type = type;
     }
 
-    private static DominionCard gold = new DominionCard(CardType.GOLD);
-    private static DominionCard silver = new DominionCard(CardType.SILVER);
-    private static DominionCard copper = new DominionCard(CardType.COPPER);
-    private static DominionCard province = new DominionCard(CardType.PROVINCE);
-    private static DominionCard duchy = new DominionCard(CardType.DUCHY);
-    private static DominionCard estate = new DominionCard(CardType.ESTATE);
-    private static DominionCard curse = new DominionCard(CardType.CURSE);
-
     public static DominionCard create(CardType type) {
         switch (type) {
             case GOLD:
-                return gold;
             case COPPER:
-                return copper;
             case SILVER:
-                return silver;
             case ESTATE:
-                return estate;
             case DUCHY:
-                return duchy;
             case PROVINCE:
-                return province;
             case CURSE:
-                return curse;
             case VILLAGE:
             case SMITHY:
             case LABORATORY:

--- a/src/main/java/games/dominion/test/CoreGameLoop.java
+++ b/src/main/java/games/dominion/test/CoreGameLoop.java
@@ -1,19 +1,29 @@
 package games.dominion.test;
 
 import core.AbstractPlayer;
+import core.CoreConstants;
 import core.actions.AbstractAction;
-import core.components.*;
-import games.dominion.*;
-import games.dominion.DominionGameState.*;
-import games.dominion.DominionConstants.*;
-import games.dominion.actions.*;
-import games.dominion.cards.*;
-import org.junit.*;
+import core.components.Deck;
+import core.components.PartialObservableDeck;
+import games.dominion.DominionConstants.DeckType;
+import games.dominion.DominionForwardModel;
+import games.dominion.DominionGame;
+import games.dominion.DominionGameState;
+import games.dominion.DominionGameState.DominionGamePhase;
+import games.dominion.DominionParameters;
+import games.dominion.actions.BuyCard;
+import games.dominion.actions.EndPhase;
+import games.dominion.actions.SimpleAction;
+import games.dominion.cards.CardType;
+import games.dominion.cards.DominionCard;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 import static org.junit.Assert.*;
-
-import java.util.*;
-import java.util.stream.Collectors;
 
 public class CoreGameLoop {
 
@@ -32,7 +42,7 @@ public class CoreGameLoop {
             assertEquals(5, state.getDeck(DeckType.HAND, i).getSize());
             assertEquals(5, state.getDeck(DeckType.DRAW, i).getSize());
             assertEquals(0, state.getDeck(DeckType.DISCARD, i).getSize());
-            Deck<DominionCard> allCards = new Deck<>("test");
+            Deck<DominionCard> allCards = new Deck<>("test", CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
             allCards.add(state.getDeck(DeckType.HAND, i));
             allCards.add(state.getDeck(DeckType.DRAW, i));
             assertEquals(7, allCards.stream().filter(c -> c.cardType() == CardType.COPPER).count());

--- a/src/main/java/games/dotsboxes/DBGameState.java
+++ b/src/main/java/games/dotsboxes/DBGameState.java
@@ -91,11 +91,6 @@ public class DBGameState extends AbstractGameState {
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<>();  // fully observable at all times
-    }
-
-    @Override
     protected void _reset() {
         grid = null;
         nCellsComplete = 0;

--- a/src/main/java/games/explodingkittens/ExplodingKittensForwardModel.java
+++ b/src/main/java/games/explodingkittens/ExplodingKittensForwardModel.java
@@ -1,8 +1,9 @@
 package games.explodingkittens;
 
-import core.actions.AbstractAction;
-import core.AbstractGameState;
 import core.AbstractForwardModel;
+import core.AbstractGameState;
+import core.CoreConstants.VisibilityMode;
+import core.actions.AbstractAction;
 import core.components.Deck;
 import core.components.PartialObservableDeck;
 import games.explodingkittens.actions.*;
@@ -15,8 +16,8 @@ import utilities.Utils;
 
 import java.util.*;
 
-import static games.explodingkittens.ExplodingKittensGameState.ExplodingKittensGamePhase.Nope;
 import static core.CoreConstants.VERBOSE;
+import static games.explodingkittens.ExplodingKittensGameState.ExplodingKittensGamePhase.Nope;
 import static utilities.Utils.generatePermutations;
 
 public class ExplodingKittensForwardModel extends AbstractForwardModel {
@@ -67,7 +68,7 @@ public class ExplodingKittensForwardModel extends AbstractForwardModel {
             }
         }
         ekgs.setPlayerHandCards(playerHandCards);
-        ekgs.setDiscardPile(new Deck<>("Discard Pile"));
+        ekgs.setDiscardPile(new Deck<>("Discard Pile", VisibilityMode.VISIBLE_TO_ALL));
 
         // Add remaining defuse cards and exploding kitten cards to the deck and shuffle again
         for (int i = ekgs.getNPlayers(); i < ekp.nDefuseCards; i++){

--- a/src/main/java/games/explodingkittens/ExplodingKittensGameState.java
+++ b/src/main/java/games/explodingkittens/ExplodingKittensGameState.java
@@ -1,12 +1,12 @@
 package games.explodingkittens;
 
-import core.AbstractParameters;
-import core.components.Component;
-import core.interfaces.IGamePhase;
-import core.actions.AbstractAction;
-import core.components.Deck;
 import core.AbstractGameState;
+import core.AbstractParameters;
+import core.actions.AbstractAction;
+import core.components.Component;
+import core.components.Deck;
 import core.components.PartialObservableDeck;
+import core.interfaces.IGamePhase;
 import core.interfaces.IPrintable;
 import games.explodingkittens.cards.ExplodingKittensCard;
 import utilities.Utils;
@@ -14,6 +14,7 @@ import utilities.Utils;
 import java.util.*;
 
 import static core.CoreConstants.PARTIAL_OBSERVABLE;
+import static core.CoreConstants.VisibilityMode;
 
 public class ExplodingKittensGameState extends AbstractGameState implements IPrintable {
 
@@ -88,7 +89,7 @@ public class ExplodingKittensGameState extends AbstractGameState implements IPri
 
             // Shuffles only hidden cards in draw pile, if player knows what's on top those will stay in place
             ekgs.drawPile.shuffleVisible(r, playerId, false);
-            Deck<ExplodingKittensCard> explosive = new Deck<>("tmp");
+            Deck<ExplodingKittensCard> explosive = new Deck<>("tmp", VisibilityMode.HIDDEN_TO_ALL);
             for (int i = 0; i < getNPlayers(); i++) {
                 if (i != playerId) {
                     for (int j = 0; j < playerHandCards.get(i).getSize(); j++) {
@@ -138,26 +139,6 @@ public class ExplodingKittensGameState extends AbstractGameState implements IPri
     @Override
     public double getGameScore(int playerId) {
         return 0;
-    }
-
-    @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<Integer>() {{
-            for (int i = 0; i < getNPlayers(); i++) {
-                if (i != playerId) {
-                    add(playerHandCards.get(i).getComponentID());
-                    for (Component c: playerHandCards.get(i).getComponents()) {
-                        add(c.getComponentID());
-                    }
-                }
-            }
-            add(drawPile.getComponentID());
-            for (int i = 0; i < drawPile.getSize(); i++) {
-                if (!drawPile.isComponentVisible(i, playerId)) {
-                    add(drawPile.get(i).getComponentID());
-                }
-            }
-        }};
     }
 
     @Override

--- a/src/main/java/games/loveletter/LoveLetterForwardModel.java
+++ b/src/main/java/games/loveletter/LoveLetterForwardModel.java
@@ -1,10 +1,10 @@
 package games.loveletter;
 
+import core.AbstractForwardModel;
 import core.AbstractGameState;
+import core.actions.AbstractAction;
 import core.components.Deck;
 import core.components.PartialObservableDeck;
-import core.AbstractForwardModel;
-import core.actions.AbstractAction;
 import core.interfaces.IGamePhase;
 import games.GameType;
 import games.loveletter.actions.*;
@@ -13,9 +13,8 @@ import utilities.Utils;
 
 import java.util.*;
 
-import static core.CoreConstants.PARTIAL_OBSERVABLE;
+import static core.CoreConstants.*;
 import static games.loveletter.LoveLetterGameState.LoveLetterGamePhase.Draw;
-import static core.CoreConstants.VERBOSE;
 
 
 public class LoveLetterForwardModel extends AbstractForwardModel {
@@ -98,7 +97,7 @@ public class LoveLetterForwardModel extends AbstractForwardModel {
                 llgs.playerHandCards.add(playerCards);
 
                 // create a player's discard pile, which is visible to all players
-                Deck<LoveLetterCard> discardCards = new Deck<>("discardPlayer" + i, i);
+                Deck<LoveLetterCard> discardCards = new Deck<>("discardPlayer" + i, i, VisibilityMode.VISIBLE_TO_ALL);
                 llgs.playerDiscardCards.add(discardCards);
             }
         } else {

--- a/src/main/java/games/loveletter/LoveLetterGameState.java
+++ b/src/main/java/games/loveletter/LoveLetterGameState.java
@@ -123,35 +123,6 @@ public class LoveLetterGameState extends AbstractGameState implements IPrintable
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        // Draw pile, other player hands and reserve cards
-        return new ArrayList<Integer>() {{
-            add(drawPile.getComponentID());
-            for (int i = 0; i < drawPile.getSize(); i++) {
-                if (!drawPile.isComponentVisible(i, playerId)) {
-                    add(drawPile.get(i).getComponentID());
-                }
-            }
-            add(reserveCards.getComponentID());
-            for (int i = 0; i < reserveCards.getSize(); i++) {
-                if (!reserveCards.isComponentVisible(i, playerId)) {
-                    add(reserveCards.get(i).getComponentID());
-                }
-            }
-            for (int i = 0; i < getNPlayers(); i++) {
-                if (playerHandCards.get(i).getDeckVisibility()[playerId]){
-                    add(playerHandCards.get(i).getComponentID());
-                    for (int j = 0; j < playerHandCards.get(i).getSize(); j++) {
-                        if (!playerHandCards.get(i).isComponentVisible(j, playerId)) {
-                            add(playerHandCards.get(i).get(j).getComponentID());
-                        }
-                    }
-                }
-            }
-        }};
-    }
-
-    @Override
     protected void _reset() {
         gamePhase = Draw;
         playerHandCards = new ArrayList<>();

--- a/src/main/java/games/loveletter/actions/KingAction.java
+++ b/src/main/java/games/loveletter/actions/KingAction.java
@@ -1,6 +1,7 @@
 package games.loveletter.actions;
 
 import core.AbstractGameState;
+import core.CoreConstants.VisibilityMode;
 import core.actions.AbstractAction;
 import core.components.Deck;
 import core.interfaces.IPrintable;
@@ -32,7 +33,7 @@ public class KingAction extends DrawCard implements IPrintable {
 
         // create a temporary deck to store cards in and then swap cards accordingly
         if (((LoveLetterGameState) gs).isNotProtected(opponentID)){
-            Deck<LoveLetterCard> tmpDeck = new Deck<>("tmp");
+            Deck<LoveLetterCard> tmpDeck = new Deck<>("tmp", VisibilityMode.HIDDEN_TO_ALL);
             while (opponentDeck.getSize() > 0)
                 tmpDeck.add(opponentDeck.draw());
             while (playerDeck.getSize() > 0)

--- a/src/main/java/games/pandemic/PandemicForwardModel.java
+++ b/src/main/java/games/pandemic/PandemicForwardModel.java
@@ -145,7 +145,7 @@ public class PandemicForwardModel extends AbstractRuleBasedForwardModel {
         int capacity = pp.max_cards_per_player;
         for (int i = 0; i < state.getNPlayers(); i++) {
             Area playerArea = new Area(i, "Player Area");
-            Deck<Card> playerHand = new Deck<>("Player Hand", VISIBLE_TO_OWNER);
+            Deck<Card> playerHand = new Deck<>("Player Hand", VISIBLE_TO_ALL);
             playerHand.setOwnerId(i);
             playerHand.setCapacity(capacity);
             playerArea.putComponent(playerHandHash, playerHand);

--- a/src/main/java/games/pandemic/PandemicForwardModel.java
+++ b/src/main/java/games/pandemic/PandemicForwardModel.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 import java.util.Random;
 
 import static core.CoreConstants.VERBOSE;
+import static core.CoreConstants.VisibilityMode.*;
 import static games.pandemic.PandemicActionFactory.*;
 import static games.pandemic.PandemicConstants.*;
 import static games.pandemic.actions.MovePlayer.placePlayer;
@@ -137,14 +138,14 @@ public class PandemicForwardModel extends AbstractRuleBasedForwardModel {
         PandemicParameters pp = (PandemicParameters)state.getGameParameters();
         PandemicData _data = state.getData();
 
-        state.tempDeck = new Deck<>("Temp Deck");
+        state.tempDeck = new Deck<>("Temp Deck", VISIBLE_TO_ALL);
         state.areas = new HashMap<>();
 
         // For each player, initialize their own areas: they get a player hand and a player card
         int capacity = pp.max_cards_per_player;
         for (int i = 0; i < state.getNPlayers(); i++) {
             Area playerArea = new Area(i, "Player Area");
-            Deck<Card> playerHand = new Deck<>("Player Hand");
+            Deck<Card> playerHand = new Deck<>("Player Hand", VISIBLE_TO_OWNER);
             playerHand.setOwnerId(i);
             playerHand.setCapacity(capacity);
             playerArea.putComponent(playerHandHash, playerHand);
@@ -192,17 +193,17 @@ public class PandemicForwardModel extends AbstractRuleBasedForwardModel {
         }
 
         // Set up decks
-        Deck<Card> playerDeck = new Deck<>("Player Deck"); // contains city & event cards
+        Deck<Card> playerDeck = new Deck<>("Player Deck", HIDDEN_TO_ALL); // contains city & event cards
         playerDeck.add(_data.findDeck("Cities"));
         playerDeck.add(_data.findDeck("Events"));
         Deck<Card> playerRoles = _data.findDeck("Player Roles");
         Deck<Card> infectionDeck =  _data.findDeck("Infections");
-        Deck<Card> infectionDiscard =  new Deck<>("Infection Discard");
+        Deck<Card> infectionDiscard =  new Deck<>("Infection Discard", VISIBLE_TO_ALL);
 
         gameArea.putComponent(PandemicConstants.playerDeckHash, playerDeck);
-        gameArea.putComponent(PandemicConstants.playerDeckDiscardHash, new Deck<>("Player Deck Discard"));
+        gameArea.putComponent(PandemicConstants.playerDeckDiscardHash, new Deck<>("Player Deck Discard", VISIBLE_TO_ALL));
         gameArea.putComponent(PandemicConstants.infectionDiscardHash, infectionDiscard);
-        gameArea.putComponent(PandemicConstants.plannerDeckHash, new Deck<>("Planner Deck")); // deck to store extra card for the contingency planner
+        gameArea.putComponent(PandemicConstants.plannerDeckHash, new Deck<>("Planner Deck", VISIBLE_TO_ALL)); // deck to store extra card for the contingency planner
         gameArea.putComponent(PandemicConstants.infectionHash, infectionDeck);
         gameArea.putComponent(PandemicConstants.playerRolesHash, playerRoles);
 

--- a/src/main/java/games/pandemic/PandemicGameState.java
+++ b/src/main/java/games/pandemic/PandemicGameState.java
@@ -118,22 +118,6 @@ public class PandemicGameState extends AbstractGameState implements IFeatureRepr
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<Integer>() {{
-            Deck<Card> pd = (Deck<Card>) getComponent(playerDeckHash);
-            Deck<Card> id = (Deck<Card>) getComponent(infectionHash);
-            add(pd.getComponentID());
-            add(id.getComponentID());
-            for (Component c: pd.getComponents()) {
-                add(c.getComponentID());
-            }
-            for (Component c: id.getComponents()) {
-                add(c.getComponentID());
-            }
-        }};
-    }
-
-    @Override
     protected void _reset() {
         areas = null;
         tempDeck = null;
@@ -244,7 +228,7 @@ public class PandemicGameState extends AbstractGameState implements IFeatureRepr
             if (playerId != -1 && key == -1) {
                 // Hiding face-down decks in game area
                 a = new Area(key, "Game area");
-                HashMap<Integer, Component> oldComponents = areas.get(key).getComponents();
+                HashMap<Integer, Component> oldComponents = areas.get(key).getComponentsMap();
                 for (Map.Entry<Integer, Component> e: oldComponents.entrySet()) {
                     if (PARTIAL_OBSERVABLE && playerId != -1 && (e.getKey() == playerDeckHash || e.getKey() == infectionHash)) {
                         Random r = new Random(gs.getGameParameters().getRandomSeed());

--- a/src/main/java/games/tictactoe/TicTacToeGameState.java
+++ b/src/main/java/games/tictactoe/TicTacToeGameState.java
@@ -63,11 +63,6 @@ public class TicTacToeGameState extends AbstractGameState implements IPrintable,
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<>();  // Always fully observable
-    }
-
-    @Override
     protected void _reset() {
         gridBoard = null;
     }

--- a/src/main/java/games/uno/UnoForwardModel.java
+++ b/src/main/java/games/uno/UnoForwardModel.java
@@ -1,17 +1,21 @@
 package games.uno;
 
-import core.actions.AbstractAction;
-import core.AbstractGameState;
 import core.AbstractForwardModel;
+import core.AbstractGameState;
+import core.actions.AbstractAction;
 import core.components.Deck;
 import games.uno.actions.NoCards;
 import games.uno.actions.PlayCard;
-import games.uno.cards.*;
+import games.uno.cards.UnoCard;
 import utilities.Utils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
 
 import static core.CoreConstants.VERBOSE;
+import static core.CoreConstants.VisibilityMode.*;
 
 public class UnoForwardModel extends AbstractForwardModel {
 
@@ -23,15 +27,15 @@ public class UnoForwardModel extends AbstractForwardModel {
         ugs.playerScore = new int[firstState.getNPlayers()];
         ugs.playerDecks = new ArrayList<>();
         for (int i = 0; i < ugs.getNPlayers(); i++) {
-            ugs.playerDecks.add(new Deck<>("Player " + i + " deck", i));
+            ugs.playerDecks.add(new Deck<>("Player " + i + " deck", i, VISIBLE_TO_OWNER));
         }
 
         // Create the draw deck with all the cards
-        ugs.drawDeck = new Deck<>("DrawDeck");
+        ugs.drawDeck = new Deck<>("DrawDeck", HIDDEN_TO_ALL);
         createCards(ugs);
 
         // Create the discard deck, at the beginning it is empty
-        ugs.discardDeck = new Deck<>("DiscardDeck");
+        ugs.discardDeck = new Deck<>("DiscardDeck", VISIBLE_TO_ALL);
 
         // Player 0 starts the game
         ugs.getTurnOrder().setStartingPlayer(0);

--- a/src/main/java/games/uno/UnoGameState.java
+++ b/src/main/java/games/uno/UnoGameState.java
@@ -176,24 +176,6 @@ public class UnoGameState extends AbstractGameState implements IPrintable {
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<Integer>() {{
-            add(drawDeck.getComponentID());
-            for (Component c: drawDeck.getComponents()) {
-                add(c.getComponentID());
-            }
-            for (int i = 0; i < getNPlayers(); i++) {
-                if (i != playerId) {
-                    add(playerDecks.get(i).getComponentID());
-                    for (Component c: playerDecks.get(i).getComponents()) {
-                        add(c.getComponentID());
-                    }
-                }
-            }
-        }};
-    }
-
-    @Override
     protected void _reset() {
         playerDecks = new ArrayList<>();
         drawDeck = null;

--- a/src/main/java/games/uno/UnoHeuristic.java
+++ b/src/main/java/games/uno/UnoHeuristic.java
@@ -1,6 +1,5 @@
 package games.uno;
 import core.AbstractGameState;
-import core.AbstractParameters;
 import core.interfaces.IStateHeuristic;
 import evaluation.TunableParameters;
 import utilities.Utils;
@@ -19,9 +18,9 @@ public class UnoHeuristic extends TunableParameters implements IStateHeuristic {
 
     @Override
     public void _reset() {
-        FACTOR_PLAYER = (double) getDefaultParameterValue("FACTOR_PLAYER");
-        FACTOR_OPPONENT = (double) getDefaultParameterValue("FACTOR_OPPONENT");
-        FACTOR_N_CARDS = (double) getDefaultParameterValue("FACTOR_N_CARDS");
+        FACTOR_PLAYER = (double) getParameterValue("FACTOR_PLAYER");
+        FACTOR_OPPONENT = (double) getParameterValue("FACTOR_OPPONENT");
+        FACTOR_N_CARDS = (double) getParameterValue("FACTOR_N_CARDS");
     }
 
     @Override

--- a/src/main/java/games/virus/VirusForwardModel.java
+++ b/src/main/java/games/virus/VirusForwardModel.java
@@ -5,14 +5,15 @@ import core.AbstractGameState;
 import core.actions.AbstractAction;
 import core.components.Deck;
 import games.virus.actions.*;
-import games.virus.cards.*;
+import games.virus.cards.VirusCard;
+import games.virus.cards.VirusTreatmentCard;
 import games.virus.components.VirusBody;
 import utilities.Utils;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 import static core.CoreConstants.VERBOSE;
+import static core.CoreConstants.VisibilityMode;
 import static games.virus.cards.VirusCard.OrganType.Treatment;
 import static games.virus.cards.VirusCard.OrganType.Wild;
 
@@ -36,13 +37,13 @@ public class VirusForwardModel extends AbstractForwardModel {
         }
 
         // Create the draw deck with all the cards
-        vgs.drawDeck = new Deck<>("DrawDeck", -1);
+        vgs.drawDeck = new Deck<>("DrawDeck", -1, VisibilityMode.HIDDEN_TO_ALL);
         createCards(vgs);
 
         vgs.drawDeck.shuffle(new Random(vgs.getGameParameters().getRandomSeed()));
 
         // Create the discard deck, at the beginning it is empty
-        vgs.discardDeck = new Deck<>("DiscardDeck", -1);
+        vgs.discardDeck = new Deck<>("DiscardDeck", -1, VisibilityMode.VISIBLE_TO_ALL);
 
         // Draw initial cards to each player
         vgs.playerDecks = new ArrayList<>(vgs.getNPlayers());
@@ -113,7 +114,7 @@ public class VirusForwardModel extends AbstractForwardModel {
         int nCards = ((VirusGameParameters)vgs.getGameParameters()).nCardsPlayerHand;
         for (int i = 0; i < vgs.getNPlayers(); i++) {
             String playerDeckName = "Player" + i + "Deck";
-            vgs.playerDecks.add(new Deck<>(playerDeckName, i));
+            vgs.playerDecks.add(new Deck<>(playerDeckName, i, VisibilityMode.VISIBLE_TO_OWNER));
             for (int j = 0; j < nCards; j++) {
                 vgs.playerDecks.get(i).add(vgs.drawDeck.draw());
             }

--- a/src/main/java/games/virus/VirusGameState.java
+++ b/src/main/java/games/virus/VirusGameState.java
@@ -79,24 +79,6 @@ public class VirusGameState extends AbstractGameState implements IPrintable {
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
-        return new ArrayList<Integer>() {{
-            add(drawDeck.getComponentID());
-            for (Component c: drawDeck.getComponents()) {
-                add(c.getComponentID());
-            }
-            for (int i = 0; i < getNPlayers(); i++) {
-                if (i != playerId) {
-                    add(playerDecks.get(i).getComponentID());
-                    for (Component c: playerDecks.get(i).getComponents()) {
-                        add(c.getComponentID());
-                    }
-                }
-            }
-        }};
-    }
-
-    @Override
     protected void _reset() {
         playerBodies = new ArrayList<>();
         playerDecks = new ArrayList<>();

--- a/src/main/java/games/virus/components/VirusBody.java
+++ b/src/main/java/games/virus/components/VirusBody.java
@@ -1,14 +1,18 @@
 package games.virus.components;
 
+import core.CoreConstants;
 import core.components.Component;
 import core.components.Deck;
+import core.interfaces.IComponentContainer;
 import games.virus.cards.VirusCard;
 import utilities.Utils;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
-public class VirusBody extends Component {
+public class VirusBody extends Component implements IComponentContainer<VirusOrgan> {
     public HashMap<VirusCard.OrganType, VirusOrgan> organs;
 
     public VirusBody()
@@ -185,5 +189,15 @@ public class VirusBody extends Component {
                 nHealthy ++;
         }
         return nHealthy;
+    }
+
+    @Override
+    public List<VirusOrgan> getComponents() {
+        return new ArrayList<>(organs.values());
+    }
+
+    @Override
+    public CoreConstants.VisibilityMode getVisibilityMode() {
+        return CoreConstants.VisibilityMode.VISIBLE_TO_ALL;
     }
 }

--- a/src/main/java/games/virus/components/VirusOrgan.java
+++ b/src/main/java/games/virus/components/VirusOrgan.java
@@ -2,14 +2,16 @@ package games.virus.components;
 
 import core.components.Component;
 import core.components.Deck;
+import core.interfaces.IComponentContainer;
 import games.virus.cards.VirusCard;
 import utilities.Utils;
 
 import java.util.List;
 
 import static core.CoreConstants.*;
+import static core.CoreConstants.VisibilityMode.*;
 
-public class VirusOrgan extends Component {
+public class VirusOrgan extends Component implements IComponentContainer<VirusCard> {
 
     public enum VirusOrganState {
         None,
@@ -28,14 +30,14 @@ public class VirusOrgan extends Component {
     {
         super(Utils.ComponentType.TOKEN);
         state = VirusOrganState.None;
-        cards = new Deck<>("DeckOnOrgan");
+        cards = new Deck<>("DeckOnOrgan", VISIBLE_TO_ALL);
     }
 
     protected VirusOrgan(int ID)
     {
         super(Utils.ComponentType.TOKEN, ID);
         state = VirusOrganState.None;
-        cards = new Deck<>("DeckOnOrgan");
+        cards = new Deck<>("DeckOnOrgan", VISIBLE_TO_ALL);
     }
 
     public void initialiseOrgan()
@@ -151,4 +153,15 @@ public class VirusOrgan extends Component {
     public Deck<VirusCard> getCards() {
         return cards;
     }
+
+    @Override
+    public List<VirusCard> getComponents() {
+        return cards.getComponents();
+    }
+
+    @Override
+    public VisibilityMode getVisibilityMode() {
+        return VISIBLE_TO_ALL;
+    }
+
 }

--- a/src/main/java/gui/views/AreaView.java
+++ b/src/main/java/gui/views/AreaView.java
@@ -366,7 +366,7 @@ public class AreaView extends ComponentView {
         // Find all sub-collections in this area: decks and other areas. Just drawing a rectangle around them and name
         List<Deck<? extends Component>> decks = new ArrayList<>();
         List<Area> areas = new ArrayList<>();
-        for (Map.Entry<Integer, Component> e: area.getComponents().entrySet()) {
+        for (Map.Entry<Integer, Component> e: area.getComponentsMap().entrySet()) {
             Rectangle r = drawMap.get(e.getKey());
             Point t = translation.get(e.getKey());
 
@@ -390,7 +390,7 @@ public class AreaView extends ComponentView {
         }
 
         // Draw components
-        for (Map.Entry<Integer, Component> e: area.getComponents().entrySet()) {
+        for (Map.Entry<Integer, Component> e: area.getComponentsMap().entrySet()) {
             Component c = e.getValue();
 
             // Decks and areas already drawn
@@ -402,7 +402,7 @@ public class AreaView extends ComponentView {
             if (!dependencies.containsKey(e.getKey())) {
                 // Check dependency
                 for (Area a : areas) {
-                    if (a.getComponents().containsValue(c)) {
+                    if (a.getComponentsMap().containsValue(c)) {
                         dependencies.put(e.getKey(), a.getComponentID());
                         break;
                     }

--- a/src/main/java/players/simple/OSLAHeuristic.java
+++ b/src/main/java/players/simple/OSLAHeuristic.java
@@ -1,0 +1,70 @@
+package players.simple;
+
+import core.*;
+import core.interfaces.*;
+import evaluation.TunableParameters;
+import org.json.simple.JSONObject;
+
+
+/**
+ * This is a wrapper to use any parameterisable heuristic with the OSLA player
+ */
+public class OSLAHeuristic extends TunableParameters {
+
+    int plyDepth = 1;
+    private IStateHeuristic heuristic = AbstractGameState::getHeuristicScore;
+
+    public OSLAHeuristic() {
+        addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
+    }
+
+    @Override
+    protected AbstractParameters _copy() {
+        OSLAHeuristic retValue = new OSLAHeuristic();
+        retValue.plyDepth = plyDepth;
+        retValue.heuristic = heuristic;
+        return retValue;
+    }
+
+    /**
+     * Any nested tunable parameter space is highly likely to be an IStateHeuristic
+     * If it is, then we set this as the heuristic after the parent code in TunableParameters
+     * has done the work to merge the search spaces together.
+     *
+     * @param json The raw JSON
+     * @return The instantiated object
+     */
+    @Override
+    public ITunableParameters registerChild(String nameSpace, JSONObject json) {
+        ITunableParameters child = super.registerChild(nameSpace, json);
+        if (child instanceof IStateHeuristic) {
+            heuristic = (IStateHeuristic) child;
+        }
+        return child;
+    }
+
+    @Override
+    public void _reset() {
+        if (heuristic instanceof TunableParameters) {
+            TunableParameters tunableHeuristic = (TunableParameters) heuristic;
+            for (String name : tunableHeuristic.getParameterNames()) {
+                tunableHeuristic.setParameterValue(name, this.getParameterValue("heuristic." + name));
+            }
+        }
+    }
+
+    @Override
+    protected boolean _equals(Object o) {
+        if (o instanceof OSLAHeuristic) {
+           OSLAHeuristic other = (OSLAHeuristic) o;
+           return other.plyDepth == plyDepth && other.heuristic.equals(heuristic);
+        }
+        return false;
+    }
+
+    @Override
+    public Object instantiate() {
+        return new OSLAPlayer(heuristic);
+    }
+
+}

--- a/src/main/java/players/simple/OSLAPlayer.java
+++ b/src/main/java/players/simple/OSLAPlayer.java
@@ -4,6 +4,7 @@ import core.actions.AbstractAction;
 import core.AbstractPlayer;
 import core.AbstractGameState;
 import core.interfaces.IStateHeuristic;
+import core.interfaces.ITunableParameters;
 
 import java.util.List;
 import java.util.Random;

--- a/src/main/java/utilities/FileStatsLogger.java
+++ b/src/main/java/utilities/FileStatsLogger.java
@@ -103,7 +103,7 @@ public class FileStatsLogger implements IStatisticLogger {
      * @return A summary of the data
      */
     @Override
-    public Map<String, StatSummary> summary() {
+    public Map<String, TAGStatSummary> summary() {
         return new HashMap<>();
     }
 }

--- a/src/main/java/utilities/SummaryLogger.java
+++ b/src/main/java/utilities/SummaryLogger.java
@@ -16,7 +16,7 @@ public class SummaryLogger implements IStatisticLogger {
 
     File logFile;
     public boolean printToConsole = true;
-    Map<String, StatSummary> allData = new HashMap<>();
+    Map<String, TAGStatSummary> allData = new HashMap<>();
     Map<String, String> otherData = new HashMap<>();
 
     public SummaryLogger() {
@@ -30,7 +30,7 @@ public class SummaryLogger implements IStatisticLogger {
     public void record(String key, Object value) {
         if (value instanceof Number) {
             if (!allData.containsKey(key))
-                allData.put(key, new StatSummary());
+                allData.put(key, new TAGStatSummary());
             allData.get(key).add((Number) value);
         } else {
             otherData.put(key, value.toString());
@@ -50,7 +50,7 @@ public class SummaryLogger implements IStatisticLogger {
     }
 
     @Override
-    public Map<String, StatSummary> summary() {
+    public Map<String, TAGStatSummary> summary() {
         return allData;
     }
 
@@ -112,7 +112,7 @@ public class SummaryLogger implements IStatisticLogger {
         List<String> alphabeticOrder = allData.keySet().stream().sorted().collect(toList());
         StringBuilder sb = new StringBuilder();
         for (String key : alphabeticOrder) {
-            StatSummary stats = allData.get(key);
+            TAGStatSummary stats = allData.get(key);
             if (stats.n() == 1) {
                 sb.append(String.format("%30s  %8.3g\n", key, stats.mean()));
             } else {

--- a/src/main/java/utilities/TAGStatSummary.java
+++ b/src/main/java/utilities/TAGStatSummary.java
@@ -2,7 +2,6 @@ package utilities;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.function.Function;
 
 /**
  * This class is used to model the statistics of several numbers.  For the statistics
@@ -10,7 +9,7 @@ import java.util.function.Function;
  * of how many, the sum and the sum of the squares is sufficient (plus max and min, for max and min).
  */
 
-public class StatSummary {
+public class TAGStatSummary {
 
     public String name; // defaults to ""
 
@@ -24,11 +23,11 @@ public class StatSummary {
 
     private ArrayList<Double> elements;
 
-    public StatSummary() {
+    public TAGStatSummary() {
         this("");
     }
 
-    public StatSummary(String name) {
+    public TAGStatSummary(String name) {
         this.name = name;
         reset();
     }
@@ -124,7 +123,7 @@ public class StatSummary {
         return sd() / Math.sqrt(n);
     }
 
-    public void add(StatSummary ss) {
+    public void add(TAGStatSummary ss) {
         n += ss.n;
         sum += ss.sum;
         sumsq += ss.sumsq;
@@ -194,8 +193,8 @@ public class StatSummary {
         return elements;
     }
 
-    public StatSummary copy() {
-        StatSummary ss = new StatSummary();
+    public TAGStatSummary copy() {
+        TAGStatSummary ss = new TAGStatSummary();
 
         ss.name = this.name;
         ss.sum = this.sum;

--- a/src/main/java/utilities/TAGSummariser.java
+++ b/src/main/java/utilities/TAGSummariser.java
@@ -4,7 +4,7 @@ import java.util.*;
 import java.util.function.*;
 import java.util.stream.*;
 
-public class TAGSummariser implements Collector<Number, StatSummary, StatSummary> {
+public class TAGSummariser implements Collector<Number, TAGStatSummary, TAGStatSummary> {
 
     /**
      * A function that creates and returns a new mutable result container.
@@ -12,8 +12,8 @@ public class TAGSummariser implements Collector<Number, StatSummary, StatSummary
      * @return a function which returns a new, mutable result container
      */
     @Override
-    public Supplier<StatSummary> supplier() {
-        return StatSummary::new;
+    public Supplier<TAGStatSummary> supplier() {
+        return TAGStatSummary::new;
     }
 
     /**
@@ -22,8 +22,8 @@ public class TAGSummariser implements Collector<Number, StatSummary, StatSummary
      * @return a function which folds a value into a mutable result container
      */
     @Override
-    public BiConsumer<StatSummary, Number> accumulator() {
-        return StatSummary::add;
+    public BiConsumer<TAGStatSummary, Number> accumulator() {
+        return TAGStatSummary::add;
     }
 
     /**
@@ -35,7 +35,7 @@ public class TAGSummariser implements Collector<Number, StatSummary, StatSummary
      * result
      */
     @Override
-    public BinaryOperator<StatSummary> combiner() {
+    public BinaryOperator<TAGStatSummary> combiner() {
         return (ss1, ss2) -> {
             ss1.add(ss2);
             return ss1;
@@ -54,7 +54,7 @@ public class TAGSummariser implements Collector<Number, StatSummary, StatSummary
      * result
      */
     @Override
-    public Function<StatSummary, StatSummary> finisher() {
+    public Function<TAGStatSummary, TAGStatSummary> finisher() {
         return ss -> ss;
     }
 


### PR DESCRIPTION
This contains two distinct pieces of work:

1) Implementation of Proposal #133 to standardise deck visibility across everything and make tracking levels of hidden information much easier; without requiring game implementers to do too much additional work.

2) OSLAHeuristic to enable quick and easy tuning of Heuristic agents (it's already possible to tune the Heuristic used in RMHC or MCTS, so this is filling in a gap).