### PR TITLE
GridBoard update for framework consistency

### DIFF
--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -686,13 +686,13 @@ public class Game {
         MCTSParams params1 = new MCTSParams();
 
         players.add(new RandomPlayer());
-        players.add(new RMHCPlayer());
-        players.add(new MCTSPlayer(params1));
+//        players.add(new RMHCPlayer());
+//        players.add(new MCTSPlayer(params1));
         players.add(new HumanGUIPlayer(ac));
 //        players.add(new HumanConsolePlayer());
 
         /* 4. Run! */
-        runOne(LoveLetter, players, seed, ac, false, null);
+        runOne(DotsAndBoxes, players, seed, ac, false, null);
         //       runMany(Collections.singletonList(Dominion), players, 100L,100, null, false, false, listeners);
 //        ArrayList<GameType> games = new ArrayList<>();
 //        games.add(TicTacToe);

--- a/src/main/java/core/actions/SetGridValueAction.java
+++ b/src/main/java/core/actions/SetGridValueAction.java
@@ -1,12 +1,13 @@
 package core.actions;
 
 import core.AbstractGameState;
+import core.components.Component;
 import core.interfaces.IPrintable;
 import core.components.GridBoard;
 
 import java.util.Objects;
 
-public class SetGridValueAction<T> extends AbstractAction implements IPrintable {
+public class SetGridValueAction<T extends Component> extends AbstractAction implements IPrintable {
 
     private final int gridBoard;
     private final int x;

--- a/src/main/java/core/components/GridBoard.java
+++ b/src/main/java/core/components/GridBoard.java
@@ -203,13 +203,13 @@ public class GridBoard<T extends Component> extends Component {
      *
      * @return 1D flattened grid
      */
-    public T[] flattenGrid() {
+    public Component[] flattenGrid() {
         int length = getHeight() * getWidth();
         Component[] array = new Component[length];
         for (int i = 0; i < getHeight(); i++) {
             System.arraycopy(grid[i], 0, array, i * getWidth(), grid[i].length);
         }
-        return (T[])array;
+        return array;
     }
 
     @Override

--- a/src/main/java/core/components/Token.java
+++ b/src/main/java/core/components/Token.java
@@ -17,10 +17,12 @@ public class Token extends Component {
 
     public Token(String name){
         super(ComponentType.TOKEN, name);
+        this.tokenType = name;
     }
 
     public Token(String name, int ID){
         super(ComponentType.TOKEN, name, ID);
+        this.tokenType = name;
     }
 
     @Override
@@ -86,5 +88,10 @@ public class Token extends Component {
     @Override
     public final int hashCode() {
         return componentID;
+    }
+
+    @Override
+    public String toString() {
+        return tokenType;
     }
 }

--- a/src/main/java/core/interfaces/IGridGameState.java
+++ b/src/main/java/core/interfaces/IGridGameState.java
@@ -1,8 +1,9 @@
 package core.interfaces;
 
+import core.components.Component;
 import core.components.GridBoard;
 
-public interface IGridGameState<T> {
+public interface IGridGameState<T extends Component> {
 
     default int getWidth() { return getGridBoard().getWidth(); }
 

--- a/src/main/java/games/dotsboxes/AddGridCellEdge.java
+++ b/src/main/java/games/dotsboxes/AddGridCellEdge.java
@@ -17,22 +17,22 @@ public class AddGridCellEdge extends AbstractAction {
     public boolean execute(AbstractGameState gs) {
         // Find neighbouring cells
         DBGameState dbgs = (DBGameState) gs;
-        HashSet<DBCell> cells = dbgs.edgeToCellMap.get(edge);
 
-        // For each cell, mark this edge as complete by current player and check if whole cell is complete to set owner
+        // Mark this edge as complete by current player and check if connected cells are complete too
+        dbgs.edgeToOwnerMap.put(edge, gs.getCurrentPlayer());
+
+        HashSet<DBCell> cells = dbgs.edgeToCellMap.get(edge);
         for (DBCell c : cells) {
-            c.nEdgesComplete++;
-            for (DBEdge e : c.edges) {
-                if (e.equals(edge)) {
-                    e.owner = gs.getCurrentPlayer();
-                    break;  // Only 1 edge would match
+            int nEdgesComplete = 0;
+            for (DBEdge e: dbgs.cellToEdgesMap.get(c)) {
+                if (dbgs.edgeToOwnerMap.containsKey(e)) {
+                    nEdgesComplete++;
                 }
             }
-            if (c.nEdgesComplete == 4) {  // A cell has 4 sides
+            if (nEdgesComplete == 4) {  // A cell has 4 sides
                 // All edges complete, this box complete
-                dbgs.nCellsComplete++;
+                dbgs.cellToOwnerMap.put(c, gs.getCurrentPlayer());
                 dbgs.nCellsPerPlayer[gs.getCurrentPlayer()]++;
-                c.owner = gs.getCurrentPlayer();
             }
         }
 

--- a/src/main/java/games/dotsboxes/DBCell.java
+++ b/src/main/java/games/dotsboxes/DBCell.java
@@ -1,29 +1,22 @@
 package games.dotsboxes;
 
+import core.components.Component;
+import utilities.Utils;
 import utilities.Vector2D;
 
-import java.util.ArrayList;
 import java.util.Objects;
 
-public class DBCell {
-    int owner;  // Owner of this cell (-1 means no owner yet, as cell is incomplete)
-    ArrayList<DBEdge> edges;  // List of edges for this cell
-    Vector2D position;  // Position of this cell in the grid
-    int nEdgesComplete;  // Number of edges completed for this cell, for faster computation. If == 4, cell is complete.
-
-    public DBCell() {}  // Default constructor for copies, to avoid creating edges every time
+public class DBCell extends Component {
+    final Vector2D position;  // Position of this cell in the grid
 
     public DBCell(int x, int y) {
-        owner = -1;
+        super(Utils.ComponentType.BOARD_NODE, "Box");
         position = new Vector2D(x, y);
-        nEdgesComplete = 0;
+    }
 
-        // Add possible edges, where (x,y) is top-left corner of this cell. 4 total possible edges
-        edges = new ArrayList<>();
-        edges.add(new DBEdge(new Vector2D(x, y), new Vector2D(x, y+1)));
-        edges.add(new DBEdge(new Vector2D(x, y), new Vector2D(x+1, y)));
-        edges.add(new DBEdge(new Vector2D(x+1, y), new Vector2D(x+1, y+1)));
-        edges.add(new DBEdge(new Vector2D(x, y+1), new Vector2D(x+1, y+1)));
+    private DBCell(int componentID, Vector2D position) {
+        super(Utils.ComponentType.BOARD_NODE, "Box", componentID);
+        this.position = position;
     }
 
     @Override
@@ -31,33 +24,20 @@ public class DBCell {
         if (this == o) return true;
         if (!(o instanceof DBCell)) return false;
         DBCell dbCell = (DBCell) o;
-        return owner == dbCell.owner &&
-                nEdgesComplete == dbCell.nEdgesComplete &&
-                Objects.equals(edges, dbCell.edges) &&
-                Objects.equals(position, dbCell.position);
+        return Objects.equals(position, dbCell.position);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(owner, edges, position, nEdgesComplete);
+        return Objects.hash(position);
     }
 
     public DBCell copy() {
-        // For grid board deep copy
-        DBCell c = new DBCell();
-        c.position = position.copy();
-        c.owner = owner;
-        c.nEdgesComplete = nEdgesComplete;
-        // Deep copy edges
-        c.edges = new ArrayList<>();
-        for (DBEdge e: edges) {
-            c.edges.add(e.copy());
-        }
-        return c;
+        return this;  // Immutable
     }
 
     @Override
     public String toString() {
-        return owner + "";
+        return position.toString();
     }
 }

--- a/src/main/java/games/dotsboxes/DBEdge.java
+++ b/src/main/java/games/dotsboxes/DBEdge.java
@@ -1,18 +1,21 @@
 package games.dotsboxes;
 
+import core.components.Component;
+import utilities.Utils;
 import utilities.Vector2D;
 
 import java.util.Objects;
 
-public class DBEdge {
-    Vector2D from;  // Edges are lines between 2 points, from -> to. No direction, so to -> from is the same.
-    Vector2D to;
-    int owner;  // Keep track of who placed this edge on the board for drawing purposes.
+public class DBEdge extends Component {
+    // Edges are lines between 2 points, from -> to. No direction, so to -> from is the same.
+
+    final Vector2D from;
+    final Vector2D to;
 
     public DBEdge(Vector2D from, Vector2D to) {
+        super(Utils.ComponentType.TOKEN);
         this.from = from;
         this.to = to;
-        this.owner = -1;
     }
 
     @Override
@@ -31,9 +34,6 @@ public class DBEdge {
     }
 
     public DBEdge copy() {
-        // We'll need deep copies of the board, so this should also be able to copy itself
-        DBEdge e = new DBEdge(from.copy(), to.copy());
-        e.owner = owner;
-        return e;
+        return this;  // Immutable
     }
 }

--- a/src/main/java/games/dotsboxes/DBGUI.java
+++ b/src/main/java/games/dotsboxes/DBGUI.java
@@ -3,12 +3,6 @@ package games.dotsboxes;
 import core.AbstractGUI;
 import core.AbstractGameState;
 import core.AbstractPlayer;
-import core.components.Component;
-import core.components.Deck;
-import games.GameType;
-import gui.views.AreaView;
-import gui.views.CardView;
-import gui.views.ComponentView;
 import players.human.ActionController;
 import players.human.HumanGUIPlayer;
 
@@ -29,7 +23,7 @@ public class DBGUI extends AbstractGUI {
         this.width = displayWidth;
         this.height = displayHeight;
 
-        view = new DBGridBoardView(((DBGameState)gameState).grid);
+        view = new DBGridBoardView(((DBGameState)gameState));
 
         JPanel infoPanel = createGameStateInfoPanel("Dots and Boxes", gameState, width, defaultInfoPanelHeight);
         JComponent actionPanel = createActionPanel(new Collection[0], width, defaultActionPanelHeight);
@@ -44,7 +38,7 @@ public class DBGUI extends AbstractGUI {
     @Override
     protected void _update(AbstractPlayer player, AbstractGameState gameState) {
         if (gameState != null) {
-            view.updateComponent(((DBGameState)gameState).grid);
+            view.updateGameState(((DBGameState)gameState));
             if (player instanceof HumanGUIPlayer) {
                 updateActionButtons(player, gameState);
             }

--- a/src/main/java/games/dotsboxes/DBGameState.java
+++ b/src/main/java/games/dotsboxes/DBGameState.java
@@ -3,7 +3,6 @@ package games.dotsboxes;
 import core.AbstractGameState;
 import core.AbstractParameters;
 import core.components.Component;
-import core.components.GridBoard;
 import core.interfaces.IStateHeuristic;
 import core.turnorders.AlternatingTurnOrder;
 
@@ -13,13 +12,19 @@ public class DBGameState extends AbstractGameState {
 
     IStateHeuristic heuristic = new DotsAndBoxesHeuristic();
 
-    // Only component needed
-    GridBoard<DBCell> grid;
+    // List of all edges possible
+    HashSet<DBEdge> edges;
+    // List of all cells possible
+    HashSet<DBCell> cells;
+    // Mapping from each edge to the cells it neighbours
+    HashMap<DBEdge, HashSet<DBCell>> edgeToCellMap;
+    // Mapping from each cell to its edges
+    HashMap<DBCell, HashSet<DBEdge>> cellToEdgesMap;
 
-    // Variables for speeding up computations
-    int nCellsComplete;
+    // Mutable state:
     int[] nCellsPerPlayer;
-    HashMap<DBEdge, HashSet<DBCell>> edgeToCellMap;  // Mapping from each edge to the cells it neighbours
+    HashMap<DBCell, Integer> cellToOwnerMap;  // Mapping from each cell to its owner, if complete
+    HashMap<DBEdge, Integer> edgeToOwnerMap;  // Mapping from each edge to its owner, if placed
 
     /**
      * Constructor. Initialises some generic game state variables.
@@ -33,43 +38,21 @@ public class DBGameState extends AbstractGameState {
 
     @Override
     protected List<Component> _getAllComponents() {
-        return new ArrayList<Component>() {{ add(grid); }};
+        return new ArrayList<Component>() {{ addAll(edges); addAll(cells); }};
     }
 
     @Override
     protected AbstractGameState _copy(int playerId) {
         DBGameState dbgs = new DBGameState(gameParameters, getNPlayers());
-        dbgs.grid = deepCopyGrid();
+        dbgs.edges = edges;
+        dbgs.cells = cells;
+        dbgs.edgeToCellMap = edgeToCellMap;
+        dbgs.cellToEdgesMap = cellToEdgesMap;
+
         dbgs.nCellsPerPlayer = nCellsPerPlayer.clone();
-        dbgs.nCellsComplete = nCellsComplete;
-        dbgs.edgeToCellMap = generateEdgeToCellMap(dbgs.grid);  // Re-generate this mapping from the copied grid
+        dbgs.cellToOwnerMap = (HashMap<DBCell, Integer>) cellToOwnerMap.clone();
+        dbgs.edgeToOwnerMap = (HashMap<DBEdge, Integer>) edgeToOwnerMap.clone();
         return dbgs;
-    }
-
-    private GridBoard<DBCell> deepCopyGrid() {
-        GridBoard<DBCell> gridCopy = grid.copy();
-        for (int i = 0; i < grid.getHeight(); i++) {
-            for (int j = 0; j < grid.getWidth(); j++) {
-                gridCopy.setElement(j, i, grid.getElement(j, i).copy());
-            }
-        }
-        return gridCopy;
-    }
-
-    private HashMap<DBEdge, HashSet<DBCell>> generateEdgeToCellMap(GridBoard<DBCell> g) {
-        HashMap<DBEdge, HashSet<DBCell>> copy = new HashMap<>();
-        for (int i = 0; i < g.getHeight(); i++) {
-            for (int j = 0; j < g.getWidth(); j++) {
-                DBCell c = g.getElement(j, i);
-                for (DBEdge edge: c.edges) {
-                    if (!copy.containsKey(edge)) {
-                        copy.put(edge, new HashSet<>());
-                    }
-                    copy.get(edge).add(c);
-                }
-            }
-        }
-        return copy;
     }
 
     @Override
@@ -97,10 +80,9 @@ public class DBGameState extends AbstractGameState {
 
     @Override
     protected void _reset() {
-        grid = null;
-        nCellsComplete = 0;
         nCellsPerPlayer = null;
-        edgeToCellMap = null;
+        cellToOwnerMap = null;
+        edgeToOwnerMap = null;
     }
 
     @Override
@@ -109,15 +91,14 @@ public class DBGameState extends AbstractGameState {
         if (!(o instanceof DBGameState)) return false;
         if (!super.equals(o)) return false;
         DBGameState that = (DBGameState) o;
-        return nCellsComplete == that.nCellsComplete &&
-                Objects.equals(grid, that.grid) &&
-                Arrays.equals(nCellsPerPlayer, that.nCellsPerPlayer) &&
-                Objects.equals(edgeToCellMap, that.edgeToCellMap);
+        return Arrays.equals(nCellsPerPlayer, that.nCellsPerPlayer) &&
+                Objects.equals(edgeToOwnerMap, that.edgeToOwnerMap) &&
+                Objects.equals(cellToOwnerMap, that.cellToOwnerMap);
     }
 
     @Override
     public int hashCode() {
-        int result = Objects.hash(super.hashCode(), grid, nCellsComplete, edgeToCellMap);
+        int result = Objects.hash(super.hashCode(), cellToOwnerMap, edgeToOwnerMap);
         result = 31 * result + Arrays.hashCode(nCellsPerPlayer);
         return result;
     }

--- a/src/main/java/games/tictactoe/TicTacToeConstants.java
+++ b/src/main/java/games/tictactoe/TicTacToeConstants.java
@@ -1,0 +1,13 @@
+package games.tictactoe;
+
+import core.components.Token;
+
+import java.util.ArrayList;
+
+public class TicTacToeConstants {
+    public static final Token defaultToken = new Token(" ");
+    public static final ArrayList<Token> playerMapping = new ArrayList<Token>() {{
+        add(new Token("x"));
+        add(new Token("o"));
+    }};
+}

--- a/src/main/java/games/tictactoe/TicTacToeConstants.java
+++ b/src/main/java/games/tictactoe/TicTacToeConstants.java
@@ -5,7 +5,6 @@ import core.components.Token;
 import java.util.ArrayList;
 
 public class TicTacToeConstants {
-    public static final Token defaultToken = new Token(" ");
     public static final ArrayList<Token> playerMapping = new ArrayList<Token>() {{
         add(new Token("x"));
         add(new Token("o"));

--- a/src/main/java/games/tictactoe/TicTacToeForwardModel.java
+++ b/src/main/java/games/tictactoe/TicTacToeForwardModel.java
@@ -2,8 +2,10 @@ package games.tictactoe;
 
 import core.actions.AbstractAction;
 import core.actions.SetGridValueAction;
+import core.components.Component;
 import core.components.GridBoard;
 import core.*;
+import core.components.Token;
 import utilities.Utils;
 import java.util.*;
 
@@ -16,7 +18,8 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
     protected void _setup(AbstractGameState firstState) {
         TicTacToeGameParameters tttgp = (TicTacToeGameParameters) firstState.getGameParameters();
         int gridSize = tttgp.gridSize;
-        ((TicTacToeGameState)firstState).gridBoard = new GridBoard<>(gridSize, gridSize, Character.class, ' ');
+        TicTacToeGameState state = (TicTacToeGameState)firstState;
+        state.gridBoard = new GridBoard<>(gridSize, gridSize, TicTacToeConstants.defaultToken);
     }
 
     @Override
@@ -27,8 +30,8 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
 
         for (int x = 0; x < tttgs.gridBoard.getWidth(); x++){
             for (int y = 0; y < tttgs.gridBoard.getHeight(); y++) {
-                if (tttgs.gridBoard.getElement(x, y) == ' ')
-                    actions.add(new SetGridValueAction(tttgs.gridBoard.getComponentID(), x, y, player == 0 ? 'x' : 'o'));
+                if (tttgs.gridBoard.getElement(x, y).equals(TicTacToeConstants.defaultToken))
+                    actions.add(new SetGridValueAction(tttgs.gridBoard.getComponentID(), x, y, TicTacToeConstants.playerMapping.get(player)));
             }
         }
         return actions;
@@ -60,15 +63,15 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
      * @param gameState - game state to check game end.
      */
     private boolean checkGameEnd(TicTacToeGameState gameState){
-        GridBoard<Character> gridBoard = gameState.getGridBoard();
+        GridBoard<Token> gridBoard = gameState.getGridBoard();
 
         // Check columns
         for (int x = 0; x < gridBoard.getWidth(); x++){
-            Character c = gridBoard.getElement(x, 0);
-            if (c != ' ') {
+            Token c = gridBoard.getElement(x, 0);
+            if (!c.getTokenType().equals(" ")) {
                 boolean win = true;
                 for (int y = 1; y < gridBoard.getHeight(); y++) {
-                    if (gridBoard.getElement(x, y) != c) {
+                    if (!gridBoard.getElement(x, y).equals(c)) {
                         win = false;
                         break;
                     }
@@ -82,11 +85,11 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
 
         // Check rows
         for (int y = 0; y < gridBoard.getHeight(); y++){
-            Character c = gridBoard.getElement(0, y);
-            if (c != ' ') {
+            Token c = gridBoard.getElement(0, y);
+            if (!c.getTokenType().equals(" ")) {
                 boolean win = true;
                 for (int x = 1; x < gridBoard.getWidth(); x++) {
-                    if (gridBoard.getElement(x, y) != c) {
+                    if (!gridBoard.getElement(x, y).equals(c)) {
                         win = false;
                         break;
                     }
@@ -100,11 +103,11 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
 
         // Check diagonals
         // Primary
-        Character c = gridBoard.getElement(0, 0);
-        if (c != ' ') {
+        Token c = gridBoard.getElement(0, 0);
+        if (!c.getTokenType().equals(" ")) {
             boolean win = true;
             for (int i = 1; i < gridBoard.getWidth(); i++) {
-                if (gridBoard.getElement(i, i) != c) {
+                if (!gridBoard.getElement(i, i).equals(c)) {
                     win = false;
                 }
             }
@@ -116,10 +119,10 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
 
         // Secondary
         c = gridBoard.getElement(gridBoard.getWidth()-1, 0);
-        if (c != ' ') {
+        if (!c.getTokenType().equals(" ")) {
             boolean win = true;
             for (int i = 1; i < gridBoard.getWidth(); i++) {
-                if (gridBoard.getElement(gridBoard.getWidth()-1-i, i) != c) {
+                if (!gridBoard.getElement(gridBoard.getWidth()-1-i, i).equals(c)) {
                     win = false;
                 }
             }
@@ -129,9 +132,10 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
             }
         }
         boolean tie = true;
-        for (Character[] row: gridBoard.getGridValues()){
-            for (Character field: row){
-                if (field.equals(' ')) {
+        Component[][] grid = gridBoard.getGridValues();
+        for (Component[] row: grid){
+            for (Component field: row){
+                if (field.equals(TicTacToeConstants.defaultToken)) {
                     tie = false;
                     break;
                 }
@@ -156,9 +160,9 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
      * Inform the game this player has won.
      * @param winnerSymbol - which player won.
      */
-    private void registerWinner(TicTacToeGameState gameState, char winnerSymbol){
+    private void registerWinner(TicTacToeGameState gameState, Token winnerSymbol){
         gameState.setGameStatus(Utils.GameResult.GAME_END);
-        int winningPlayer = gameState.playerMapping.indexOf(winnerSymbol);
+        int winningPlayer = TicTacToeConstants.playerMapping.indexOf(winnerSymbol);
         gameState.setPlayerResult(Utils.GameResult.WIN, winningPlayer);
         gameState.setPlayerResult(Utils.GameResult.LOSE, 1-winningPlayer);
     }

--- a/src/main/java/games/tictactoe/TicTacToeForwardModel.java
+++ b/src/main/java/games/tictactoe/TicTacToeForwardModel.java
@@ -19,7 +19,7 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
         TicTacToeGameParameters tttgp = (TicTacToeGameParameters) firstState.getGameParameters();
         int gridSize = tttgp.gridSize;
         TicTacToeGameState state = (TicTacToeGameState)firstState;
-        state.gridBoard = new GridBoard<>(gridSize, gridSize, TicTacToeConstants.defaultToken);
+        state.gridBoard = new GridBoard<>(gridSize, gridSize);
     }
 
     @Override
@@ -30,7 +30,7 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
 
         for (int x = 0; x < tttgs.gridBoard.getWidth(); x++){
             for (int y = 0; y < tttgs.gridBoard.getHeight(); y++) {
-                if (tttgs.gridBoard.getElement(x, y).equals(TicTacToeConstants.defaultToken))
+                if (tttgs.gridBoard.getElement(x, y) == null)
                     actions.add(new SetGridValueAction(tttgs.gridBoard.getComponentID(), x, y, TicTacToeConstants.playerMapping.get(player)));
             }
         }
@@ -68,10 +68,11 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
         // Check columns
         for (int x = 0; x < gridBoard.getWidth(); x++){
             Token c = gridBoard.getElement(x, 0);
-            if (!c.getTokenType().equals(" ")) {
+            if (c != null) {
                 boolean win = true;
                 for (int y = 1; y < gridBoard.getHeight(); y++) {
-                    if (!gridBoard.getElement(x, y).equals(c)) {
+                    Token o = gridBoard.getElement(x, y);
+                    if (o == null || !o.equals(c)) {
                         win = false;
                         break;
                     }
@@ -86,10 +87,11 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
         // Check rows
         for (int y = 0; y < gridBoard.getHeight(); y++){
             Token c = gridBoard.getElement(0, y);
-            if (!c.getTokenType().equals(" ")) {
+            if (c != null) {
                 boolean win = true;
                 for (int x = 1; x < gridBoard.getWidth(); x++) {
-                    if (!gridBoard.getElement(x, y).equals(c)) {
+                    Token o = gridBoard.getElement(x, y);
+                    if (o == null || !o.equals(c)) {
                         win = false;
                         break;
                     }
@@ -104,10 +106,11 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
         // Check diagonals
         // Primary
         Token c = gridBoard.getElement(0, 0);
-        if (!c.getTokenType().equals(" ")) {
+        if (c != null) {
             boolean win = true;
             for (int i = 1; i < gridBoard.getWidth(); i++) {
-                if (!gridBoard.getElement(i, i).equals(c)) {
+                Token o = gridBoard.getElement(i, i);
+                if (o == null || !o.equals(c)) {
                     win = false;
                 }
             }
@@ -119,10 +122,11 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
 
         // Secondary
         c = gridBoard.getElement(gridBoard.getWidth()-1, 0);
-        if (!c.getTokenType().equals(" ")) {
+        if (c != null) {
             boolean win = true;
             for (int i = 1; i < gridBoard.getWidth(); i++) {
-                if (!gridBoard.getElement(gridBoard.getWidth()-1-i, i).equals(c)) {
+                Token o = gridBoard.getElement(gridBoard.getWidth()-1-i, i);
+                if (o == null || !o.equals(c)) {
                     win = false;
                 }
             }
@@ -135,7 +139,7 @@ public class TicTacToeForwardModel extends AbstractForwardModel {
         Component[][] grid = gridBoard.getGridValues();
         for (Component[] row: grid){
             for (Component field: row){
-                if (field.equals(TicTacToeConstants.defaultToken)) {
+                if (field == null) {
                     tie = false;
                     break;
                 }

--- a/src/main/java/games/tictactoe/TicTacToeGameState.java
+++ b/src/main/java/games/tictactoe/TicTacToeGameState.java
@@ -4,6 +4,7 @@ import core.AbstractParameters;
 import core.components.Component;
 import core.components.GridBoard;
 import core.AbstractGameState;
+import core.components.Token;
 import core.interfaces.IGridGameState;
 import core.interfaces.IPrintable;
 import core.interfaces.IVectorObservation;
@@ -15,13 +16,9 @@ import java.util.List;
 import java.util.Objects;
 
 
-public class TicTacToeGameState extends AbstractGameState implements IPrintable, IGridGameState<Character>, IVectorObservation {
+public class TicTacToeGameState extends AbstractGameState implements IPrintable, IGridGameState<Token>, IVectorObservation {
 
-    GridBoard<Character> gridBoard;
-    final ArrayList<Character> playerMapping = new ArrayList<Character>() {{
-        add('x');
-        add('o');
-    }};
+    GridBoard<Token> gridBoard;
 
     public TicTacToeGameState(AbstractParameters gameParameters, int nPlayers){
         super(gameParameters, new AlternatingTurnOrder(nPlayers));
@@ -78,22 +75,17 @@ public class TicTacToeGameState extends AbstractGameState implements IPrintable,
         if (!(o instanceof TicTacToeGameState)) return false;
         if (!super.equals(o)) return false;
         TicTacToeGameState that = (TicTacToeGameState) o;
-        return Objects.equals(gridBoard, that.gridBoard) &&
-                Objects.equals(playerMapping, that.playerMapping);
+        return Objects.equals(gridBoard, that.gridBoard);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), gridBoard, playerMapping);
+        return Objects.hash(super.hashCode(), gridBoard);
     }
 
     @Override
-    public GridBoard<Character> getGridBoard() {
+    public GridBoard<Token> getGridBoard() {
         return gridBoard;
-    }
-
-    public ArrayList<Character> getPlayerMapping() {
-        return playerMapping;
     }
 
     @Override

--- a/src/main/java/games/tictactoe/TicTacToeHeuristic.java
+++ b/src/main/java/games/tictactoe/TicTacToeHeuristic.java
@@ -1,6 +1,6 @@
 package games.tictactoe;
 import core.AbstractGameState;
-import core.AbstractParameters;
+import core.components.Token;
 import core.interfaces.IStateHeuristic;
 import evaluation.TunableParameters;
 import utilities.Pair;
@@ -39,7 +39,7 @@ public class TicTacToeHeuristic extends TunableParameters implements IStateHeuri
 
         double nTotalCount = nPlayer.length * 2 + 2;  // N rows + N columns + 2 diagonals
 
-        Character playerChar = ttgs.playerMapping.get(playerId);
+        Token playerChar = TicTacToeConstants.playerMapping.get(playerId);
 
         // Check columns
         for (int x = 0; x < ttgs.gridBoard.getWidth(); x++){
@@ -65,7 +65,7 @@ public class TicTacToeHeuristic extends TunableParameters implements IStateHeuri
         return pScore * FACTOR_PLAYER + oppScore * FACTOR_OPPONENT;
     }
 
-    private Pair<Integer, Integer> countColumns(TicTacToeGameState ttgs, int column, Character playerChar) {
+    private Pair<Integer, Integer> countColumns(TicTacToeGameState ttgs, int column, Token playerChar) {
         Pair<Integer, Integer> count = new Pair<>(0, 0);
         for (int y = 0; y < ttgs.gridBoard.getHeight(); y++) {
             checkChar(count, playerChar, ttgs.gridBoard.getElement(column, y));
@@ -73,7 +73,7 @@ public class TicTacToeHeuristic extends TunableParameters implements IStateHeuri
         return count;
     }
 
-    private Pair<Integer, Integer> countRows(TicTacToeGameState ttgs, int row, Character playerChar) {
+    private Pair<Integer, Integer> countRows(TicTacToeGameState ttgs, int row, Token playerChar) {
         Pair<Integer, Integer> count = new Pair<>(0, 0);
         for (int x = 0; x < ttgs.gridBoard.getWidth(); x++) {
             checkChar(count, playerChar, ttgs.gridBoard.getElement(x, row));
@@ -81,7 +81,7 @@ public class TicTacToeHeuristic extends TunableParameters implements IStateHeuri
         return count;
     }
 
-    private Pair<Integer, Integer> countPrimaryDiagonal(TicTacToeGameState ttgs, Character playerChar) {
+    private Pair<Integer, Integer> countPrimaryDiagonal(TicTacToeGameState ttgs, Token playerChar) {
         Pair<Integer, Integer> count = new Pair<>(0, 0);
         for (int x = 0; x < ttgs.gridBoard.getWidth(); x++) {
             checkChar(count, playerChar, ttgs.gridBoard.getElement(x, x));
@@ -89,7 +89,7 @@ public class TicTacToeHeuristic extends TunableParameters implements IStateHeuri
         return count;
     }
 
-    private Pair<Integer, Integer> countSecondaryDiagonal(TicTacToeGameState ttgs, Character playerChar) {
+    private Pair<Integer, Integer> countSecondaryDiagonal(TicTacToeGameState ttgs, Token playerChar) {
         Pair<Integer, Integer> count = new Pair<>(0, 0);
         for (int x = 0; x < ttgs.gridBoard.getWidth(); x++) {
             checkChar(count, playerChar, ttgs.gridBoard.getElement(ttgs.gridBoard.getWidth()-1-x, x));
@@ -97,10 +97,10 @@ public class TicTacToeHeuristic extends TunableParameters implements IStateHeuri
         return count;
     }
 
-    private void checkChar(Pair<Integer, Integer> count, Character playerChar, Character c) {
-        if (c == playerChar) {
+    private void checkChar(Pair<Integer, Integer> count, Token playerChar, Token c) {
+        if (c.equals(playerChar)) {
             count.a ++;
-        } else if (c != ' ') {
+        } else if (!c.getTokenType().equals(" ")) {
             count.b ++;
         }
     }

--- a/src/main/java/games/tictactoe/gui/TTTBoardView.java
+++ b/src/main/java/games/tictactoe/gui/TTTBoardView.java
@@ -1,6 +1,7 @@
 package games.tictactoe.gui;
 
 import core.components.GridBoard;
+import core.components.Token;
 import gui.views.ComponentView;
 
 import java.awt.*;
@@ -15,7 +16,7 @@ public class TTTBoardView extends ComponentView {
     Rectangle[] rects;  // Used for highlights + action trimming
     ArrayList<Rectangle> highlight;
 
-    public TTTBoardView(GridBoard<Character> gridBoard) {
+    public TTTBoardView(GridBoard<Token> gridBoard) {
         super(gridBoard, gridBoard.getWidth() * defaultItemSize, gridBoard.getHeight() * defaultItemSize);
         rects = new Rectangle[gridBoard.getWidth() * gridBoard.getHeight()];
         highlight = new ArrayList<>();
@@ -42,7 +43,7 @@ public class TTTBoardView extends ComponentView {
 
     @Override
     protected void paintComponent(Graphics g) {
-        drawGridBoard((Graphics2D)g, (GridBoard<Character>) component, 0, 0);
+        drawGridBoard((Graphics2D)g, (GridBoard<Token>) component, 0, 0);
 
         if (highlight.size() > 0) {
             g.setColor(Color.green);
@@ -55,7 +56,7 @@ public class TTTBoardView extends ComponentView {
         }
     }
 
-    public void drawGridBoard(Graphics2D g, GridBoard<Character> gridBoard, int x, int y) {
+    public void drawGridBoard(Graphics2D g, GridBoard<Token> gridBoard, int x, int y) {
         int width = gridBoard.getWidth() * defaultItemSize;
         int height = gridBoard.getHeight() * defaultItemSize;
 
@@ -80,7 +81,7 @@ public class TTTBoardView extends ComponentView {
         }
     }
 
-    private void drawCell(Graphics2D g, Character element, int x, int y) {
+    private void drawCell(Graphics2D g, Token element, int x, int y) {
         // Paint cell background
         g.setColor(Color.lightGray);
         g.fillRect(x, y, defaultItemSize, defaultItemSize);

--- a/src/main/java/games/tictactoe/gui/TTTBoardView.java
+++ b/src/main/java/games/tictactoe/gui/TTTBoardView.java
@@ -89,10 +89,12 @@ public class TTTBoardView extends ComponentView {
         g.drawRect(x, y, defaultItemSize, defaultItemSize);
 
         // Paint element in cell
-        Font f = g.getFont();
-        g.setFont(new Font(f.getName(), Font.BOLD, defaultItemSize*3/2));
-        g.drawString(element.toString(), x + defaultItemSize/16, y + defaultItemSize - defaultItemSize/16);
-        g.setFont(f);
+        if (element != null) {
+            Font f = g.getFont();
+            g.setFont(new Font(f.getName(), Font.BOLD, defaultItemSize * 3 / 2));
+            g.drawString(element.toString(), x + defaultItemSize / 16, y + defaultItemSize - defaultItemSize / 16);
+            g.setFont(f);
+        }
     }
 
     public ArrayList<Rectangle> getHighlight() {

--- a/src/main/java/games/tictactoe/gui/TicTacToeGUI.java
+++ b/src/main/java/games/tictactoe/gui/TicTacToeGUI.java
@@ -6,6 +6,8 @@ import core.AbstractPlayer;
 import core.Game;
 import core.actions.AbstractAction;
 import core.actions.SetGridValueAction;
+import core.components.Token;
+import games.tictactoe.TicTacToeConstants;
 import games.tictactoe.TicTacToeGameState;
 import players.human.ActionController;
 import players.human.HumanGUIPlayer;
@@ -58,11 +60,10 @@ public class TicTacToeGUI extends AbstractGUI {
             if (highlight.size() > 0) {
                 Rectangle r = highlight.get(0);
                 for (AbstractAction abstractAction : actions) {
-                    SetGridValueAction<Character> action = (SetGridValueAction<Character>) abstractAction;
+                    SetGridValueAction<Token> action = (SetGridValueAction<Token>) abstractAction;
                     if (action.getX() == r.x/defaultItemSize && action.getY() == r.y/defaultItemSize) {
                         actionButtons[0].setVisible(true);
-                        actionButtons[0].setButtonAction(action, "Play " +
-                                ((TicTacToeGameState) gameState).getPlayerMapping().get(player.getPlayerID()));
+                        actionButtons[0].setButtonAction(action, "Play " + TicTacToeConstants.playerMapping.get(player.getPlayerID()));
                         break;
                     }
                 }

--- a/src/main/java/gui/views/GridBoardView.java
+++ b/src/main/java/gui/views/GridBoardView.java
@@ -1,12 +1,13 @@
 package gui.views;
 
+import core.components.Component;
 import core.components.GridBoard;
 
 import java.awt.*;
 
 import static core.AbstractGUI.defaultItemSize;
 
-public class GridBoardView<T> extends ComponentView {
+public class GridBoardView<T extends Component> extends ComponentView {
 
     public GridBoardView(GridBoard<T> gridBoard) {
         super(gridBoard, gridBoard.getWidth() * defaultItemSize, gridBoard.getHeight() * defaultItemSize);
@@ -17,7 +18,7 @@ public class GridBoardView<T> extends ComponentView {
         drawGridBoard((Graphics2D)g, (GridBoard<?>) component, 0, 0);
     }
 
-    public static <T> void drawGridBoard(Graphics2D g, GridBoard<T> gridBoard, int x, int y) {
+    public static <T extends Component> void drawGridBoard(Graphics2D g, GridBoard<T> gridBoard, int x, int y) {
         int width = gridBoard.getWidth() * defaultItemSize;
         int height = gridBoard.getHeight() * defaultItemSize;
 
@@ -36,7 +37,7 @@ public class GridBoardView<T> extends ComponentView {
         }
     }
 
-    public static <T> void drawGridBoard(Graphics2D g, GridBoard<T> gridBoard, Rectangle rect) {
+    public static <T extends Component> void drawGridBoard(Graphics2D g, GridBoard<T> gridBoard, Rectangle rect) {
         // Draw background
         g.setColor(Color.lightGray);
         g.fillRect(rect.x, rect.y, rect.width-1, rect.height-1);
@@ -52,7 +53,7 @@ public class GridBoardView<T> extends ComponentView {
         }
     }
 
-    private static <T> void drawCell(Graphics2D g, T element, int x, int y) {
+    private static <T extends Component> void drawCell(Graphics2D g, T element, int x, int y) {
         // Paint cell background
         g.setColor(Color.lightGray);
         g.fillRect(x, y, defaultItemSize, defaultItemSize);


### PR DESCRIPTION
GridBoard was the only component allowed to go rogue and ignore the whole component system in the framework, e.g. by placing characters/any object types in a grid, that are not necessarily components themselves, leading to strange areas conceptually. So, this PR mostly addresses the change of this class, including the removal of reflection, and keeping everything expressed in components:

- GridBoard is a generic of type <T extends Component> like Deck
- Reflection removed in GridBoard and all operations are in terms of components
- Tic Tac Toe still uses a GridBoard, but with the lowest level component instead (a Token representing each symbol). **Initially "defaultToken"s are put in the board, potentially better to remove this concept and simply place tokens with actions, to more accurately represent the game state.**
- Dots&Boxes no longer uses GridBoard, but instead some simpler data structures grouping and mapping components, for a speed up of game state copy computation and general simplification of game code
- Edges and boxes/cells in Dots&Boxes also extend Component now to keep with the consistency