### PR TITLE
Multi NTBEA

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,11 +37,11 @@
             <artifactId>xchart</artifactId>
             <version>3.6.4</version>
         </dependency>
-        <dependency>
-            <groupId>com.github.hopshackle</groupId>
-            <artifactId>NTBEA</artifactId>
-            <version>0.2.1</version>
-        </dependency>
+<!--        <dependency>-->
+<!--            <groupId>com.github.hopshackle</groupId>-->
+<!--            <artifactId>NTBEA</artifactId>-->
+<!--            <version>0.2.1</version>-->
+<!--        </dependency>-->
     </dependencies>
 
 </project>

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -16,6 +16,7 @@ import java.util.*;
 
 import static java.util.stream.Collectors.toList;
 import static utilities.Utils.GameResult.GAME_ONGOING;
+import static utilities.Utils.GameResult.WIN;
 
 
 /**
@@ -238,14 +239,39 @@ public abstract class AbstractGameState {
     protected abstract double _getHeuristicScore(int playerId);
 
     /**
-     * This provides the current score in game turns. This will only be relevant for games that have the concept
+     * This provides the current score in game terms. This will only be relevant for games that have the concept
      * of victory points, etc.
      * If a game does not support this directly, then just return 0.0
      * (Unlike _getHeuristicScore(), there is no constraint on the range..whatever the game rules say.
+     *
      * @param playerId - player observing the state.
      * @return - double, score of current state
      */
     public abstract double getGameScore(int playerId);
+
+    /**
+     * Returns the ordinal position of a player using getGameScore().
+     *
+     * If a Game does not have a score, but does have the concept of player position (e.g. in a race)
+     * then this method should be overridden.
+     * This may also apply for games with important tie-breaking rules not visible in the raw score.
+     *
+     * @param playerId player ID
+     * @return The ordinal position of the player; 1 is 1st, 2 is 2nd and so on.
+     */
+    public int getOrdinalPosition(int playerId) {
+        if (playerResults[playerId] == Utils.GameResult.WIN)
+            return 1;
+        double playerScore = getGameScore(playerId);
+        int ordinal = 1;
+        for (int i = 0, n = getNPlayers(); i < n; i++) {
+            if (getGameScore(i) > playerScore)
+                ordinal++;
+        }
+        if (ordinal == 1 && !isNotTerminal() && playerResults[playerId] != Utils.GameResult.WIN)
+            ordinal = 1 + (int) Arrays.stream(playerResults).filter(r -> r == WIN).count();
+        return ordinal;
+    }
 
     /**
      * Provide a list of component IDs which are hidden in partially observable copies of games.

--- a/src/main/java/evaluation/GameMultiPlayerEvaluator.java
+++ b/src/main/java/evaluation/GameMultiPlayerEvaluator.java
@@ -67,8 +67,8 @@ public class GameMultiPlayerEvaluator implements MultiSolutionEvaluator {
      */
     @Override
     public double[] evaluate(List<int[]> settings) {
-//        System.out.printf("Starting evaluation %d of %n\t%s at %tT%n", nEvals,
-//                settings.stream().map(Arrays::toString).collect(joining(",\n\t")), System.currentTimeMillis());
+  //      System.out.printf("Starting evaluation %d of %n\t%s at %tT%n", nEvals,
+   //             settings.stream().map(Arrays::toString).collect(Collectors.joining(",\n\t")), System.currentTimeMillis());
 
         List<AbstractPlayer> allPlayers = new ArrayList<>(nPlayers);
 
@@ -89,7 +89,7 @@ public class GameMultiPlayerEvaluator implements MultiSolutionEvaluator {
         for (int i = 0; i < nPlayers; i++)
             retValue[i] = evalFn.apply(finalState, i);
 
-    //    System.out.printf("Result : %s%n", Arrays.toString(retValue));
+  //      System.out.printf("Result : %s%n", Arrays.toString(retValue));
         return retValue;
     }
 

--- a/src/main/java/evaluation/GameMultiPlayerEvaluator.java
+++ b/src/main/java/evaluation/GameMultiPlayerEvaluator.java
@@ -1,0 +1,104 @@
+package evaluation;
+
+import core.AbstractGameState;
+import core.AbstractPlayer;
+import core.Game;
+import core.interfaces.IStatisticLogger;
+import evodef.MultiSolutionEvaluator;
+import evodef.SearchSpace;
+import games.GameType;
+import utilities.SummaryLogger;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+/**
+ * Game Evaluator is used for NTBEA optimisation of parameters. It implements the SolutionEvaluator interface.
+ * On each NTBEA trial the evaluate(int[] settings) function is called with the set of parameters to try next.
+ * The meaning of these settings is encapsulated in the AgentSearchSpace, as this will vary with whatever is being
+ * optimised.
+ */
+public class GameMultiPlayerEvaluator implements MultiSolutionEvaluator {
+
+    GameType game;
+    ITPSearchSpace searchSpace;
+    int nPlayers;
+    int nEvals = 0;
+    Random rnd;
+    public boolean reportStatistics;
+    public IStatisticLogger statsLogger = new SummaryLogger();
+
+    /**
+     * GameEvaluator
+     *
+     * @param game             The game that will be run for each trial. After each trial it is reset().
+     * @param parametersToTune The ITunableParameters object that defines the parameter space we are optimising over.
+     *                         This will vary with whatever is being optimised.
+     * @param seed             Random seed to use
+     */
+    public <T> GameMultiPlayerEvaluator(GameType game, ITPSearchSpace parametersToTune,
+                                        int nPlayers,
+                                        long seed) {
+        this.game = game;
+        this.searchSpace = parametersToTune;
+        this.nPlayers = nPlayers;
+        this.rnd = new Random(seed);
+    }
+
+    @Override
+    public void reset() {
+        nEvals = 0;
+    }
+
+
+    /**
+     * There should never be a need to call this method directly. It is called by the NTBEA framework as needed.
+     *
+     * @param settings is an integer array per player corresponding to the searchSpace.
+     *                 The length of settings corresponds to searchSpace.nDims()
+     *                 the value of settings[i] is a number in [0, searchSpace.nValues(i)]
+     *                 the actual underlying parameter value can be found with searchSpace.value(i, settings[i])
+     * @return Returns the game score for the agent being optimised
+     */
+    @Override
+    public double[] evaluate(List<int[]> settings) {
+/*        System.out.println(String.format("Starting evaluation %d of %s at %tT", nEvals,
+                Arrays.toString(settings), System.currentTimeMillis()));*/
+
+        List<AbstractPlayer> allPlayers = new ArrayList<>(nPlayers);
+
+        for (int i = 0; i < nPlayers; i++) {
+            AbstractPlayer tunedPlayer = (AbstractPlayer) searchSpace.getAgent(settings.get(i));
+            if (reportStatistics) tunedPlayer.setStatsLogger(statsLogger);
+            allPlayers.add(tunedPlayer);
+        }
+
+        Game newGame = game.createGameInstance(nPlayers);
+        newGame.reset(allPlayers, rnd.nextLong());
+
+        newGame.run();
+        AbstractGameState finalState = newGame.getGameState();
+
+        nEvals++;
+        return finalState.getHeuristicScore(playerIndex);
+    }
+
+    /**
+     * @return The searchSpace
+     */
+    @Override
+    public SearchSpace searchSpace() {
+        return searchSpace;
+    }
+
+    /**
+     * @return The number of NTBEA iterations/trials that have been run so far
+     */
+    @Override
+    public int nEvals() {
+        return nEvals;
+    }
+
+
+}

--- a/src/main/java/evaluation/ParameterSearch.java
+++ b/src/main/java/evaluation/ParameterSearch.java
@@ -1,14 +1,11 @@
 package evaluation;
 
+import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.interfaces.ITunableParameters;
-import evodef.EvoAlg;
-import evodef.MultiSolutionEvaluator;
-import evodef.SearchSpace;
+import evodef.*;
 import games.GameType;
-import ntbea.MultiNTupleBanditEA;
-import ntbea.NTupleBanditEA;
-import ntbea.NTupleSystem;
+import ntbea.*;
 import org.json.simple.JSONObject;
 import players.PlayerFactory;
 import utilities.Pair;
@@ -19,10 +16,7 @@ import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Comparator;
-import java.util.List;
+import java.util.*;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 
@@ -43,9 +37,11 @@ public class ParameterSearch {
                         "\tevalGames=     The number of games to run with the best predicted setting to estimate its true value (default is 20% of NTBEA iterations) \n" +
                         "\topponent=      The agent used as opponent. Default is not to use a specific opponent, but use MultiNTBEA. \n" +
                         "\t               This can either be a json-format file detailing the parameters, or\n" +
-                        "\t               one of mcts|rmhc|random|osla|<className>  \n" +
+                        "\t               one of coop|mcts|rmhc|random|osla|<className>  \n" +
                         "\t               If className is specified, this must be the full name of a class implementing AbstractPlayer\n" +
-                        "\t               with a no-argument constructor\n" +
+                        "\t               with a no-argument constructor.\n" +
+                        "\t               'coop' means that the agent being tuned is used for all agents (i.e. if co-operative)\n" +
+                        "\teval=          Score|Ordinal|Heuristic|Win specifies what we are optimising. Defaults to Win.\n" +
                         "\tuseThreeTuples If specified then we use 3-tuples as well as 1-, 2- and N-tuples \n" +
                         "\tkExplore=      The k to use in NTBEA - defaults to 1.0 - this makes sense for win/lose games with a score in {0, 1}\n" +
                         "\t               For scores with larger ranges, we recommend scaling kExplore appropriately.\n" +
@@ -137,6 +133,7 @@ public class ParameterSearch {
         int nPlayers = getArg(args, "nPlayers", game.getMinPlayers());
         long seed = getArg(args, "seed", System.currentTimeMillis());
         String logfile = getArg(args, "logFile", "");
+        String evalMethod = getArg(args, "eval", "Win");
 
         ITPSearchSpace searchSpace = (ITPSearchSpace) landscapeModel.getSearchSpace();
         int searchSpaceSize = IntStream.range(0, searchSpace.nDims()).reduce(1, (acc, i) -> acc * searchSpace.nValues(i));
@@ -146,18 +143,33 @@ public class ParameterSearch {
 
         // Set up opponents
         List<AbstractPlayer> opponents = new ArrayList<>();
-        for (int i = 0; i < nPlayers; i++) {
-            AbstractPlayer opponent = PlayerFactory.createPlayer(opponentDescriptor);
-            opponents.add(opponent);
+        // if we are in coop mode, then we have no opponents. This is indicated by leaving the list empty.
+        if (!opponentDescriptor.equals("coop")) {
+            for (int i = 0; i < nPlayers; i++) {
+                AbstractPlayer opponent = opponentDescriptor.isEmpty() ? new RandomPlayer() : PlayerFactory.createPlayer(opponentDescriptor);
+                opponents.add(opponent);
+            }
         }
 
         // TODO: Add Game tuning objectives that measure how close the result is, etc.
+        BiFunction<AbstractGameState, Integer, Double> evalFunction = null;
+        if (evalMethod.equals("Win"))
+            evalFunction = (state, playerId) -> state.getPlayerResults()[playerId].value;
+        if (evalMethod.equals("Score"))
+            evalFunction = AbstractGameState::getGameScore;
+        if (evalMethod.equals("Heuristic"))
+            evalFunction = AbstractGameState::getHeuristicScore;
+        if (evalMethod.equals("Ordinal")) // we maximise, so the lowest ordinal position of 1 is best
+            evalFunction = (state, playerId) -> -(double) state.getOrdinalPosition(playerId);
+        if (evalFunction == null)
+            throw new AssertionError("Invalid evaluation method provided: " + evalMethod);
 
         // Initialise the GameEvaluator that will do all the heavy lifting
         GameEvaluator evaluator = new GameEvaluator(
                 game,
                 searchSpace,
                 nPlayers,
+                evalFunction,
                 opponents,
                 seed,
                 true

--- a/src/main/java/evaluation/ParameterSearch.java
+++ b/src/main/java/evaluation/ParameterSearch.java
@@ -371,7 +371,7 @@ public class ParameterSearch {
         Set<int[]> bestSet = new HashSet<>();
         int diverseSize = allTuples.size();
         int optimalSize = 9;
-        for (double k : Arrays.asList(0.1, 0.03, 0.02, 0.01, 0.003, 0.001, 0.0003)) {
+        for (double k : Arrays.asList(0.0001, 0.0003, 0.001, 0.003, 0.01, 0.03, 0.1, 0.3)) {
             double modK = k * kExplore;
             Set<int[]> diverseGood = new HashSet<>();
             diverseGood.add(best);
@@ -388,12 +388,15 @@ public class ParameterSearch {
                     diverseGood.add(tuple);
                 }
             }
+            System.out.printf("k = %.6f gives %d tuples out of %d%n", modK, diverseGood.size(), allTuples.size());
             // We
             if (Math.abs(Math.sqrt(optimalSize) - Math.sqrt(diverseGood.size())) < Math.abs(Math.sqrt(optimalSize) - Math.sqrt(diverseSize))) {
                 diverseSize = diverseGood.size();
                 bestSet = diverseGood;
             }
-            System.out.printf("k = %.6f gives %d tuples out of %d%n", modK, diverseGood.size(), allTuples.size());
+            // we can stop once we have at least the optimal number (to avoid thrashing compute)
+            if (diverseGood.size() >= optimalSize)
+                break;
         }
         System.out.println("\nBest settings with diversity:");
         for (int[] settings : bestSet) {

--- a/src/main/java/games/coltexpress/test/RoundCardVisibilityAndShuffling.java
+++ b/src/main/java/games/coltexpress/test/RoundCardVisibilityAndShuffling.java
@@ -3,6 +3,7 @@ package games.coltexpress.test;
 import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.CoreConstants;
+import core.Game;
 import core.actions.AbstractAction;
 import core.interfaces.IGameListener;
 import games.coltexpress.ColtExpressForwardModel;
@@ -41,6 +42,11 @@ public class RoundCardVisibilityAndShuffling {
     }
 
     static class TestRoundEndListener implements IGameListener {
+        @Override
+        public void onGameEvent(CoreConstants.GameEvents type, Game game) {
+
+        }
+
         @Override
         public void onEvent(CoreConstants.GameEvents type, AbstractGameState gameState, AbstractAction action) {
             if (type == ROUND_OVER) {

--- a/src/main/java/games/pandemic/PandemicGameState.java
+++ b/src/main/java/games/pandemic/PandemicGameState.java
@@ -106,7 +106,7 @@ public class PandemicGameState extends AbstractGameState implements IFeatureRepr
     }
 
     /**
-     * This provides the current score in game turns. This will only be relevant for games that have the concept
+     * This provides the current score in game terms. This will only be relevant for games that have the concept
      * of victory points, etc.
      * If a game does not support this directly, then just return 0.0
      *


### PR DESCRIPTION
This incorporates a new NTBEA library that supports 'MultiNTBEA'.

MultiNTBEA is a modification to cater for Multiplayer games (or other optimisation problems). The change over vanilla NTBEA is that in each game (trial), a separate point in parameter space is selected independently for each of the players, but using the same underlying NTuple model. 

This means that in a 4-Player game, say, to optimise MCTS parameters, then each trial uses four differently parameterised MCTS agents. Once the game is complete, the NTuple model is updated with all four points. This means that the game contributes four times as much data to the model compared to a fixed opponent (but also takes a lot longer if that fixed opponent is something computationally cheap like a Random player, or OSLA in some cases).

This also - hopefully - may give better quality parameter recommendations for the general case of an unknown opponent instead of overfitting to beat a fixed opponent (or whatever quality).

This is now the default setting for ParameterSearch if no 'opponent' parameter is specified. Additionally there is some diversity checking after a run is complete to highlight other points in the NTuple model that were very close to the winner in performance, but distant in parameter-space. This works by adding a parameter-setting, X,  to the 'diverse' list if:

NTupleValue(X) + k * ManhattanDistance(X, BEST) >= NTupleValue(BEST)

(for all BEST currently in the 'diverse' list). We cycle through values of k until we find one that gives us about nine parameter settings.
A HammingDistance could also be used (not implemented as yet), but *most* dimensions are discretizations of a continuous set of values, so have innate ordinality, and in this case a Manhattan distance seems fairer.

