### PR TITLE
Timers for agent decision making

### DIFF
--- a/src/main/java/core/AbstractForwardModel.java
+++ b/src/main/java/core/AbstractForwardModel.java
@@ -1,6 +1,7 @@
 package core;
 
 import core.actions.AbstractAction;
+import utilities.ElapsedCpuChessTimer;
 import utilities.Utils;
 
 import java.util.Arrays;
@@ -24,6 +25,10 @@ public abstract class AbstractForwardModel {
         firstState.playerResults = new Utils.GameResult[firstState.getNPlayers()];
         Arrays.fill(firstState.playerResults, Utils.GameResult.GAME_ONGOING);
         firstState.gamePhase = AbstractGameState.DefaultGamePhase.Main;
+        firstState.playerTimer = new ElapsedCpuChessTimer[firstState.getNPlayers()];
+        for (int i = 0; i < firstState.getNPlayers(); i++) {
+            firstState.playerTimer[i] = new ElapsedCpuChessTimer(firstState.gameType.getThinkingTimeMins(), firstState.gameType.getIncrementS());
+        }
 
         _setup(firstState);
         firstState.addAllComponents();
@@ -77,15 +82,23 @@ public abstract class AbstractForwardModel {
     }
 
     /**
-     * Current player tried to play an illegal action. Either disqualify (Automatic loss and no more playing),
-     * or play a random action for them instead.
+     * Current player tried to play an illegal action.
      * Subclasses can overwrite for their own behaviour.
      *
      * @param gameState - game state in which illegal action was attempted.
      * @param action    - action played
      */
     protected void illegalActionPlayed(AbstractGameState gameState, AbstractAction action) {
-        if (DISQUALIFY_PLAYER_ON_ILLEGAL_ACTION_PLAYED) {
+        disqualifyOrRandomAction(DISQUALIFY_PLAYER_ON_ILLEGAL_ACTION_PLAYED, gameState);
+    }
+
+    /**
+     * Either disqualify (automatic loss and no more playing), or play a random action for the player instead.
+     * @param flag - boolean to check if player should be disqualified, or random action should be played
+     * @param gameState - current game state
+     */
+    protected final void disqualifyOrRandomAction(boolean flag, AbstractGameState gameState) {
+        if (flag) {
             gameState.setPlayerResult(Utils.GameResult.DISQUALIFY, gameState.getCurrentPlayer());
             gameState.turnOrder.endPlayerTurn(gameState);
         } else {

--- a/src/main/java/core/AbstractForwardModel.java
+++ b/src/main/java/core/AbstractForwardModel.java
@@ -27,7 +27,9 @@ public abstract class AbstractForwardModel {
         firstState.gamePhase = AbstractGameState.DefaultGamePhase.Main;
         firstState.playerTimer = new ElapsedCpuChessTimer[firstState.getNPlayers()];
         for (int i = 0; i < firstState.getNPlayers(); i++) {
-            firstState.playerTimer[i] = new ElapsedCpuChessTimer(firstState.gameType.getThinkingTimeMins(), firstState.gameType.getIncrementS());
+            firstState.playerTimer[i] = new ElapsedCpuChessTimer(firstState.gameParameters.thinkingTimeMins,
+                    firstState.gameParameters.incrementActionS, firstState.gameParameters.incrementTurnS,
+                    firstState.gameParameters.incrementRoundS, firstState.gameParameters.incrementMilestoneS);
         }
 
         _setup(firstState);

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -8,6 +8,8 @@ import core.interfaces.IComponentContainer;
 import core.interfaces.IExtendedSequence;
 import core.interfaces.IGamePhase;
 import core.turnorders.TurnOrder;
+import games.GameType;
+import utilities.ElapsedCpuChessTimer;
 import utilities.Utils;
 
 import java.util.*;
@@ -32,6 +34,11 @@ public abstract class AbstractGameState {
     protected final AbstractParameters gameParameters;
     protected TurnOrder turnOrder;
     private Area allComponents;
+
+    // Timers for all players
+    protected ElapsedCpuChessTimer[] playerTimer;
+    // Game being played
+    protected final GameType gameType;
 
     // A record of all actions taken to reach this game state
     private List<AbstractAction> history = new ArrayList<>();
@@ -61,9 +68,10 @@ public abstract class AbstractGameState {
      * @param gameParameters - game parameters.
      * @param turnOrder - turn order for this game.
      */
-    public AbstractGameState(AbstractParameters gameParameters, TurnOrder turnOrder){
+    public AbstractGameState(AbstractParameters gameParameters, TurnOrder turnOrder, GameType gameType){
         this.gameParameters = gameParameters;
         this.turnOrder = turnOrder;
+        this.gameType = gameType;
     }
 
     /**
@@ -78,6 +86,7 @@ public abstract class AbstractGameState {
         gamePhase = DefaultGamePhase.Main;
         history = new ArrayList<>();
         historyText = new ArrayList<>();
+        playerTimer = new ElapsedCpuChessTimer[getNPlayers()];
         _reset();
     }
 
@@ -171,6 +180,11 @@ public abstract class AbstractGameState {
                 a -> s.actionsInProgress.push(a.copy())
         );
 
+        s.playerTimer = new ElapsedCpuChessTimer[getNPlayers()];
+        for (int i = 0; i < getNPlayers(); i++) {
+            s.playerTimer[i] = playerTimer[i].copy();
+        }
+
         // Update the list of components for ID matching in actions.
         s.addAllComponents();
         return s;
@@ -229,7 +243,7 @@ public abstract class AbstractGameState {
      * of victory points, etc.
      * If a game does not support this directly, then just return 0.0
      * (Unlike _getHeuristicScore(), there is no constraint on the range..whatever the game rules say.
-     * @param playerId
+     * @param playerId - player observing the state.
      * @return - double, score of current state
      */
     public abstract double getGameScore(int playerId);

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -328,6 +328,18 @@ public abstract class AbstractGameState {
         return copy(-1);
     }
 
+    public final ElapsedCpuChessTimer[] getPlayerTimer() {
+        return playerTimer;
+    }
+
+    public final GameType getGameType() {
+        return gameType;
+    }
+
+    public final Stack<IExtendedSequence> getActionsInProgress() {
+        return actionsInProgress;
+    }
+
     /**
      * Retrieves a simple numerical assessment of the current game state, the bigger the better.
      * Subjective heuristic function definition.

--- a/src/main/java/core/AbstractParameters.java
+++ b/src/main/java/core/AbstractParameters.java
@@ -1,18 +1,19 @@
 package core;
 
 import core.interfaces.ITunableParameters;
-import org.json.simple.JSONObject;
-import org.json.simple.parser.JSONParser;
-
-import java.io.FileReader;
 import java.util.*;
-import java.util.stream.*;
-
-import static java.util.stream.Collectors.*;
 
 public abstract class AbstractParameters {
 
+    // Random seed for this game
     long randomSeed;
+
+    // Player thinking time for the entire game, in minutes. Default max value.
+    long thinkingTimeMins = Long.MAX_VALUE;
+    // Increment in seconds, added after a common milestone: action, turn, round. Default 0.
+    long incrementActionS = 0, incrementTurnS = 0, incrementRoundS = 0;
+    // Increment in seconds, added after a custom milestone (to be added manually in game implementation). Default 0.
+    long incrementMilestoneS = 0;
 
     public AbstractParameters(long seed) {
         randomSeed = seed;
@@ -43,6 +44,46 @@ public abstract class AbstractParameters {
      */
     public long getRandomSeed() {
         return randomSeed;
+    }
+
+    /**
+     * Retrieve total thinking time for the game, in minutes
+     * @return - thinking time.
+     */
+    public long getThinkingTimeMins() {
+        return thinkingTimeMins;
+    }
+
+    /**
+     * Retrieve the number of seconds added to a player's timer after an action is taken
+     * @return - action increment
+     */
+    public long getIncrementActionS() {
+        return incrementActionS;
+    }
+
+    /**
+     * Retrieve the number of seconds added to a player's timer after a turn is finished
+     * @return - turn increment
+     */
+    public long getIncrementTurnS() {
+        return incrementTurnS;
+    }
+
+    /**
+     * Retrieve the number of seconds added to a player's timer after a round is finished
+     * @return - round increment
+     */
+    public long getIncrementRoundS() {
+        return incrementRoundS;
+    }
+
+    /**
+     * Retrieve the number of seconds added to a player's timer after a game-specific defined milestone
+     * @return - milestone increment
+     */
+    public long getIncrementMilestoneS() {
+        return incrementMilestoneS;
     }
 
     /**
@@ -92,11 +133,16 @@ public abstract class AbstractParameters {
         if (this == o) return true;
         if (!(o instanceof AbstractParameters)) return false;
         AbstractParameters that = (AbstractParameters) o;
-        return randomSeed == that.randomSeed && _equals(o);
+        return randomSeed == that.randomSeed &&
+                thinkingTimeMins == that.thinkingTimeMins &&
+                incrementActionS == that.incrementActionS &&
+                incrementTurnS == that.incrementTurnS &&
+                incrementRoundS == that.incrementRoundS &&
+                incrementMilestoneS == that.incrementMilestoneS;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(randomSeed);
+        return Objects.hash(randomSeed, thinkingTimeMins, incrementActionS, incrementTurnS, incrementRoundS, incrementMilestoneS);
     }
 }

--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -6,6 +6,8 @@ public class CoreConstants {
     public final static boolean VERBOSE = false;
     public final static boolean PARTIAL_OBSERVABLE = true;
     public final static boolean DISQUALIFY_PLAYER_ON_ILLEGAL_ACTION_PLAYED = false;
+    public final static boolean DISQUALIFY_PLAYER_ON_TIMEOUT = false;
+    public final static boolean TIMER_ENABLED = true;
     public final static boolean ALWAYS_DISPLAY_FULL_OBSERVABLE = false;
     public final static boolean ALWAYS_DISPLAY_CURRENT_PLAYER = false;
     public final static long FRAME_SLEEP_MS = 100;

--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -7,7 +7,6 @@ public class CoreConstants {
     public final static boolean PARTIAL_OBSERVABLE = true;
     public final static boolean DISQUALIFY_PLAYER_ON_ILLEGAL_ACTION_PLAYED = false;
     public final static boolean DISQUALIFY_PLAYER_ON_TIMEOUT = false;
-    public final static boolean TIMER_ENABLED = true;
     public final static boolean ALWAYS_DISPLAY_FULL_OBSERVABLE = false;
     public final static boolean ALWAYS_DISPLAY_CURRENT_PLAYER = false;
     public final static long FRAME_SLEEP_MS = 100;

--- a/src/main/java/core/turnorders/TurnOrder.java
+++ b/src/main/java/core/turnorders/TurnOrder.java
@@ -121,6 +121,8 @@ public abstract class TurnOrder {
     public void endPlayerTurn(AbstractGameState gameState) {
         if (gameState.getGameStatus() != GAME_ONGOING) return;
 
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementTurn();
+
         listeners.forEach(l -> l.onEvent(CoreConstants.GameEvents.TURN_OVER, gameState, null));
 
         turnCounter++;
@@ -138,6 +140,10 @@ public abstract class TurnOrder {
      * @param gameState - current game state.
      */
     public void endRound(AbstractGameState gameState) {
+        if (gameState.getGameStatus() != GAME_ONGOING) return;
+
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementRound();
+
         listeners.forEach(l -> l.onEvent(CoreConstants.GameEvents.ROUND_OVER, gameState, null));
 
         roundCounter++;

--- a/src/main/java/games/GameType.java
+++ b/src/main/java/games/GameType.java
@@ -61,27 +61,34 @@ public enum GameType {
     Pandemic(2, 4,
             new ArrayList<Category>() {{ add(Strategy); add(Medical); }},
             new ArrayList<Mechanic>() {{ add(ActionPoints); add(Cooperative); add(HandManagement);
-            add(PointToPointMovement); add(SetCollection); add(Trading); add(VariablePlayerPowers); }}),
+            add(PointToPointMovement); add(SetCollection); add(Trading); add(VariablePlayerPowers); }},
+            30, 1),
     TicTacToe (2, 2,
             new ArrayList<Category>() {{ add(Simple); add(Abstract); }},
-            new ArrayList<Mechanic>() {{ add(PatternBuilding); }}),
+            new ArrayList<Mechanic>() {{ add(PatternBuilding); }},
+            5, 0),
     ExplodingKittens (2, 5,
             new ArrayList<Category>() {{ add(Strategy); add(Animals); add(Cards); add(ComicBook); add(Humour); }},
             new ArrayList<Mechanic>() {{ add(HandManagement); add(HotPotato); add(PlayerElimination); add(PushYourLuck);
-            add(SetCollection); add(TakeThat); }}),
+            add(SetCollection); add(TakeThat); }},
+            20, 0),
     LoveLetter (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Deduction); add(Renaissance); }},
-            new ArrayList<Mechanic>() {{ add(HandManagement); add(PlayerElimination); }}),
+            new ArrayList<Mechanic>() {{ add(HandManagement); add(PlayerElimination); }},
+            20, 0),
     Uno (2, 10,
             new ArrayList<Category>() {{ add(Cards); add(ComicBook); add(Number); add(MoviesTVRadio); }},
-            new ArrayList<Mechanic>() {{ add(HandManagement); add(LoseATurn); add(TakeThat); }}),
+            new ArrayList<Mechanic>() {{ add(HandManagement); add(LoseATurn); add(TakeThat); }},
+            20, 0),
     Virus (2, 6,
             new ArrayList<Category>() {{ add(Cards); add(Medical); }},
-            new ArrayList<Mechanic>() {{ add(CardDrafting); add(SetCollection); add(TakeThat); }}),
+            new ArrayList<Mechanic>() {{ add(CardDrafting); add(SetCollection); add(TakeThat); }},
+            20,0),
     ColtExpress (2, 6,
             new ArrayList<Category>() {{ add(Strategy); add(AmericanWest); add(Fighting); add(Trains); }},
             new ArrayList<Mechanic>() {{ add(ActionQueue); add(HandManagement); add(Memory); add(ProgrammedEvent);
-            add(SimultaneousActionSelection); add(TakeThat); add(VariablePlayerPowers); }}),
+            add(SimultaneousActionSelection); add(TakeThat); add(VariablePlayerPowers); }},
+            20, 0),
     DotsAndBoxes(2, 6,
             new ArrayList<Category>() {{
                 add(Simple);
@@ -90,7 +97,8 @@ public enum GameType {
             }},
             new ArrayList<Mechanic>() {{
                 add(Enclosure);
-            }}),
+            }},
+            5, 0),
     Diamant( 2, 6,
             new ArrayList<Category>() {{
                 add(Adventure);
@@ -101,16 +109,20 @@ public enum GameType {
                 add(MoveThroughDeck);
                 add(PushYourLuck);
                 add(SimultaneousActionSelection);
-            }}),
+            }},
+            10, 0),
     Dominion (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Strategy);}},
-            new ArrayList<Mechanic>() {{ add(DeckManagement); }}),
+            new ArrayList<Mechanic>() {{ add(DeckManagement); }},
+            30, 0),
     DominionSizeDistortion (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Strategy);}},
-            new ArrayList<Mechanic>() {{ add(DeckManagement); }}),
+            new ArrayList<Mechanic>() {{ add(DeckManagement); }},
+            30, 0),
     DominionImprovements (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Strategy);}},
-            new ArrayList<Mechanic>() {{ add(DeckManagement); }})
+            new ArrayList<Mechanic>() {{ add(DeckManagement); }},
+            30, 0)
     ;
 
 //    Carcassonne (2, 5,
@@ -317,11 +329,14 @@ public enum GameType {
 
 
     // Minimum and maximum number of players supported in this game
-    private int minPlayers, maxPlayers;
+    private final int minPlayers, maxPlayers;
+
+    // Player thinking time for the entire game, in minutes. Increment in seconds (added after a decision is taken)
+    private long thinkingTimeMins, incrementS;
 
     // boardgamegeek.com topic classification of games
-    private ArrayList<Category> categories;
-    private ArrayList<Mechanic> mechanics;
+    private final ArrayList<Category> categories;
+    private final ArrayList<Mechanic> mechanics;
 
     public enum Category {
         Strategy,
@@ -444,11 +459,13 @@ public enum GameType {
         }
     }
 
-    GameType(int minPlayers, int maxPlayers, ArrayList<Category> categories, ArrayList<Mechanic> mechanics) {
+    GameType(int minPlayers, int maxPlayers, ArrayList<Category> categories, ArrayList<Mechanic> mechanics, long thinkingTimeMS, long incrementS) {
         this.minPlayers = minPlayers;
         this.maxPlayers = maxPlayers;
         this.categories = categories;
         this.mechanics = mechanics;
+        this.thinkingTimeMins = thinkingTimeMS;
+        this.incrementS = incrementS;
     }
 
     // Getters
@@ -457,6 +474,12 @@ public enum GameType {
     }
     public int getMaxPlayers() {
         return maxPlayers;
+    }
+    public long getThinkingTimeMins() {
+        return thinkingTimeMins;
+    }
+    public long getIncrementS() {
+        return incrementS;
     }
     public ArrayList<Category> getCategories() {
         return categories;
@@ -477,6 +500,14 @@ public enum GameType {
             if (gt.minPlayers > max) max = gt.minPlayers;
         }
         return max;
+    }
+
+    // Setters
+    public void setThinkingTimeMins(long mins) {
+        this.thinkingTimeMins = mins;
+    }
+    public void setIncrementS(long inc) {
+        this.incrementS = inc;
     }
 
     /**

--- a/src/main/java/games/GameType.java
+++ b/src/main/java/games/GameType.java
@@ -61,34 +61,27 @@ public enum GameType {
     Pandemic(2, 4,
             new ArrayList<Category>() {{ add(Strategy); add(Medical); }},
             new ArrayList<Mechanic>() {{ add(ActionPoints); add(Cooperative); add(HandManagement);
-            add(PointToPointMovement); add(SetCollection); add(Trading); add(VariablePlayerPowers); }},
-            30, 1),
+            add(PointToPointMovement); add(SetCollection); add(Trading); add(VariablePlayerPowers); }}),
     TicTacToe (2, 2,
             new ArrayList<Category>() {{ add(Simple); add(Abstract); }},
-            new ArrayList<Mechanic>() {{ add(PatternBuilding); }},
-            5, 0),
+            new ArrayList<Mechanic>() {{ add(PatternBuilding); }}),
     ExplodingKittens (2, 5,
             new ArrayList<Category>() {{ add(Strategy); add(Animals); add(Cards); add(ComicBook); add(Humour); }},
             new ArrayList<Mechanic>() {{ add(HandManagement); add(HotPotato); add(PlayerElimination); add(PushYourLuck);
-            add(SetCollection); add(TakeThat); }},
-            20, 0),
+            add(SetCollection); add(TakeThat); }}),
     LoveLetter (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Deduction); add(Renaissance); }},
-            new ArrayList<Mechanic>() {{ add(HandManagement); add(PlayerElimination); }},
-            20, 0),
+            new ArrayList<Mechanic>() {{ add(HandManagement); add(PlayerElimination); }}),
     Uno (2, 10,
             new ArrayList<Category>() {{ add(Cards); add(ComicBook); add(Number); add(MoviesTVRadio); }},
-            new ArrayList<Mechanic>() {{ add(HandManagement); add(LoseATurn); add(TakeThat); }},
-            20, 0),
+            new ArrayList<Mechanic>() {{ add(HandManagement); add(LoseATurn); add(TakeThat); }}),
     Virus (2, 6,
             new ArrayList<Category>() {{ add(Cards); add(Medical); }},
-            new ArrayList<Mechanic>() {{ add(CardDrafting); add(SetCollection); add(TakeThat); }},
-            20,0),
+            new ArrayList<Mechanic>() {{ add(CardDrafting); add(SetCollection); add(TakeThat); }}),
     ColtExpress (2, 6,
             new ArrayList<Category>() {{ add(Strategy); add(AmericanWest); add(Fighting); add(Trains); }},
             new ArrayList<Mechanic>() {{ add(ActionQueue); add(HandManagement); add(Memory); add(ProgrammedEvent);
-            add(SimultaneousActionSelection); add(TakeThat); add(VariablePlayerPowers); }},
-            20, 0),
+            add(SimultaneousActionSelection); add(TakeThat); add(VariablePlayerPowers); }}),
     DotsAndBoxes(2, 6,
             new ArrayList<Category>() {{
                 add(Simple);
@@ -97,8 +90,7 @@ public enum GameType {
             }},
             new ArrayList<Mechanic>() {{
                 add(Enclosure);
-            }},
-            5, 0),
+            }}),
     Diamant( 2, 6,
             new ArrayList<Category>() {{
                 add(Adventure);
@@ -109,20 +101,16 @@ public enum GameType {
                 add(MoveThroughDeck);
                 add(PushYourLuck);
                 add(SimultaneousActionSelection);
-            }},
-            10, 0),
+            }}),
     Dominion (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Strategy);}},
-            new ArrayList<Mechanic>() {{ add(DeckManagement); }},
-            30, 0),
+            new ArrayList<Mechanic>() {{ add(DeckManagement); }}),
     DominionSizeDistortion (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Strategy);}},
-            new ArrayList<Mechanic>() {{ add(DeckManagement); }},
-            30, 0),
+            new ArrayList<Mechanic>() {{ add(DeckManagement); }}),
     DominionImprovements (2, 4,
             new ArrayList<Category>() {{ add(Cards); add(Strategy);}},
-            new ArrayList<Mechanic>() {{ add(DeckManagement); }},
-            30, 0)
+            new ArrayList<Mechanic>() {{ add(DeckManagement); }})
     ;
 
 //    Carcassonne (2, 5,
@@ -331,9 +319,6 @@ public enum GameType {
     // Minimum and maximum number of players supported in this game
     private final int minPlayers, maxPlayers;
 
-    // Player thinking time for the entire game, in minutes. Increment in seconds (added after a decision is taken)
-    private long thinkingTimeMins, incrementS;
-
     // boardgamegeek.com topic classification of games
     private final ArrayList<Category> categories;
     private final ArrayList<Mechanic> mechanics;
@@ -459,13 +444,11 @@ public enum GameType {
         }
     }
 
-    GameType(int minPlayers, int maxPlayers, ArrayList<Category> categories, ArrayList<Mechanic> mechanics, long thinkingTimeMS, long incrementS) {
+    GameType(int minPlayers, int maxPlayers, ArrayList<Category> categories, ArrayList<Mechanic> mechanics) {
         this.minPlayers = minPlayers;
         this.maxPlayers = maxPlayers;
         this.categories = categories;
         this.mechanics = mechanics;
-        this.thinkingTimeMins = thinkingTimeMS;
-        this.incrementS = incrementS;
     }
 
     // Getters
@@ -474,12 +457,6 @@ public enum GameType {
     }
     public int getMaxPlayers() {
         return maxPlayers;
-    }
-    public long getThinkingTimeMins() {
-        return thinkingTimeMins;
-    }
-    public long getIncrementS() {
-        return incrementS;
     }
     public ArrayList<Category> getCategories() {
         return categories;
@@ -500,14 +477,6 @@ public enum GameType {
             if (gt.minPlayers > max) max = gt.minPlayers;
         }
         return max;
-    }
-
-    // Setters
-    public void setThinkingTimeMins(long mins) {
-        this.thinkingTimeMins = mins;
-    }
-    public void setIncrementS(long inc) {
-        this.incrementS = inc;
     }
 
     /**

--- a/src/main/java/games/coltexpress/ColtExpressGameState.java
+++ b/src/main/java/games/coltexpress/ColtExpressGameState.java
@@ -8,6 +8,7 @@ import core.components.Deck;
 import core.components.PartialObservableDeck;
 import core.interfaces.IGamePhase;
 import core.interfaces.IPrintable;
+import games.GameType;
 import games.coltexpress.ColtExpressTypes.CharacterType;
 import games.coltexpress.cards.ColtExpressCard;
 import games.coltexpress.cards.RoundCard;
@@ -47,7 +48,7 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
     PartialObservableDeck<RoundCard> rounds;
 
     public ColtExpressGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new ColtExpressTurnOrder(nPlayers, ((ColtExpressParameters) gameParameters).nMaxRounds));
+        super(gameParameters, new ColtExpressTurnOrder(nPlayers, ((ColtExpressParameters) gameParameters).nMaxRounds), GameType.ColtExpress);
         gamePhase = ColtExpressGamePhase.PlanActions;
         trainCompartments = new LinkedList<>();
         playerPlayingBelle = -1;

--- a/src/main/java/games/coltexpress/ColtExpressTurnOrder.java
+++ b/src/main/java/games/coltexpress/ColtExpressTurnOrder.java
@@ -131,6 +131,10 @@ public class ColtExpressTurnOrder extends TurnOrder {
      */
     @Override
     public void endRound(AbstractGameState gameState) {
+        if (gameState.getGameStatus() != GAME_ONGOING) return;
+
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementRound();
+
         listeners.forEach(l -> l.onEvent(CoreConstants.GameEvents.ROUND_OVER, gameState, null));
 
         turnCounter = 0;

--- a/src/main/java/games/diamant/DiamantGameState.java
+++ b/src/main/java/games/diamant/DiamantGameState.java
@@ -7,6 +7,7 @@ import core.components.Counter;
 import core.components.Deck;
 import core.interfaces.IPrintable;
 import core.turnorders.SimultaneousTurnOrder;
+import games.GameType;
 import games.diamant.cards.DiamantCard;
 import games.diamant.components.ActionsPlayed;
 
@@ -46,7 +47,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
      * @param nPlayers      - number of players for this game.
      */
     public DiamantGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new SimultaneousTurnOrder(nPlayers));
+        super(gameParameters, new SimultaneousTurnOrder(nPlayers), GameType.Diamant);
     }
 
     @Override

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -6,6 +6,7 @@ import core.components.Component;
 import core.components.Deck;
 import core.components.PartialObservableDeck;
 import core.interfaces.IGamePhase;
+import games.GameType;
 import games.dominion.DominionConstants.DeckType;
 import games.dominion.actions.IDelayedAction;
 import games.dominion.cards.CardType;
@@ -59,7 +60,7 @@ public class DominionGameState extends AbstractGameState {
      * @param nPlayers       - number of players
      */
     public DominionGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new DominionTurnOrder(nPlayers));
+        super(gameParameters, new DominionTurnOrder(nPlayers), GameType.Dominion);
         rnd = new Random(gameParameters.getRandomSeed());
         playerCount = nPlayers;
         defenceStatus = new boolean[nPlayers];  // defaults to false

--- a/src/main/java/games/dotsboxes/DBGameState.java
+++ b/src/main/java/games/dotsboxes/DBGameState.java
@@ -5,6 +5,7 @@ import core.AbstractParameters;
 import core.components.Component;
 import core.interfaces.IStateHeuristic;
 import core.turnorders.AlternatingTurnOrder;
+import games.GameType;
 
 import java.util.*;
 
@@ -33,7 +34,7 @@ public class DBGameState extends AbstractGameState {
      * @param nPlayers      - number of players.
      */
     public DBGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new AlternatingTurnOrder(nPlayers));
+        super(gameParameters, new AlternatingTurnOrder(nPlayers), GameType.DotsAndBoxes);
     }
 
     @Override

--- a/src/main/java/games/explodingkittens/ExplodingKittensGameState.java
+++ b/src/main/java/games/explodingkittens/ExplodingKittensGameState.java
@@ -8,6 +8,7 @@ import core.components.Deck;
 import core.components.PartialObservableDeck;
 import core.interfaces.IGamePhase;
 import core.interfaces.IPrintable;
+import games.GameType;
 import games.explodingkittens.cards.ExplodingKittensCard;
 import utilities.Utils;
 
@@ -38,7 +39,7 @@ public class ExplodingKittensGameState extends AbstractGameState implements IPri
     Stack<AbstractAction> actionStack;
 
     public ExplodingKittensGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new ExplodingKittensTurnOrder(nPlayers));
+        super(gameParameters, new ExplodingKittensTurnOrder(nPlayers), GameType.ExplodingKittens);
         playerGettingAFavor = -1;
     }
 

--- a/src/main/java/games/loveletter/LoveLetterGameState.java
+++ b/src/main/java/games/loveletter/LoveLetterGameState.java
@@ -7,6 +7,7 @@ import core.interfaces.IGamePhase;
 import core.components.Deck;
 import core.components.PartialObservableDeck;
 import core.interfaces.IPrintable;
+import games.GameType;
 import games.loveletter.cards.LoveLetterCard;
 import utilities.Utils;
 
@@ -41,7 +42,7 @@ public class LoveLetterGameState extends AbstractGameState implements IPrintable
     int[] affectionTokens;
 
     public LoveLetterGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new LoveLetterTurnOrder(nPlayers));
+        super(gameParameters, new LoveLetterTurnOrder(nPlayers), GameType.LoveLetter);
         gamePhase = Draw;
     }
 

--- a/src/main/java/games/loveletter/LoveLetterTurnOrder.java
+++ b/src/main/java/games/loveletter/LoveLetterTurnOrder.java
@@ -20,6 +20,8 @@ public class LoveLetterTurnOrder extends AlternatingTurnOrder {
             return;
         }
 
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementTurn();
+
         turnCounter++;
         moveToNextPlayer(gameState, nextPlayer(gameState));
     }

--- a/src/main/java/games/pandemic/PandemicGameState.java
+++ b/src/main/java/games/pandemic/PandemicGameState.java
@@ -7,6 +7,7 @@ import core.properties.*;
 import core.AbstractGameState;
 import core.components.Area;
 import core.AbstractParameters;
+import games.GameType;
 import utilities.Hash;
 import utilities.Utils;
 
@@ -154,7 +155,7 @@ public class PandemicGameState extends AbstractGameState implements IFeatureRepr
      * @param nPlayers - number of players.
      */
     public PandemicGameState(AbstractParameters pp, int nPlayers) {
-        super(pp, new PandemicTurnOrder(nPlayers, ((PandemicParameters)pp).n_actions_per_turn));
+        super(pp, new PandemicTurnOrder(nPlayers, ((PandemicParameters)pp).n_actions_per_turn), GameType.Pandemic);
         data = new PandemicData();
         data.load(((PandemicParameters)gameParameters).getDataPath());
     }

--- a/src/main/java/games/pandemic/PandemicTurnOrder.java
+++ b/src/main/java/games/pandemic/PandemicTurnOrder.java
@@ -46,6 +46,8 @@ public class PandemicTurnOrder extends ReactiveTurnOrder {
     public void endPlayerTurn(AbstractGameState gameState) {
         if (gameState.getGameStatus() != GAME_ONGOING) return;
 
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementTurn();
+
         turnCounter++;
         if (turnCounter >= nPlayers) endRound(gameState);
         else {
@@ -62,6 +64,10 @@ public class PandemicTurnOrder extends ReactiveTurnOrder {
      * @param gameState - current game state.
      */
     public void endRound(AbstractGameState gameState) {
+        if (gameState.getGameStatus() != GAME_ONGOING) return;
+
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementRound();
+
         roundCounter++;
         if (nMaxRounds != -1 && roundCounter == nMaxRounds) gameState.setGameStatus(Utils.GameResult.GAME_END);
         else {

--- a/src/main/java/games/tictactoe/TicTacToeGameState.java
+++ b/src/main/java/games/tictactoe/TicTacToeGameState.java
@@ -8,6 +8,7 @@ import core.components.Token;
 import core.interfaces.IGridGameState;
 import core.interfaces.IPrintable;
 import core.interfaces.IVectorObservation;
+import games.GameType;
 import utilities.VectorObservation;
 import core.turnorders.AlternatingTurnOrder;
 
@@ -21,7 +22,7 @@ public class TicTacToeGameState extends AbstractGameState implements IPrintable,
     GridBoard<Token> gridBoard;
 
     public TicTacToeGameState(AbstractParameters gameParameters, int nPlayers){
-        super(gameParameters, new AlternatingTurnOrder(nPlayers));
+        super(gameParameters, new AlternatingTurnOrder(nPlayers), GameType.TicTacToe);
     }
 
     @Override

--- a/src/main/java/games/uno/UnoGameState.java
+++ b/src/main/java/games/uno/UnoGameState.java
@@ -5,6 +5,7 @@ import core.components.Component;
 import core.components.Deck;
 import core.AbstractGameState;
 import core.interfaces.IPrintable;
+import games.GameType;
 import games.uno.cards.*;
 
 import java.util.*;
@@ -27,7 +28,7 @@ public class UnoGameState extends AbstractGameState implements IPrintable {
      * @param nPlayers      - number of players for this game.
      */
     public UnoGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new UnoTurnOrder(nPlayers));
+        super(gameParameters, new UnoTurnOrder(nPlayers), GameType.Uno);
     }
 
     @Override

--- a/src/main/java/games/uno/UnoTurnOrder.java
+++ b/src/main/java/games/uno/UnoTurnOrder.java
@@ -45,6 +45,8 @@ public class UnoTurnOrder extends AlternatingTurnOrder {
     public void endPlayerTurn(AbstractGameState gameState) {
         if (gameState.getGameStatus() != GAME_ONGOING) return;
 
+        gameState.getPlayerTimer()[getCurrentPlayer(gameState)].incrementTurn();
+
         turnCounter++;
         moveToNextPlayer(gameState, nextPlayer(gameState));
     }

--- a/src/main/java/games/virus/VirusGameState.java
+++ b/src/main/java/games/virus/VirusGameState.java
@@ -6,6 +6,7 @@ import core.components.Component;
 import core.components.Deck;
 import core.interfaces.IPrintable;
 import core.turnorders.AlternatingTurnOrder;
+import games.GameType;
 import games.virus.cards.*;
 import games.virus.components.VirusBody;
 import games.virus.components.VirusOrgan;
@@ -24,7 +25,7 @@ public class VirusGameState extends AbstractGameState implements IPrintable {
     Deck<VirusCard>       discardDeck;    // The deck with already played cards. It is visible for all players
 
     public VirusGameState(AbstractParameters gameParameters, int nPlayers) {
-        super(gameParameters, new AlternatingTurnOrder(nPlayers));
+        super(gameParameters, new AlternatingTurnOrder(nPlayers), GameType.Virus);
     }
 
     @Override

--- a/src/main/java/utilities/ElapsedCpuChessTimer.java
+++ b/src/main/java/utilities/ElapsedCpuChessTimer.java
@@ -3,10 +3,10 @@ package utilities;
 public class ElapsedCpuChessTimer extends ElapsedCpuTimer {
 
     private long timeRemaining;
-    private final long incrementAction, incrementTurn, incrementRound, incrementMilestone;
+    private final double incrementAction, incrementTurn, incrementRound, incrementMilestone;
 
-    public ElapsedCpuChessTimer(long maxTimeMinutes, long incrementAction, long incrementTurn, long incrementRound,
-                                long incrementMilestone) {
+    public ElapsedCpuChessTimer(long maxTimeMinutes, double incrementAction, double incrementTurn, double incrementRound,
+                                double incrementMilestone) {
         setMaxTimeMillis(maxTimeMinutes * 60000);
         this.incrementAction = incrementAction * 1000000000;
         this.incrementTurn = incrementTurn * 1000000000;

--- a/src/main/java/utilities/ElapsedCpuChessTimer.java
+++ b/src/main/java/utilities/ElapsedCpuChessTimer.java
@@ -1,0 +1,57 @@
+package utilities;
+
+public class ElapsedCpuChessTimer extends ElapsedCpuTimer {
+
+    private long timeRemaining;
+    private final long increment;
+
+    public ElapsedCpuChessTimer(long maxTimeMinutes, long incrementSeconds) {
+        setMaxTimeMillis(maxTimeMinutes * 60000);
+        this.increment = incrementSeconds * 1000000000;
+        reset();
+    }
+
+    public void reset() {
+        super.reset();
+        timeRemaining = maxTime;
+    }
+
+    public void pause() {
+        // Update timeRemaining variable with time elapsed
+        timeRemaining -= elapsed();
+        // Add increment
+        timeRemaining += increment;
+    }
+
+    public void resume() {
+        // Update oldTime to current time
+        oldTime = getTime();
+    }
+
+    public long remainingTime() {
+        return timeRemaining;
+    }
+
+    public long remainingTimeMillis() {
+        return (long) (timeRemaining / 1000000.0);
+    }
+
+    public boolean exceededMaxTime() {
+        return (timeRemaining - increment) <= 0;
+    }
+
+    public ElapsedCpuChessTimer copy()
+    {
+        ElapsedCpuChessTimer newCpuTimer = new ElapsedCpuChessTimer(this.maxTime, this.increment);
+        newCpuTimer.oldTime = this.oldTime;
+        newCpuTimer.bean = this.bean;
+        newCpuTimer.nIters = this.nIters;
+        newCpuTimer.timeRemaining = this.timeRemaining;
+        return newCpuTimer;
+    }
+
+    @Override
+    public String toString() {
+        return remainingTimeMillis() + " ms remaining (" + increment/1000000.0 + " ms) increment";
+    }
+}

--- a/src/main/java/utilities/ElapsedCpuChessTimer.java
+++ b/src/main/java/utilities/ElapsedCpuChessTimer.java
@@ -3,11 +3,15 @@ package utilities;
 public class ElapsedCpuChessTimer extends ElapsedCpuTimer {
 
     private long timeRemaining;
-    private final long increment;
+    private final long incrementAction, incrementTurn, incrementRound, incrementMilestone;
 
-    public ElapsedCpuChessTimer(long maxTimeMinutes, long incrementSeconds) {
+    public ElapsedCpuChessTimer(long maxTimeMinutes, long incrementAction, long incrementTurn, long incrementRound,
+                                long incrementMilestone) {
         setMaxTimeMillis(maxTimeMinutes * 60000);
-        this.increment = incrementSeconds * 1000000000;
+        this.incrementAction = incrementAction * 1000000000;
+        this.incrementTurn = incrementTurn * 1000000000;
+        this.incrementRound = incrementRound * 1000000000;
+        this.incrementMilestone = incrementMilestone * 1000000000;
         reset();
     }
 
@@ -19,8 +23,26 @@ public class ElapsedCpuChessTimer extends ElapsedCpuTimer {
     public void pause() {
         // Update timeRemaining variable with time elapsed
         timeRemaining -= elapsed();
+    }
+
+    public void incrementAction() {
         // Add increment
-        timeRemaining += increment;
+        timeRemaining += incrementAction;
+    }
+
+    public void incrementTurn() {
+        // Add increment
+        timeRemaining += incrementTurn;
+    }
+
+    public void incrementRound() {
+        // Add increment
+        timeRemaining += incrementRound;
+    }
+
+    public void incrementMileStone() {
+        // Add increment
+        timeRemaining += incrementMilestone;
     }
 
     public void resume() {
@@ -37,12 +59,13 @@ public class ElapsedCpuChessTimer extends ElapsedCpuTimer {
     }
 
     public boolean exceededMaxTime() {
-        return (timeRemaining - increment) <= 0;
+        return (timeRemaining - incrementAction) <= 0;
     }
 
     public ElapsedCpuChessTimer copy()
     {
-        ElapsedCpuChessTimer newCpuTimer = new ElapsedCpuChessTimer(this.maxTime, this.increment);
+        ElapsedCpuChessTimer newCpuTimer = new ElapsedCpuChessTimer(this.maxTime, this.incrementAction,
+                this.incrementTurn, this.incrementRound, this.incrementMilestone);
         newCpuTimer.oldTime = this.oldTime;
         newCpuTimer.bean = this.bean;
         newCpuTimer.nIters = this.nIters;
@@ -52,6 +75,6 @@ public class ElapsedCpuChessTimer extends ElapsedCpuTimer {
 
     @Override
     public String toString() {
-        return remainingTimeMillis() + " ms remaining (" + increment/1000000.0 + " ms) increment";
+        return remainingTimeMillis() + " ms remaining (" + incrementAction/1000000.0 + " ms) increment act";
     }
 }

--- a/src/main/java/utilities/ElapsedCpuTimer.java
+++ b/src/main/java/utilities/ElapsedCpuTimer.java
@@ -10,27 +10,21 @@ import java.lang.management.ThreadMXBean;
 
 public class ElapsedCpuTimer {
 
-    private static final boolean OS_WIN = System.getProperty("os.name").contains("Windows");
+    protected static final boolean OS_WIN = System.getProperty("os.name").contains("Windows");
 
     // allows for easy reporting of elapsed time
-    private ThreadMXBean bean = ManagementFactory.getThreadMXBean();
-    private long oldTime;
-    private long maxTime;
-    private int nIters;
+    protected ThreadMXBean bean = ManagementFactory.getThreadMXBean();
+    protected long oldTime;
+    protected long maxTime;
+    protected int nIters;
 
     public ElapsedCpuTimer() {
-        oldTime = getTime();
-        nIters = 0;
+        reset();
     }
 
-    public ElapsedCpuTimer copy()
-    {
-        ElapsedCpuTimer newCpuTimer = new ElapsedCpuTimer();
-        newCpuTimer.maxTime = this.maxTime;
-        newCpuTimer.oldTime = this.oldTime;
-        newCpuTimer.bean = this.bean;
-        newCpuTimer.nIters = this.nIters;
-        return newCpuTimer;
+    public void reset() {
+        oldTime = getTime();
+        nIters = 0;
     }
 
     public long elapsed() {
@@ -57,39 +51,11 @@ public class ElapsedCpuTimer {
         return elapsedMinutes()/60.0;
     }
 
-
-    @Override
-    public String toString() {
-        // now resets the timer...
-        String ret = elapsed() / 1000000.0 + " ms elapsed";
-        //reset();
-        return ret;
-    }
-
-    private long getTime() {
-        return getCpuTime();
-    }
-
-    private long getCpuTime() {
-
-        if(OS_WIN)
-            return System.nanoTime();
-
-        if (bean.isCurrentThreadCpuTimeSupported()) {
-            return bean.getCurrentThreadCpuTime();
-        } else {
-            throw new RuntimeException("CpuTime NOT Supported");
-        }
-
-    }
-
     public void setMaxTimeMillis(long time) {
         maxTime = time * 1000000;
-
     }
 
-    public long remainingTimeMillis()
-    {
+    public long remainingTimeMillis() {
         long diff = maxTime - elapsed();
         return (long) (diff / 1000000.0);
     }
@@ -116,4 +82,38 @@ public class ElapsedCpuTimer {
     public void endIteration() {
         nIters++;
     }
+
+    public ElapsedCpuTimer copy()
+    {
+        ElapsedCpuTimer newCpuTimer = new ElapsedCpuTimer();
+        newCpuTimer.maxTime = this.maxTime;
+        newCpuTimer.oldTime = this.oldTime;
+        newCpuTimer.bean = this.bean;
+        newCpuTimer.nIters = this.nIters;
+        return newCpuTimer;
+    }
+
+    @Override
+    public String toString() {
+        // now resets the timer...
+        String ret = elapsed() / 1000000.0 + " ms elapsed";
+        //reset();
+        return ret;
+    }
+
+    protected long getTime() {
+        return getCpuTime();
+    }
+
+    protected long getCpuTime() {
+        if(OS_WIN)
+            return System.nanoTime();
+
+        if (bean.isCurrentThreadCpuTimeSupported()) {
+            return bean.getCurrentThreadCpuTime();
+        } else {
+            throw new RuntimeException("CpuTime NOT Supported");
+        }
+    }
+
 }


### PR DESCRIPTION
- Added timer per game for agent, which is updated when agent is asked for a decision.
- Timer supports increment (time added after a decision is made)
- Timeout checks in main Game loop, which points to a function to either disqualify or play a random action for the player
- Time defined per game type (but not final, so it can be set differently for different runs), initialised in the FM.setup() (so it's reset when the game is reset)
- New timing class (ElapsedCpuChessTimer) to allow for pausing/resuming a player's clock and keeping track of overall remaining time