### PR TITLE
ColtExpress copy() fixes, plus COMPETITION_MODE changes

### DIFF
--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -5,6 +5,7 @@ import utilities.Hash;
 public class CoreConstants {
     public final static boolean VERBOSE = false;
     public final static boolean PARTIAL_OBSERVABLE = true;
+    public final static boolean COMPETITION_MODE = false;
     public final static boolean DISQUALIFY_PLAYER_ON_ILLEGAL_ACTION_PLAYED = false;
     public final static boolean ALWAYS_DISPLAY_FULL_OBSERVABLE = false;
     public final static boolean ALWAYS_DISPLAY_CURRENT_PLAYER = false;

--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -8,16 +8,17 @@ import games.GameType;
 import players.human.ActionController;
 import players.human.HumanGUIPlayer;
 import players.mcts.MCTSParams;
-import players.mcts.MCTSPlayer;
-import players.rmhc.RMHCPlayer;
 import players.simple.RandomPlayer;
-import utilities.*;
+import utilities.Pair;
+import utilities.TAGStatSummary;
+import utilities.Utils;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import static core.CoreConstants.*;
-import static games.GameType.*;
+import static games.GameType.DotsAndBoxes;
 
 public class Game {
 
@@ -245,6 +246,10 @@ public class Game {
                             agentTime += (System.nanoTime() - s);
                             nDecisions++;
                         }
+                    }
+                    if (COMPETITION_MODE && !observedActions.contains(action)) {
+                        System.out.printf("Action played that was not in the list of available actions: %s%n", action.getString(gameState));
+                        action = null;
                     }
                     AbstractAction finalAction = action;
                     listeners.forEach(l -> l.onEvent(GameEvents.ACTION_CHOSEN, gameState, finalAction));

--- a/src/main/java/core/components/PartialObservableDeck.java
+++ b/src/main/java/core/components/PartialObservableDeck.java
@@ -53,6 +53,8 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
     /**
      * Retrieves the components in this deck visible by the given player.
      *
+     * It always returns a List of the correct length, but with a NULL entry for hidden components
+     *
      * @param playerID - ID of player observing the deck.
      * @return - ArrayList of components observed by the player.
      */

--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -65,7 +65,7 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
 
             cegs.playerHandCards.add(playerHand);
 
-            Deck<Loot> loot = new Deck<>("playerLoot" + playerIndex, playerIndex, VisibilityMode.VISIBLE_TO_ALL);
+            Deck<Loot> loot = new Deck<>("playerLoot" + playerIndex, playerIndex, VisibilityMode.HIDDEN_TO_ALL);
             for (Group<LootType, Integer, Integer> e: cep.playerStartLoot) {
                 LootType lootType = e.a;
                 int value = e.b;
@@ -89,24 +89,22 @@ public class ColtExpressForwardModel extends AbstractForwardModel {
     private void setupRounds(ColtExpressGameState cegs, ColtExpressParameters cep){
         cegs.rounds = new PartialObservableDeck<>("Rounds", -1, cegs.getNPlayers());
 
+        // Add 1 random end round card
+        // A deck works on a First In Last Out basis - so we deal the last card to be drawn first (it goes to the bottom of the deck)
+        cegs.rounds.add(cegs.getRandomEndRoundCard(cep));
+
         // Add random round cards
-        ArrayList<Integer> availableRounds = new ArrayList<>();
-        for (int i = 0; i < cep.roundCards.length; i++) {
-            availableRounds.add(i);
-        }
+        ArrayList<ColtExpressTypes.RegularRoundCard> availableRounds = new ArrayList<>(Arrays.asList(cep.roundCards));
         for (int i = 0; i < cep.nMaxRounds-1; i++) {
             Random r = new Random(cep.getRandomSeed() + cegs.getTurnOrder().getRoundCounter() + i);
             int choice = r.nextInt(availableRounds.size());
-            cegs.rounds.add(cegs.getRoundCard(cep, choice, cegs.getNPlayers()));
-            availableRounds.remove(Integer.valueOf(choice));
+            cegs.rounds.add(cegs.getRoundCard(availableRounds.get(choice), cegs.getNPlayers()));
+            availableRounds.remove(availableRounds.get(choice));
         }
         // set first card to be visible
         boolean[] allTrue = new boolean[cegs.getNPlayers()];
         Arrays.fill(allTrue, true);
         cegs.rounds.setVisibilityOfComponent(0, allTrue);
-
-        // Add 1 random end round card
-        cegs.rounds.add(cegs.getRandomEndRoundCard(cep, cegs.getTurnOrder().getRoundCounter()));
     }
 
     @Override

--- a/src/main/java/games/coltexpress/ColtExpressGame.java
+++ b/src/main/java/games/coltexpress/ColtExpressGame.java
@@ -1,10 +1,13 @@
 package games.coltexpress;
 
+import core.AbstractForwardModel;
 import core.AbstractGameState;
 import core.AbstractPlayer;
-import core.AbstractForwardModel;
 import core.Game;
 import games.GameType;
+import games.coltexpress.gui.ColtExpressGUI;
+import players.human.ActionController;
+import players.human.HumanGUIPlayer;
 import players.simple.RandomPlayer;
 import utilities.Utils;
 
@@ -24,7 +27,8 @@ public class ColtExpressGame extends Game {
     public static void main(String[] args){
         ArrayList<AbstractPlayer> agents = new ArrayList<>();
         agents.add(new RandomPlayer());
-        agents.add(new RandomPlayer());
+        ActionController ac = new ActionController();
+        agents.add(new HumanGUIPlayer(ac));
         agents.add(new RandomPlayer());
         agents.add(new RandomPlayer());
 
@@ -34,7 +38,7 @@ public class ColtExpressGame extends Game {
             ColtExpressGameState tmp_gameState = new ColtExpressGameState(params, agents.size());
 
             Game game = new ColtExpressGame(agents, forwardModel, tmp_gameState);
-            game.run(null);
+            game.run(new ColtExpressGUI(game, ac, 1));
             ColtExpressGameState gameState = (ColtExpressGameState) game.getGameState();
 
             //gameState.printToConsole();

--- a/src/main/java/games/coltexpress/ColtExpressGameState.java
+++ b/src/main/java/games/coltexpress/ColtExpressGameState.java
@@ -19,6 +19,7 @@ import java.util.*;
 
 import static core.CoreConstants.PARTIAL_OBSERVABLE;
 import static core.CoreConstants.VisibilityMode;
+import static java.util.stream.Collectors.toList;
 
 public class ColtExpressGameState extends AbstractGameState implements IPrintable {
 
@@ -46,11 +47,14 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
     // The round cards
     PartialObservableDeck<RoundCard> rounds;
 
+    Random rnd;
+
     public ColtExpressGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, new ColtExpressTurnOrder(nPlayers, ((ColtExpressParameters) gameParameters).nMaxRounds));
         gamePhase = ColtExpressGamePhase.PlanActions;
         trainCompartments = new LinkedList<>();
         playerPlayingBelle = -1;
+        rnd = new Random(gameParameters.getRandomSeed());
     }
 
     @Override
@@ -95,7 +99,6 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
         }
 
         if (PARTIAL_OBSERVABLE && playerId != -1) {
-            Random r = new Random(copy.gameParameters.getRandomSeed());
             for (int i = 0; i < getNPlayers(); i++) {
                 if (i != playerId) {
                     // Other player hands are hidden, but it's known what's in a player's deck
@@ -103,7 +106,7 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
                     copy.playerDecks.get(i).add(copy.playerHandCards.get(i));
                     int nCardsInHand = copy.playerHandCards.get(i).getSize();
                     copy.playerHandCards.get(i).clear();
-                    copy.playerDecks.get(i).shuffle(r);
+                    copy.playerDecks.get(i).shuffle(rnd);
                     for (int j = 0; j < nCardsInHand; j++) {
                         copy.playerHandCards.get(i).add(copy.playerDecks.get(i).draw());
                     }
@@ -117,7 +120,7 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
                     // Random value for loot of this same type
                     Loot realLoot = playerLoot.get(i).get(j);
                     ArrayList<Pair<Integer,Integer>> lootOptions = ((ColtExpressParameters)copy.gameParameters).loot.get(realLoot.getLootType());
-                    int randomValue = lootOptions.get(r.nextInt(lootOptions.size())).a;
+                    int randomValue = lootOptions.get(rnd.nextInt(lootOptions.size())).a;
                     dLoot.add(new Loot(realLoot.getLootType(), randomValue));
                 }
             }
@@ -132,14 +135,14 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
                     // Random value for loot of this same type
                     Loot realLoot = realCompartment.lootOnTop.get(j);
                     ArrayList<Pair<Integer,Integer>> lootOptions = ((ColtExpressParameters)copy.gameParameters).loot.get(realLoot.getLootType());
-                    int randomValue = lootOptions.get(r.nextInt(lootOptions.size())).a;
+                    int randomValue = lootOptions.get(rnd.nextInt(lootOptions.size())).a;
                     copyCompartment.lootOnTop.add(new Loot(realLoot.getLootType(), randomValue));
                 }
                 for (int j = 0; j < realCompartment.lootInside.getSize(); j++) {
                     // Random value for loot of this same type
                     Loot realLoot = realCompartment.lootInside.get(j);
                     ArrayList<Pair<Integer,Integer>> lootOptions = ((ColtExpressParameters)copy.gameParameters).loot.get(realLoot.getLootType());
-                    int randomValue = lootOptions.get(r.nextInt(lootOptions.size())).a;
+                    int randomValue = lootOptions.get(rnd.nextInt(lootOptions.size())).a;
                     copyCompartment.lootInside.add(new Loot(realLoot.getLootType(), randomValue));
                 }
             }
@@ -164,7 +167,7 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
             // Then we randomise the invisible ones
             for (Map.Entry<Integer, ArrayList<Integer>> e: cardReplacements.entrySet()) {
                 // loop over each player, and shuffle their decks (which now includes all cards we can't see)
-                copy.playerDecks.get(e.getKey()).shuffle(r);
+                copy.playerDecks.get(e.getKey()).shuffle(rnd);
                 Deck<ColtExpressCard> bulletCards = new Deck<>("tempDeck", VisibilityMode.HIDDEN_TO_ALL);
                 for (int i: e.getValue()) {
                     // This might be a bullet card...
@@ -178,15 +181,21 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
                 }
                 // then we put the bullet cards back into the player deck and reshuffle
                 copy.playerDecks.get(e.getKey()).add(bulletCards);
-                copy.playerDecks.get(e.getKey()).shuffle(r);
+                copy.playerDecks.get(e.getKey()).shuffle(rnd);
             }
 
             // Round cards are hidden for subsequent rounds, randomize those
-            for (int i = getTurnOrder().getRoundCounter()+1; i < rounds.getSize(); i++) {
-                if (i != rounds.getSize() -1) {
-                    copy.rounds.setComponent(i, getRandomRoundCard((ColtExpressParameters) getGameParameters(), i));
-                } else {
-                    copy.rounds.setComponent(i, getRandomEndRoundCard((ColtExpressParameters) getGameParameters(), i));
+            // We exclude any visible RoundCard
+            List<RoundCard> exclusionList = copy.rounds.getVisibleComponents(playerId).stream()
+                    .filter(Objects::nonNull).collect(toList());
+            for (int i = 0; i < rounds.getSize(); i++) {
+                if (!rounds.isComponentVisible(i, playerId)) {
+                    if (i == rounds.getSize() - 1) { // last card, so use an End Round Card
+                        copy.rounds.setComponent(i, getRandomEndRoundCard((ColtExpressParameters) getGameParameters()));
+                    } else {
+                        copy.rounds.setComponent(i, getRandomRoundCard((ColtExpressParameters) getGameParameters(), i, exclusionList));
+                        exclusionList.add(copy.rounds.get(i));
+                    }
                 }
             }
         }
@@ -305,7 +314,7 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
     public List<Deck<ColtExpressCard>> getPlayerDecks() {
         return playerDecks;
     }
-    public Deck<RoundCard> getRounds() {
+    public PartialObservableDeck<RoundCard> getRounds() {
         return rounds;
     }
     public HashMap<Integer, CharacterType> getPlayerCharacters() {
@@ -379,9 +388,9 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
      * Helper getter methods for round card composition.
      */
 
-    RoundCard getRandomEndRoundCard(ColtExpressParameters cep, int i) {
+    RoundCard getRandomEndRoundCard(ColtExpressParameters cep) {
         int nEndCards = cep.endRoundCards.length;
-        int choice = new Random(cep.getRandomSeed() + i).nextInt(nEndCards);
+        int choice = rnd.nextInt(nEndCards);
         return getEndRoundCard(cep, choice);
     }
 
@@ -394,19 +403,19 @@ public class ColtExpressGameState extends AbstractGameState implements IPrintabl
         return null;
     }
 
-    RoundCard getRandomRoundCard(ColtExpressParameters cep, int i) {
-        int nRoundCards = cep.roundCards.length;
-        int choice = new Random(cep.getRandomSeed() + i).nextInt(nRoundCards);
-        return getRoundCard(cep, choice, getNPlayers());
+    RoundCard getRandomRoundCard(ColtExpressParameters cep, int i, List<RoundCard> exclusionList) {
+        List<String> namesToExclude = exclusionList.stream().map(RoundCard::getComponentName).collect(toList());
+        List<ColtExpressTypes.RegularRoundCard> availableTypes = Arrays.stream(cep.roundCards)
+                .filter(rc -> !namesToExclude.contains(rc.name())).collect(toList());
+        int nRoundCards = availableTypes.size();
+        int choice = rnd.nextInt(nRoundCards);
+        return getRoundCard(availableTypes.get(choice), getNPlayers());
     }
 
-    RoundCard getRoundCard(ColtExpressParameters cep, int idx, int nPlayers) {
-        if (idx >= 0 && idx < cep.roundCards.length) {
-            RoundCard.TurnType[] turnTypes = cep.roundCards[idx].getTurnTypeSequence(nPlayers);
-            AbstractAction event = cep.roundCards[idx].getEndCardEvent();
-            return new RoundCard(cep.roundCards[idx].name(), turnTypes, event);
-        }
-        return null;
+    RoundCard getRoundCard(ColtExpressTypes.RegularRoundCard cardType, int nPlayers) {
+        RoundCard.TurnType[] turnTypes = cardType.getTurnTypeSequence(nPlayers);
+        AbstractAction event = cardType.getEndCardEvent();
+        return new RoundCard(cardType.name(), turnTypes, event);
     }
 
 }

--- a/src/main/java/games/coltexpress/components/Compartment.java
+++ b/src/main/java/games/coltexpress/components/Compartment.java
@@ -42,8 +42,8 @@ public class Compartment extends Component implements IComponentContainer<Deck<L
 
     public Compartment(int nPlayers, int compartmentID, int which, ColtExpressParameters cep){
         super(Utils.ComponentType.BOARD_NODE);
-        this.lootInside = new Deck<>("lootInside", VisibilityMode.VISIBLE_TO_ALL);
-        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.VISIBLE_TO_ALL);
+        this.lootInside = new Deck<>("lootInside", VisibilityMode.HIDDEN_TO_ALL);
+        this.lootOnTop = new Deck<>("lootOntop", VisibilityMode.HIDDEN_TO_ALL);
         this.nPlayers = nPlayers;
         this.compartmentID = compartmentID;
         playersInsideCompartment = new HashSet<>();

--- a/src/main/java/games/coltexpress/test/RoundCardVisibilityAndShuffling.java
+++ b/src/main/java/games/coltexpress/test/RoundCardVisibilityAndShuffling.java
@@ -1,0 +1,93 @@
+package games.coltexpress.test;
+
+import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.CoreConstants;
+import core.actions.AbstractAction;
+import core.interfaces.IGameListener;
+import games.coltexpress.ColtExpressForwardModel;
+import games.coltexpress.ColtExpressGame;
+import games.coltexpress.ColtExpressGameState;
+import games.coltexpress.ColtExpressParameters;
+import games.coltexpress.cards.RoundCard;
+import org.junit.Test;
+import players.simple.RandomPlayer;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Objects;
+
+import static core.CoreConstants.GameEvents.ROUND_OVER;
+import static java.util.stream.Collectors.toList;
+import static org.junit.Assert.*;
+
+public class RoundCardVisibilityAndShuffling {
+
+    List<AbstractPlayer> players = Arrays.asList(new RandomPlayer(),
+            new RandomPlayer(),
+            new RandomPlayer());
+
+    @Test
+    public void testVisibilityAndShuffleEachRound() {
+        ColtExpressGame game = new ColtExpressGame(players,
+                new ColtExpressForwardModel(),
+                new ColtExpressGameState(new ColtExpressParameters(6), 3));
+
+        // We now run through Game making random decision. Each time the round changes, we copy the state x10 and
+        // check shuffling. The work is done in TestRoundEndListener()
+        game.addListener(new TestRoundEndListener());
+
+        game.run();
+    }
+
+    static class TestRoundEndListener implements IGameListener {
+        @Override
+        public void onEvent(CoreConstants.GameEvents type, AbstractGameState gameState, AbstractAction action) {
+            if (type == ROUND_OVER) {
+                ColtExpressGameState state = (ColtExpressGameState) gameState;
+                long visibleRoundCards = state.getRounds().getVisibleComponents(0).stream().filter(Objects::nonNull).count();
+       //         System.out.printf("End of Round: %d, Visible Cards: %d%n", state.getTurnOrder().getRoundCounter(), visibleRoundCards);
+                for (int i = 0; i < state.getTurnOrder().getRoundCounter(); i++)
+                    assertTrue(state.getRounds().getVisibilityForPlayer(i, 0));
+                assertEquals(visibleRoundCards, state.getTurnOrder().getRoundCounter() + 1);
+
+                // 1 card visible at end of Round 0, and so on.
+
+                int matches = 0, nonMatches = 0;
+                List<String> visibleCards = state.getRounds().getVisibleComponents(0).stream()
+                        .filter(Objects::nonNull)
+                        .map(RoundCard::getComponentName)
+                        .collect(toList());
+
+                for (int loop = 0; loop < 30; loop++) {
+                    ColtExpressGameState copyState = (ColtExpressGameState) state.copy(0);
+                    assertEquals(visibleRoundCards, copyState.getTurnOrder().getRoundCounter() + 1);
+
+                    // this relies on the fact that the visible cards occur first, followed by the invisible ones
+                    for (int i = 0; i < copyState.getRounds().getSize(); i++) {
+                        for (int j = 0; j < 3; j++)
+                            assertEquals(state.getRounds().getVisibilityOfComponent(i)[j], copyState.getRounds().getVisibilityOfComponent(i)[j]);
+                        RoundCard roundCard = state.getRounds().get(i);
+                        if (state.getRounds().isComponentVisible(i, 0)) {
+                            assertEquals(roundCard, copyState.getRounds().get(i));
+                        } else {
+                            // We need to check Component Name, as equality also checks componentID, which will not match
+                            if (roundCard.getComponentName().equals(copyState.getRounds().get(i).getComponentName()))
+                                matches++; // it is possible for the card to be identical, but should be rare...we check this in aggregate later
+                            else
+                                nonMatches++; // the most likely outcome
+                            // we can be confident that none of the visible cards should be shuffled into an invisible space
+                            assertFalse(visibleCards.contains(copyState.getRounds().get(i).getComponentName()));
+                        }
+                    }
+                }
+          //      System.out.printf("Matches: %d of %d%n", matches, matches + nonMatches);
+                if (visibleRoundCards < 5) {// on the last round we know everything
+                    assertTrue(nonMatches > matches);
+                    assertTrue(matches > 0); // we should have something match by chance!
+                }
+            }
+
+        }
+    }
+}


### PR DESCRIPTION
A few things in here:
1) COMPETITION_MODE. This does two additional things.
 a) deletes history when copying a state from a player perspective to prevent any accidental hidden information leakage. By defining the purpose of History to be for debugging and game spectating we can avoid calling this a hack.
 b) Checks that the Action provided by the Agent in Game is one of the ones that was provided!

2) Fixes to ColtExpress
 a) Loot now correctly HIDDEN_TO_ALL (this was my mistake)
 b) State initialisation in CE was incorrectly putting the EndRound card first! (Due to an easy mistake as adding a card *last* to a Deck actually puts it in the first position.)
 c) the _copy(id) method in ColtExpress always gave the same redeterminisation every time it was called. This was because it initialised a new Random number generator on each call to _copy(), and used the same seed each time. Now fixed so that calling it 100 times will give you 100 independent shuffles.
 d) Also, when shuffling a state, the RoundCards did not take account of those that were visible. So it would be possible for one to be incorrectly duplicated and present twice (one visible, one hidden).
 e) Tests added for the redetermininisation changes.