### PR TITLE
Fixed shallow copy bug of Node classes

### DIFF
--- a/src/main/java/core/rules/Node.java
+++ b/src/main/java/core/rules/Node.java
@@ -20,6 +20,27 @@ public abstract class Node {
     }
 
     /**
+     * Copy constructor, does not copy parent node to avoid endless recursion in looping graphs.
+     * @param node - Node to be copied
+     */
+    public Node(Node node) {
+        this.id = node.id;
+        this.actionNode = node.actionNode;
+        this.nextPlayerNode = node.nextPlayerNode;
+        this.action = node.action;
+    }
+
+    /**
+     * Create a copy of the Node by calling subclass _copy()
+     * @return - New Node object with the same properties
+     */
+    public Node copy() {
+        return _copy();
+    }
+
+    protected abstract Node _copy();
+
+    /**
      * Executes the functionality of this node.
      * @param gs - game state to apply functionality in.
      * @return - Node, the next node to execute afterwards.

--- a/src/main/java/core/rules/nodetypes/BranchingRuleNode.java
+++ b/src/main/java/core/rules/nodetypes/BranchingRuleNode.java
@@ -28,6 +28,14 @@ public abstract class BranchingRuleNode extends RuleNode {
     }
 
     /**
+     * Copy constructor, does not copy childYes or childNo to avoid endless recursion in looping graphs.
+     * @param node - Node to be copied
+     */
+    protected BranchingRuleNode(BranchingRuleNode node) {
+        super(node);
+    }
+
+    /**
      * Apply the functionality of the rule in the given game state, and decide which of the children is to be executed
      * next.
      * @param gs - game state to modify.

--- a/src/main/java/core/rules/nodetypes/ConditionNode.java
+++ b/src/main/java/core/rules/nodetypes/ConditionNode.java
@@ -16,6 +16,18 @@ public abstract class ConditionNode extends Node {
     boolean passed;  // The result of the test, true if condition test returns true, false otherwise
 
     /**
+     * Copy constructor, does not copy childYes or childNo to avoid endless recursion in looping graphs.
+     * @param node - Node to be copied
+     */
+    protected ConditionNode(ConditionNode node) {
+        super(node);
+    }
+
+    public ConditionNode() {
+        super();
+    }
+
+    /**
      * Tests a condition given a game state, returns true if condition passes, false otherwise.
      * @param gs - game state to test condition in.
      * @return - boolean, the result of the condition test.

--- a/src/main/java/core/rules/nodetypes/RuleNode.java
+++ b/src/main/java/core/rules/nodetypes/RuleNode.java
@@ -25,6 +25,7 @@ public abstract class RuleNode extends Node {
         gameOverConditions = new ArrayList<>();
     }
 
+
     /**
      * Specialised constructor to use for rule nodes requiring actions.
      * @param actionNode - true if action node.
@@ -33,6 +34,15 @@ public abstract class RuleNode extends Node {
         super();
         this.actionNode = actionNode;
         gameOverConditions = new ArrayList<>();
+    }
+
+    /**
+     * Copy constructor, does not copy childNext to avoid endless recursion in looping graphs.
+     * @param node - Node to be copied
+     */
+    protected RuleNode(RuleNode node) {
+        super(node);
+        this.gameOverConditions = node.gameOverConditions;
     }
 
     /**

--- a/src/main/java/core/rules/rulenodes/EndPlayerTurn.java
+++ b/src/main/java/core/rules/rulenodes/EndPlayerTurn.java
@@ -1,6 +1,7 @@
 package core.rules.rulenodes;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 
 /**
@@ -12,10 +13,23 @@ public class EndPlayerTurn extends RuleNode {
         setNextPlayerNode();
     }
 
+    /**
+     * Copy constructor
+     * @param endPlayerTurn - Node to be copied
+     */
+    public EndPlayerTurn(EndPlayerTurn endPlayerTurn) {
+        super(endPlayerTurn);
+    }
+
     @Override
     protected boolean run(AbstractGameState gs) {
         gs.getTurnOrder().endPlayerTurn(gs);
         gs.setMainGamePhase();
         return true;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new EndPlayerTurn(this);
     }
 }

--- a/src/main/java/core/rules/rulenodes/ForceAllPlayerReaction.java
+++ b/src/main/java/core/rules/rulenodes/ForceAllPlayerReaction.java
@@ -1,6 +1,7 @@
 package core.rules.rulenodes;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import core.turnorders.ReactiveTurnOrder;
 
@@ -12,10 +13,27 @@ import static core.AbstractGameState.DefaultGamePhase.PlayerReaction;
  */
 public class ForceAllPlayerReaction extends RuleNode {
 
+    public ForceAllPlayerReaction() {
+        super();
+    }
+
+    /**
+     * Copy constructor
+     * @param forceAllPlayerReaction - Node to be copied
+     */
+    public ForceAllPlayerReaction(ForceAllPlayerReaction forceAllPlayerReaction) {
+        super(forceAllPlayerReaction);
+    }
+
     @Override
     protected boolean run(AbstractGameState gs) {
         ((ReactiveTurnOrder)gs.getTurnOrder()).addAllReactivePlayers(gs);
         gs.setGamePhase(PlayerReaction);
         return false;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new ForceAllPlayerReaction(this);
     }
 }

--- a/src/main/java/core/rules/rulenodes/PlayerAction.java
+++ b/src/main/java/core/rules/rulenodes/PlayerAction.java
@@ -1,6 +1,7 @@
 package core.rules.rulenodes;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 
 /**
@@ -13,6 +14,14 @@ public class PlayerAction extends RuleNode {
         super(true);
     }
 
+    /**
+     * Copy constructor
+     * @param playerAction - Node to be copied
+     */
+    public PlayerAction(PlayerAction playerAction) {
+        super(playerAction);
+    }
+
     @Override
     protected boolean run(AbstractGameState gs) {
         if (action != null) {
@@ -20,6 +29,11 @@ public class PlayerAction extends RuleNode {
             return true;
         }
         return false;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new PlayerAction(this);
     }
 
 }

--- a/src/main/java/games/pandemic/PandemicForwardModel.java
+++ b/src/main/java/games/pandemic/PandemicForwardModel.java
@@ -303,7 +303,7 @@ public class PandemicForwardModel extends AbstractRuleBasedForwardModel {
 
     @Override
     protected AbstractForwardModel _copy() {
-        return new PandemicForwardModel(root);
+        return new PandemicForwardModel(copyRoot());
     }
 
     @Override

--- a/src/main/java/games/pandemic/rules/conditions/ActionsPerTurnPlayed.java
+++ b/src/main/java/games/pandemic/rules/conditions/ActionsPerTurnPlayed.java
@@ -1,6 +1,7 @@
 package games.pandemic.rules.conditions;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.ConditionNode;
 import games.pandemic.PandemicTurnOrder;
 
@@ -12,8 +13,22 @@ public class ActionsPerTurnPlayed extends ConditionNode {
         this.n_actions = n_actions;
     }
 
+    /**
+     * Copy constructor
+     * @param actionsPerTurnPlayed - Node to be copied
+     */
+    public ActionsPerTurnPlayed(ActionsPerTurnPlayed actionsPerTurnPlayed) {
+        super(actionsPerTurnPlayed);
+        this.n_actions = actionsPerTurnPlayed.n_actions;
+    }
+
     @Override
     public boolean test(AbstractGameState gs) {
         return ((PandemicTurnOrder)gs.getTurnOrder()).getTurnStep() >= n_actions;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new ActionsPerTurnPlayed(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/conditions/EnoughDraws.java
+++ b/src/main/java/games/pandemic/rules/conditions/EnoughDraws.java
@@ -1,6 +1,7 @@
 package games.pandemic.rules.conditions;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.ConditionNode;
 import games.pandemic.PandemicGameState;
 
@@ -12,8 +13,22 @@ public class EnoughDraws extends ConditionNode {
         this.cards_to_draw = cards_to_draw;
     }
 
+    /**
+     * Copy constructor
+     * @param enoughDraws - Node to be copied
+     */
+    public EnoughDraws(EnoughDraws enoughDraws) {
+        super(enoughDraws);
+        this.cards_to_draw = enoughDraws.cards_to_draw;
+    }
+
     @Override
     public boolean test(AbstractGameState gs) {
         return ((PandemicGameState)gs).getNCardsDrawn() >= cards_to_draw;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new EnoughDraws(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/conditions/HasRPCard.java
+++ b/src/main/java/games/pandemic/rules/conditions/HasRPCard.java
@@ -4,6 +4,7 @@ import core.AbstractGameState;
 import core.components.Card;
 import core.components.Deck;
 import core.properties.PropertyString;
+import core.rules.Node;
 import core.rules.nodetypes.ConditionNode;
 import games.pandemic.PandemicGameState;
 
@@ -12,6 +13,18 @@ import static core.CoreConstants.playerHandHash;
 
 @SuppressWarnings("unchecked")
 public class HasRPCard extends ConditionNode {
+
+    public HasRPCard() {
+        super();
+    }
+
+    /**
+     * Copy constructor
+     * @param hasRPCard - Node to be copied
+     */
+    public HasRPCard(HasRPCard hasRPCard) {
+        super(hasRPCard);
+    }
 
     @Override
     protected boolean test(AbstractGameState gs) {
@@ -27,5 +40,10 @@ public class HasRPCard extends ConditionNode {
             }
         }
         return false;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new HasRPCard(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/conditions/IsEpidemic.java
+++ b/src/main/java/games/pandemic/rules/conditions/IsEpidemic.java
@@ -1,12 +1,31 @@
 package games.pandemic.rules.conditions;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.ConditionNode;
 import games.pandemic.PandemicGameState;
 
 public class IsEpidemic extends ConditionNode {
+
+    public IsEpidemic() {
+        super();
+    }
+
+    /**
+     * Copy constructor
+     * @param isEpidemic - Node to be copied
+     */
+    public IsEpidemic(IsEpidemic isEpidemic) {
+        super(isEpidemic);
+    }
+
     @Override
     public boolean test(AbstractGameState gs) {
         return ((PandemicGameState)gs).isEpidemic();
+    }
+
+    @Override
+    protected Node _copy() {
+        return new IsEpidemic(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/conditions/PlayerHandOverCapacity.java
+++ b/src/main/java/games/pandemic/rules/conditions/PlayerHandOverCapacity.java
@@ -3,6 +3,7 @@ package games.pandemic.rules.conditions;
 import core.AbstractGameState;
 import core.components.Card;
 import core.components.Deck;
+import core.rules.Node;
 import core.rules.nodetypes.ConditionNode;
 import games.pandemic.PandemicGameState;
 import games.pandemic.rules.rules.PlayerAction;
@@ -15,6 +16,15 @@ public class PlayerHandOverCapacity extends ConditionNode {
 
     public PlayerHandOverCapacity() {
         this.playerId = -2;  // Current player by default
+    }
+
+    /**
+     * Copy constructor
+     * @param playerHandOverCapacity - Node to be copied
+     */
+    public PlayerHandOverCapacity(PlayerHandOverCapacity playerHandOverCapacity) {
+        super(playerHandOverCapacity);
+        this.playerId = playerHandOverCapacity.playerId;
     }
 
     @Override
@@ -40,6 +50,11 @@ public class PlayerHandOverCapacity extends ConditionNode {
         }
 
         return playerDeck != null && playerDeck.isOverCapacity();
+    }
+
+    @Override
+    protected Node _copy() {
+        return new PlayerHandOverCapacity(this);
     }
 
 }

--- a/src/main/java/games/pandemic/rules/rules/DrawCards.java
+++ b/src/main/java/games/pandemic/rules/rules/DrawCards.java
@@ -5,6 +5,7 @@ import core.actions.DrawCard;
 import core.components.Card;
 import core.components.Deck;
 import core.properties.PropertyString;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import games.pandemic.PandemicConstants;
 import games.pandemic.PandemicGameState;
@@ -13,6 +14,18 @@ import static core.CoreConstants.nameHash;
 import static core.CoreConstants.playerHandHash;
 
 public class DrawCards extends RuleNode {
+
+    public DrawCards() {
+        super();
+    }
+
+    /**
+     * Copy constructor
+     * @param drawCards - Node to be copied
+     */
+    public DrawCards(DrawCards drawCards) {
+        super(drawCards);
+    }
 
     @Override
     public boolean run(AbstractGameState gs) {
@@ -43,5 +56,10 @@ public class DrawCards extends RuleNode {
             return true;
         }
         return false;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new DrawCards(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/EpidemicInfect.java
+++ b/src/main/java/games/pandemic/rules/rules/EpidemicInfect.java
@@ -4,6 +4,7 @@ import core.AbstractGameState;
 import core.components.Card;
 import core.components.Counter;
 import core.components.Deck;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import games.pandemic.PandemicGameState;
 import games.pandemic.actions.InfectCity;
@@ -20,6 +21,16 @@ public class EpidemicInfect extends RuleNode {
         this.max_cubes_per_city = max_cubes_per_city;
     }
 
+    /**
+     * Copy constructor
+     * @param epidemicInfect - Node to be copied
+     */
+    public EpidemicInfect(EpidemicInfect epidemicInfect) {
+        super(epidemicInfect);
+        this.n_cubes_epidemic = epidemicInfect.n_cubes_epidemic;
+        this.max_cubes_per_city = epidemicInfect.max_cubes_per_city;
+    }
+
     @Override
     protected boolean run(AbstractGameState gs) {
         // 1. infection counter idx ++
@@ -31,5 +42,9 @@ public class EpidemicInfect extends RuleNode {
         // 2. N cubes on bottom card in infection deck, then add this card on top of infection discard
         return new InfectCity(infectionDeck.getComponentID(), infectionDiscard.getComponentID(),
                 infectionDeck.getSize()-1, max_cubes_per_city, n_cubes_epidemic).execute(gs);
+    }
+
+    protected Node _copy() {
+        return new EpidemicInfect(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/EpidemicIntensify.java
+++ b/src/main/java/games/pandemic/rules/rules/EpidemicIntensify.java
@@ -3,6 +3,7 @@ package games.pandemic.rules.rules;
 import core.AbstractGameState;
 import core.components.Card;
 import core.components.Deck;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import games.pandemic.PandemicGameState;
 
@@ -20,6 +21,15 @@ public class EpidemicIntensify extends RuleNode {
         this.rnd = rnd;
     }
 
+    /**
+     * Copy constructor
+     * @param epidemicIntensify - Node to be copied
+     */
+    public EpidemicIntensify(EpidemicIntensify epidemicIntensify) {
+        super(epidemicIntensify);
+        this.rnd = epidemicIntensify.rnd;
+    }
+
     @Override
     protected boolean run(AbstractGameState gs) {
         PandemicGameState pgs = (PandemicGameState)gs;
@@ -30,5 +40,10 @@ public class EpidemicIntensify extends RuleNode {
         infectionDeck.add(infectionDiscard);
         infectionDiscard.clear();
         return true;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new EpidemicIntensify(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/ForceDiscardReaction.java
+++ b/src/main/java/games/pandemic/rules/rules/ForceDiscardReaction.java
@@ -3,6 +3,7 @@ package games.pandemic.rules.rules;
 import core.AbstractGameState;
 import core.components.Card;
 import core.components.Deck;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import games.pandemic.PandemicGameState;
 import games.pandemic.PandemicTurnOrder;
@@ -12,6 +13,18 @@ import static core.CoreConstants.playerHandHash;
 
 @SuppressWarnings("unchecked")
 public class ForceDiscardReaction extends RuleNode {
+
+    public ForceDiscardReaction(){
+        super();
+    }
+
+    /**
+     * Copy constructor
+     * @param forceDiscardReaction - Node to be copied
+     */
+    public ForceDiscardReaction(ForceDiscardReaction forceDiscardReaction){
+        super(forceDiscardReaction);
+    }
 
     @Override
     protected boolean run(AbstractGameState gs) {
@@ -24,5 +37,10 @@ public class ForceDiscardReaction extends RuleNode {
         }
         pgs.setGamePhase(DiscardReaction);
         return false;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new ForceDiscardReaction(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/ForceRPReaction.java
+++ b/src/main/java/games/pandemic/rules/rules/ForceRPReaction.java
@@ -1,6 +1,7 @@
 package games.pandemic.rules.rules;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import games.pandemic.PandemicTurnOrder;
 import core.components.Card;
@@ -14,6 +15,18 @@ import static core.CoreConstants.playerHandHash;
 
 @SuppressWarnings("unchecked")
 public class ForceRPReaction extends RuleNode {
+
+    public ForceRPReaction() {
+        super();
+    }
+
+    /**
+     * Copy constructor
+     * @param forceRPReaction - Node to be copied
+     */
+    public ForceRPReaction(ForceRPReaction forceRPReaction) {
+        super(forceRPReaction);
+    }
 
     @Override
     protected boolean run(AbstractGameState gs) {
@@ -33,5 +46,10 @@ public class ForceRPReaction extends RuleNode {
             }
         }
         return true;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new ForceRPReaction(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/InfectCities.java
+++ b/src/main/java/games/pandemic/rules/rules/InfectCities.java
@@ -4,6 +4,7 @@ import core.AbstractGameState;
 import core.components.Card;
 import core.components.Counter;
 import core.components.Deck;
+import core.rules.Node;
 import core.rules.nodetypes.RuleNode;
 import games.pandemic.PandemicGameState;
 import games.pandemic.actions.InfectCity;
@@ -20,6 +21,17 @@ public class InfectCities extends RuleNode {
         this.infection_rate = infection_rate;
         this.max_cubes_per_city = max_cubes_per_city;
         this.n_cubes_infection = n_cubes_infection;
+    }
+
+    /**
+     * Copy constructor
+     * @param infectCities - Node to be copied
+     */
+    public InfectCities(InfectCities infectCities) {
+        super(infectCities);
+        this.max_cubes_per_city = infectCities.max_cubes_per_city;
+        this.n_cubes_infection = infectCities.n_cubes_infection;
+        this.infection_rate = infectCities.infection_rate;
     }
 
     @Override
@@ -41,5 +53,10 @@ public class InfectCities extends RuleNode {
         ((PandemicGameState)gs).setEpidemic(false);
         ((PandemicGameState)gs).setNCardsDrawn(0);
         return true;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new InfectCities(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/NextPlayer.java
+++ b/src/main/java/games/pandemic/rules/rules/NextPlayer.java
@@ -1,6 +1,7 @@
 package games.pandemic.rules.rules;
 
 import core.AbstractGameState;
+import core.rules.Node;
 import core.rules.rulenodes.EndPlayerTurn;
 import games.pandemic.PandemicGameState;
 
@@ -9,10 +10,22 @@ public class NextPlayer extends EndPlayerTurn {
     public NextPlayer() {
         setNextPlayerNode();
     }
+    /**
+     * Copy constructor
+     * @param nextPlayer - Node to be copied
+     */
+    public NextPlayer(NextPlayer nextPlayer) {
+        super(nextPlayer);
+    }
 
     @Override
     protected boolean run(AbstractGameState gs) {
         ((PandemicGameState)gs).setNCardsDrawn(0);
         return super.run(gs);
+    }
+
+    @Override
+    protected Node _copy() {
+        return new NextPlayer(this);
     }
 }

--- a/src/main/java/games/pandemic/rules/rules/PlayerAction.java
+++ b/src/main/java/games/pandemic/rules/rules/PlayerAction.java
@@ -7,6 +7,7 @@ import core.components.Card;
 import core.components.Counter;
 import core.components.Deck;
 import core.properties.PropertyString;
+import core.rules.Node;
 import games.pandemic.PandemicConstants;
 import games.pandemic.PandemicGameState;
 import games.pandemic.PandemicTurnOrder;
@@ -27,6 +28,16 @@ public class PlayerAction extends core.rules.rulenodes.PlayerAction {
         super();
         this.n_initial_disease_cubes = n_initial_disease_cubes;
         this.playerHandOverCapacity = -1;
+    }
+
+    /**
+     * Copy constructor
+     * @param playerAction - Node to be copied
+     */
+    public PlayerAction(PlayerAction playerAction) {
+        super(playerAction);
+        this.n_initial_disease_cubes = playerAction.n_initial_disease_cubes;
+        this.playerHandOverCapacity = playerAction.playerHandOverCapacity;
     }
 
     @Override
@@ -80,5 +91,10 @@ public class PlayerAction extends core.rules.rulenodes.PlayerAction {
 
     public void setPlayerHandOverCapacity(int playerHandOverCapacity) {
         this.playerHandOverCapacity = playerHandOverCapacity;
+    }
+
+    @Override
+    protected Node _copy() {
+        return new PlayerAction(this);
     }
 }


### PR DESCRIPTION
Fix for issue #157 
- Added copy constructors to Node.java and Node-sublasses.
- Added method(s) to copy the rulegraph from a root node in AbstractRuleBasedForwardModel.java.