### PR TITLE
Fixes two bugs found in Heuristic Tuning

### DIFF
--- a/src/main/java/evaluation/GameReportII.java
+++ b/src/main/java/evaluation/GameReportII.java
@@ -201,7 +201,7 @@ public class GameReportII {
         AbstractForwardModel fm = game.getForwardModel();
         long s = System.nanoTime();
         fm.setup(gs);
-        data.put("TimeSetup", (System.nanoTime() - s) / 10e3);
+        data.put("TimeSetup", (System.nanoTime() - s) / 1e3);
 
         Pair<Integer, int[]> components = countComponents(gs);
         data.put("StateSizeStart", components.a);
@@ -245,10 +245,10 @@ public class GameReportII {
         data.put("ActionSpaceKurtosis", stats.kurtosis());
         data.put("ActionSpaceVarCoeff", Math.abs(stats.sd() / stats.mean()));
         data.put("Decisions", stats.n());
-        data.put("TimeNext", game.getNextTime() / 10e3);
-        data.put("TimeCopy", game.getCopyTime() / 10e3);
-        data.put("TimeActionCompute", game.getActionComputeTime() / 10e3);
-        data.put("TimeAgent", game.getAgentTime() / 10e3);
+        data.put("TimeNext", game.getNextTime() / 1e3);
+        data.put("TimeCopy", game.getCopyTime() / 1e3);
+        data.put("TimeActionCompute", game.getActionComputeTime() / 1e3);
+        data.put("TimeAgent", game.getAgentTime() / 1e3);
 
         data.put("Ticks", game.getTick());
         data.put("Rounds", game.getGameState().getTurnOrder().getRoundCounter());

--- a/src/main/java/evaluation/ITPSearchSpace.java
+++ b/src/main/java/evaluation/ITPSearchSpace.java
@@ -1,19 +1,22 @@
 package evaluation;
 
-import core.interfaces.IStateHeuristic;
 import core.interfaces.ITunableParameters;
 import evodef.AgentSearchSpace;
-import org.json.simple.*;
+import org.json.simple.JSONArray;
+import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
-import players.mcts.MCTSParams;
 import utilities.Pair;
 
 import java.io.FileReader;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
-import static java.util.stream.Collectors.*;
-
-import java.util.stream.*;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
 
 /**
  * This is a wrapper around ITunableParameters<T> (the TAG standard) to implement the AgentSearchSpace
@@ -112,7 +115,8 @@ public class ITPSearchSpace extends AgentSearchSpace<Object> {
                         // this defines a default we should be using in itp
                         if (data == null)
                             throw new AssertionError("We have a problem with null data in JSON file using key " + key);
-                        itp.setParameterValue(key, data);
+                        String[] namespaceSplit = key.split("\\.");
+                        itp.setParameterValue(namespaceSplit[namespaceSplit.length - 1], data);
                     }
                 } else if (!baseKey.equals("class")){
                     System.out.println("Unexpected key in JSON when loading ITPSearchSpace : " + baseKey);

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -1,18 +1,23 @@
 package players.mcts;
 
-import core.*;
-import core.interfaces.*;
+import core.AbstractGameState;
+import core.AbstractParameters;
+import core.AbstractPlayer;
+import core.interfaces.IStateHeuristic;
+import core.interfaces.ITunableParameters;
 import evaluation.TunableParameters;
 import org.json.simple.JSONObject;
 import players.PlayerParameters;
 import players.simple.RandomPlayer;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.Random;
 
-import static players.mcts.MCTSEnums.SelectionPolicy.*;
-import static players.mcts.MCTSEnums.Strategies.*;
-import static players.mcts.MCTSEnums.TreePolicy.*;
-import static players.mcts.MCTSEnums.OpponentTreePolicy.*;
+import static players.mcts.MCTSEnums.OpponentTreePolicy.MaxN;
+import static players.mcts.MCTSEnums.OpponentTreePolicy.Paranoid;
+import static players.mcts.MCTSEnums.SelectionPolicy.ROBUST;
+import static players.mcts.MCTSEnums.Strategies.RANDOM;
+import static players.mcts.MCTSEnums.TreePolicy.UCB;
 
 public class MCTSParams extends PlayerParameters {
 
@@ -85,6 +90,7 @@ public class MCTSParams extends PlayerParameters {
         ITunableParameters child = super.registerChild(nameSpace, json);
         if (child instanceof IStateHeuristic) {
             heuristic = (IStateHeuristic) child;
+            setParameterValue("heuristic", child);
         }
         return child;
     }

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -4,8 +4,6 @@ import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.actions.AbstractAction;
 import core.interfaces.IStateHeuristic;
-import core.interfaces.IStatisticLogger;
-import utilities.SummaryLogger;
 
 import java.util.List;
 import java.util.Random;

--- a/src/main/java/players/simple/OSLAPlayer.java
+++ b/src/main/java/players/simple/OSLAPlayer.java
@@ -1,9 +1,9 @@
 package players.simple;
 
 import core.AbstractForwardModel;
-import core.actions.AbstractAction;
-import core.AbstractPlayer;
 import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.actions.AbstractAction;
 import core.interfaces.IStateHeuristic;
 import core.turnorders.SimultaneousTurnOrder;
 
@@ -44,7 +44,9 @@ public class OSLAPlayer extends AbstractPlayer {
         double maxQ = Double.NEGATIVE_INFINITY;
         AbstractAction bestAction = null;
 
-        for (AbstractAction action : actions) {
+        double[] valState = new double[actions.size()];
+        for (int actionIndex = 0; actionIndex < actions.size(); actionIndex++) {
+            AbstractAction action = actions.get(actionIndex);
             AbstractGameState gsCopy = gs.copy();
 
             getForwardModel().next(gsCopy, action);
@@ -53,14 +55,14 @@ public class OSLAPlayer extends AbstractPlayer {
                 advanceToEndOfRoundWithRandomActions(gsCopy);
             }
 
-            double valState;
             if (heuristic != null) {
-                valState = heuristic.evaluateState(gsCopy, this.getPlayerID());
+                valState[actionIndex] = heuristic.evaluateState(gsCopy, this.getPlayerID());
             } else {
-                valState = gsCopy.getHeuristicScore(this.getPlayerID());
+                valState[actionIndex] = gsCopy.getHeuristicScore(this.getPlayerID());
             }
 
-            double Q = noise(valState, this.epsilon, this.random.nextDouble());
+            double Q = noise(valState[actionIndex], this.epsilon, this.random.nextDouble());
+       //     System.out.println(Arrays.stream(valState).mapToObj(v -> String.format("%1.3f", v)).collect(Collectors.joining("\t")));
 
             if (Q > maxQ) {
                 maxQ = Q;


### PR DESCRIPTION
1) When tuning MCTSParams, values in the Heuristic were never tuned (as I forgot to initialise it properly)

2) When tuning nested parameters (usually an MCTS evaluation function currently), then this would fall over unless *all* the parameters were being tuned.

3) Also fixes a reporting error where Copy and Next times were accidentally divided by 10. 
