### PR TITLE
Turnorder adjustments

### DIFF
--- a/src/main/java/games/descent2e/DescentGameState.java
+++ b/src/main/java/games/descent2e/DescentGameState.java
@@ -207,14 +207,17 @@ public class DescentGameState extends AbstractGameState implements IPrintable {
 
         // Find currently acting figure (hero or monster)
         Figure actingFigure;
-        if (getCurrentPlayer() != 0) {
+        if (getCurrentPlayer() != overlordPlayer) {
             // If hero player, get corresponding hero
-            actingFigure = getHeroes().get(getCurrentPlayer() - 1);
+            actingFigure = getHeroes().get(((DescentTurnOrder)getTurnOrder()).heroFigureActingNext);
         } else {
             // Otherwise, monster is playing
             actingFigure = monsterGroup.get(nextMonster);
         }
         return actingFigure;
+    }
+    public int getActingPlayer() {
+        return getActingFigure().getOwnerId();
     }
 
     public boolean playerHasAvailableInterrupt(int player, Triggers trigger) {

--- a/src/main/java/games/descent2e/DescentTurnOrder.java
+++ b/src/main/java/games/descent2e/DescentTurnOrder.java
@@ -6,19 +6,18 @@ import core.turnorders.TurnOrder;
 import games.descent2e.components.Figure;
 import games.descent2e.components.Monster;
 
-import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
 
 import static utilities.Utils.GameResult.GAME_END;
 import static utilities.Utils.GameResult.GAME_ONGOING;
 
+// Order is all heroes (controlled by their owner ID player), then all monsters by monster group (controlled by overlord)
 public class DescentTurnOrder extends ReactiveTurnOrder {
     int monsterGroupActingNext;
     int monsterActingNext;
-    int heroPlayerActingNext;
+    int heroFigureActingNext;
 
-    // TODO: order is player, overlord(monster group 1), player, overlord (monster group 2) ...
     public DescentTurnOrder(int nPlayers) {
         super(nPlayers);
     }
@@ -28,32 +27,46 @@ public class DescentTurnOrder extends ReactiveTurnOrder {
         super._reset();
         monsterGroupActingNext = 0;
         monsterActingNext = 0;
-        heroPlayerActingNext = 0;
+        heroFigureActingNext = 0;
     }
 
     public int getMonsterGroupActingNext() {
         return monsterGroupActingNext;
     }
 
-    public int getHeroPlayerActingNext() {
-        return heroPlayerActingNext;
+    public int getHeroFigureActingNext() {
+        return heroFigureActingNext;
     }
 
     public int getMonsterActingNext() {
         return monsterActingNext;
     }
 
-    public void nextMonster(int groupSize) {
-        monsterActingNext = (groupSize+monsterActingNext+1)%groupSize;
+    public void nextMonster(DescentGameState dgs) {
+        int groupSize = dgs.getMonsters().get(monsterGroupActingNext).size();
+        int next = (groupSize+monsterActingNext+1)%groupSize;
+        if (next == 0 && monsterActingNext == groupSize-1) {
+            // Next monster group
+            nextMonsterGroup(dgs);
+            monsterActingNext = 0;
+        } else {
+            monsterActingNext = next;
+        }
+    }
+    public void nextMonsterGroup(DescentGameState dgs) {
+        int nMonsters = dgs.getMonsters().size();
+        monsterGroupActingNext = (nMonsters+monsterGroupActingNext+1)%nMonsters;
     }
 
+    // Here this really means "end figure turn"
     @Override
     public void endPlayerTurn(AbstractGameState gameState) {
         if (gameState.getGameStatus() != GAME_ONGOING) return;
         DescentGameState dgs = (DescentGameState) gameState;
+        int nFigures = dgs.getMonsters().stream().mapToInt(List::size).sum() + nPlayers-1;
 
         turnCounter++;
-        if (turnCounter >= (nPlayers + dgs.getMonsters().size())) endRound(gameState);
+        if (turnCounter >= nFigures) endRound(gameState);
         else {
             turnOwner = nextPlayer(gameState);
             int n = 0;
@@ -70,13 +83,18 @@ public class DescentTurnOrder extends ReactiveTurnOrder {
 
     @Override
     public int nextPlayer(AbstractGameState gameState) {
-        int nMonsters = ((DescentGameState)gameState).getMonsters().size();
-        if (turnOwner == 0) {
-            monsterGroupActingNext = (nMonsters+monsterGroupActingNext+1)%nMonsters;
-            return 1+heroPlayerActingNext;
+        if (turnOwner == ((DescentGameState)gameState).overlordPlayer) {
+            // Move to next monster, or next monster group
+            nextMonster((DescentGameState) gameState);
+            // Always return overlord, player turn init on end round when all monsters are finished
+            return ((DescentGameState)gameState).overlordPlayer;
         } else {
-            heroPlayerActingNext = (nPlayers-1+heroPlayerActingNext+1)%(nPlayers-1);
-            return 0;
+            // Return next hero, or overlord if we cycled back
+            int nHeroes = ((DescentGameState)gameState).heroes.size();
+            heroFigureActingNext = (nHeroes + heroFigureActingNext +1)%nHeroes;
+            if (heroFigureActingNext == 0)
+                return ((DescentGameState)gameState).overlordPlayer;
+            else return ((DescentGameState)gameState).heroes.get(heroFigureActingNext).getOwnerId();
         }
     }
 
@@ -97,7 +115,7 @@ public class DescentTurnOrder extends ReactiveTurnOrder {
         dgs.overlord.resetRound();
         monsterGroupActingNext = 0;
         monsterActingNext = 0;
-
+        heroFigureActingNext = 0;
     }
 
     @Override
@@ -106,7 +124,7 @@ public class DescentTurnOrder extends ReactiveTurnOrder {
         pto.reactivePlayers = new LinkedList<>(reactivePlayers);
         pto.monsterActingNext = monsterActingNext;
         pto.monsterGroupActingNext = monsterGroupActingNext;
-        pto.heroPlayerActingNext = heroPlayerActingNext;
+        pto.heroFigureActingNext = heroFigureActingNext;
         return pto;
     }
 }

--- a/src/main/java/games/descent2e/actions/DescentAction.java
+++ b/src/main/java/games/descent2e/actions/DescentAction.java
@@ -25,6 +25,11 @@ public abstract class DescentAction extends AbstractAction {
     }
     public abstract boolean execute(DescentGameState gs);
     public abstract DescentAction copy();
+    public boolean canExecute(Triggers currentPoint, DescentGameState dgs) {
+        if (triggerPoints.contains(currentPoint)) return canExecute(dgs);
+        return false;
+    }
+    public abstract boolean canExecute(DescentGameState dgs);
 
     @Override
     public boolean equals(Object o) {

--- a/src/main/java/games/descent2e/actions/EndTurn.java
+++ b/src/main/java/games/descent2e/actions/EndTurn.java
@@ -2,22 +2,20 @@ package games.descent2e.actions;
 
 import core.AbstractGameState;
 import games.descent2e.DescentGameState;
-import games.descent2e.components.Figure;
-import games.descent2e.components.Hero;
 
-public class Rest extends DescentAction{
-    public Rest() {
+public class EndTurn extends DescentAction{
+    public EndTurn() {
         super(Triggers.ACTION_POINT_SPEND);
     }
 
     @Override
     public String getString(AbstractGameState gameState) {
-        return "Rest";
+        return "End turn";
     }
 
     @Override
     public boolean execute(DescentGameState gs) {
-        ((Hero)gs.getActingFigure()).setRested(true);
+        gs.getTurnOrder().endPlayerTurn(gs);
         return true;
     }
 
@@ -28,6 +26,6 @@ public class Rest extends DescentAction{
 
     @Override
     public boolean canExecute(DescentGameState dgs) {
-        return dgs.getHeroes().get(dgs.getCurrentPlayer()-1).getAttributeValue(Figure.Attribute.Fatigue) > 0;
+        return true;
     }
 }

--- a/src/main/java/games/descent2e/actions/Move.java
+++ b/src/main/java/games/descent2e/actions/Move.java
@@ -6,42 +6,26 @@ import core.components.BoardNode;
 import core.properties.PropertyInt;
 import games.descent2e.DescentGameState;
 import games.descent2e.DescentParameters;
-import games.descent2e.DescentTurnOrder;
 import games.descent2e.components.Figure;
-import games.descent2e.components.Monster;
 import utilities.Vector2D;
-
-import java.util.ArrayList;
-import java.util.List;
 
 
 public class Move extends AbstractAction {
-    Vector2D location;
+    Vector2D position;
 
     public Move(Vector2D whereTo) {
-        this.location = whereTo;
+        this.position = whereTo;
     }
 
     @Override
     public boolean execute(AbstractGameState gs) {
         DescentGameState dgs = (DescentGameState)gs;
         DescentParameters dp = (DescentParameters)gs.getGameParameters();
-        int currentPlayer = gs.getCurrentPlayer();
 
-        Figure f;
-        if (currentPlayer == 0) {
-            // Move monsters
-            int monsterGroupIdx = ((DescentTurnOrder)dgs.getTurnOrder()).getMonsterGroupActingNext();
-            List<Monster> monsterGroup = dgs.getMonsters().get(monsterGroupIdx);
-            f = monsterGroup.get(((DescentTurnOrder)dgs.getTurnOrder()).getMonsterActingNext());
-        }
-        else {
-            // Move corresponding hero player
-            f = dgs.getHeroes().get(currentPlayer-1);
-        }
+        Figure f = ((DescentGameState) gs).getActingFigure();
         // Update location
         Vector2D oldLocation = f.getPosition().copy();
-        f.setPosition(location.copy());
+        f.setPosition(position.copy());
 
         // TODO: maybe change orientation if monster doesn't fit vertically
         int w = 1;
@@ -58,7 +42,7 @@ public class Move extends AbstractAction {
         for (int i = 0; i < h; i++) {
             for (int j = 0; j < w; j++) {
                 BoardNode currentTile = dgs.getMasterBoard().getElement(oldLocation.getX() + j, oldLocation.getY() + i);
-                BoardNode destinationTile = dgs.getMasterBoard().getElement(location.getX() + j, location.getY() + i);
+                BoardNode destinationTile = dgs.getMasterBoard().getElement(position.getX() + j, position.getY() + i);
 
                 PropertyInt prop1 = new PropertyInt("players", -1);
                 PropertyInt prop2 = new PropertyInt("players", f.getComponentID());
@@ -106,7 +90,7 @@ public class Move extends AbstractAction {
 
     @Override
     public AbstractAction copy() {
-        return new Move(location.copy());
+        return new Move(position.copy());
     }
 
     @Override

--- a/src/main/java/games/descent2e/actions/Rest.java
+++ b/src/main/java/games/descent2e/actions/Rest.java
@@ -28,6 +28,7 @@ public class Rest extends DescentAction{
 
     @Override
     public boolean canExecute(DescentGameState dgs) {
-        return dgs.getHeroes().get(dgs.getCurrentPlayer()-1).getAttributeValue(Figure.Attribute.Fatigue) > 0;
+        Figure f = dgs.getActingFigure();
+        return f instanceof Hero && f.getAttributeValue(Figure.Attribute.Fatigue) > 0;
     }
 }

--- a/src/main/java/games/descent2e/actions/herofeats/HealAllInRange.java
+++ b/src/main/java/games/descent2e/actions/herofeats/HealAllInRange.java
@@ -24,6 +24,11 @@ public class HealAllInRange extends DescentAction {
     }
 
     @Override
+    public boolean canExecute(DescentGameState dgs) {
+        return false;
+    }
+
+    @Override
     public boolean equals(Object obj) {
         return false;
     }

--- a/src/main/java/games/descent2e/actions/tokens/AcolyteAction.java
+++ b/src/main/java/games/descent2e/actions/tokens/AcolyteAction.java
@@ -35,7 +35,7 @@ public class AcolyteAction extends TokenAction {
     public boolean canExecute(DescentGameState gs) {
         // Can only execute if player adjacent to villager token
         DToken acolyte = (DToken) gs.getComponentById(tokenID);
-        Hero hero = gs.getHeroes().get(acolyte.getOwnerId()-1);
+        Hero hero = gs.getHeroes().get(acolyte.getOwnerId());
         Vector2D loc = hero.getPosition();
         GridBoard board = gs.getMasterBoard();
         List<Vector2D> neighbours = getNeighbourhood(loc.getX(), loc.getY(), board.getWidth(), board.getHeight(), true);
@@ -60,13 +60,14 @@ public class AcolyteAction extends TokenAction {
     @Override
     public boolean execute(DescentGameState gs) {
         DToken acolyte = (DToken) gs.getComponentById(tokenID);
-        Hero hero = gs.getHeroes().get(acolyte.getOwnerId()-1);
+        int heroIdx = acolyte.getOwnerId();
+        Hero hero = gs.getHeroes().get(heroIdx);
         Vector2D loc = hero.getPosition();
         GridBoard board = gs.getMasterBoard();
         List<Vector2D> neighbours = getNeighbourhood(loc.getX(), loc.getY(), board.getWidth(), board.getHeight(), true);
         for (DToken token: gs.getTokens()) {
             if (token.getDescentTokenType() == DescentTypes.DescentToken.Villager && neighbours.contains(token.getPosition())) {
-                token.setOwnerId(hero.getOwnerId(), gs); // Take this one
+                token.setOwnerId(heroIdx, gs); // Take this one
                 token.setPosition(null);  // Take off the map
                 return true;
             }

--- a/src/main/java/games/descent2e/actions/tokens/AcolyteAction.java
+++ b/src/main/java/games/descent2e/actions/tokens/AcolyteAction.java
@@ -4,6 +4,7 @@ import core.AbstractGameState;
 import core.components.GridBoard;
 import games.descent2e.DescentGameState;
 import games.descent2e.DescentTypes;
+import games.descent2e.actions.Triggers;
 import games.descent2e.components.Hero;
 import games.descent2e.components.tokens.DToken;
 import utilities.Vector2D;
@@ -28,6 +29,22 @@ public class AcolyteAction extends TokenAction {
     @Override
     public AcolyteAction copy() {
         return this;
+    }
+
+    @Override
+    public boolean canExecute(DescentGameState gs) {
+        // Can only execute if player adjacent to villager token
+        DToken acolyte = (DToken) gs.getComponentById(tokenID);
+        Hero hero = gs.getHeroes().get(acolyte.getOwnerId()-1);
+        Vector2D loc = hero.getPosition();
+        GridBoard board = gs.getMasterBoard();
+        List<Vector2D> neighbours = getNeighbourhood(loc.getX(), loc.getY(), board.getWidth(), board.getHeight(), true);
+        for (DToken token: gs.getTokens()) {
+            if (token.getDescentTokenType() == DescentTypes.DescentToken.Villager && neighbours.contains(token.getPosition())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/games/descent2e/actions/tokens/SearchAction.java
+++ b/src/main/java/games/descent2e/actions/tokens/SearchAction.java
@@ -4,13 +4,19 @@ import core.AbstractGameState;
 import core.actions.AbstractAction;
 import core.components.Card;
 import core.components.Deck;
+import core.components.GridBoard;
 import games.descent2e.DescentGameState;
+import games.descent2e.DescentTypes;
 import games.descent2e.actions.DescentAction;
 import games.descent2e.actions.Triggers;
 import games.descent2e.components.Hero;
 import games.descent2e.components.tokens.DToken;
+import utilities.Vector2D;
 
+import java.util.List;
 import java.util.Random;
+
+import static utilities.Utils.getNeighbourhood;
 
 /**
  * Draw random search card and add to player
@@ -23,6 +29,22 @@ public class SearchAction extends TokenAction {
     @Override
     public SearchAction copy() {
         return this;
+    }
+
+    @Override
+    public boolean canExecute(DescentGameState gs) {
+        // Can only execute if player adjacent to search token
+        DToken acolyte = (DToken) gs.getComponentById(tokenID);
+        Hero hero = gs.getHeroes().get(acolyte.getOwnerId()-1);
+        Vector2D loc = hero.getPosition();
+        GridBoard board = gs.getMasterBoard();
+        List<Vector2D> neighbours = getNeighbourhood(loc.getX(), loc.getY(), board.getWidth(), board.getHeight(), true);
+        for (DToken token: gs.getTokens()) {
+            if (token.getDescentTokenType() == DescentTypes.DescentToken.Search && neighbours.contains(token.getPosition())) {
+                return true;
+            }
+        }
+        return false;
     }
 
     @Override

--- a/src/main/java/games/descent2e/actions/tokens/SearchAction.java
+++ b/src/main/java/games/descent2e/actions/tokens/SearchAction.java
@@ -1,13 +1,11 @@
 package games.descent2e.actions.tokens;
 
 import core.AbstractGameState;
-import core.actions.AbstractAction;
 import core.components.Card;
 import core.components.Deck;
 import core.components.GridBoard;
 import games.descent2e.DescentGameState;
 import games.descent2e.DescentTypes;
-import games.descent2e.actions.DescentAction;
 import games.descent2e.actions.Triggers;
 import games.descent2e.components.Hero;
 import games.descent2e.components.tokens.DToken;
@@ -35,7 +33,7 @@ public class SearchAction extends TokenAction {
     public boolean canExecute(DescentGameState gs) {
         // Can only execute if player adjacent to search token
         DToken acolyte = (DToken) gs.getComponentById(tokenID);
-        Hero hero = gs.getHeroes().get(acolyte.getOwnerId()-1);
+        Hero hero = gs.getHeroes().get(acolyte.getOwnerId());
         Vector2D loc = hero.getPosition();
         GridBoard board = gs.getMasterBoard();
         List<Vector2D> neighbours = getNeighbourhood(loc.getX(), loc.getY(), board.getWidth(), board.getHeight(), true);

--- a/src/main/java/games/descent2e/actions/tokens/TradeAcolyteAction.java
+++ b/src/main/java/games/descent2e/actions/tokens/TradeAcolyteAction.java
@@ -91,6 +91,31 @@ public class TradeAcolyteAction extends TokenAction implements IExtendedSequence
     }
 
     @Override
+    public boolean canExecute(DescentGameState dgs) {
+        // Can only execute if player adjacent to another hero
+        DToken acolyte = (DToken) dgs.getComponentById(tokenID);
+        if (acolyte.getOwnerId() == dgs.getCurrentPlayer()) {
+            Hero hero = dgs.getHeroes().get(acolyte.getOwnerId() - 1);
+            Vector2D loc = hero.getPosition();
+            GridBoard board = dgs.getMasterBoard();
+            List<Vector2D> neighbours = getNeighbourhood(loc.getX(), loc.getY(), board.getWidth(), board.getHeight(), true);
+            for (Vector2D n : neighbours) {
+                BoardNode bn = board.getElement(n.getX(), n.getY());
+                if (bn != null) {
+                    PropertyInt figureAtNode = ((PropertyInt) bn.getProperty(playersHash));
+                    if (figureAtNode != null && figureAtNode.value != -1) {
+                        Figure f = (Figure) dgs.getComponentById(figureAtNode.value);
+                        if (f instanceof Hero) {
+                            return true;
+                        }
+                    }
+                }
+            }
+        }
+        return false;
+    }
+
+    @Override
     public boolean equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof TradeAcolyteAction)) return false;

--- a/src/main/java/games/descent2e/components/Figure.java
+++ b/src/main/java/games/descent2e/components/Figure.java
@@ -57,7 +57,10 @@ public class Figure extends Token {
     }
 
     public void resetRound() {
-        this.attributes.get(MovePoints).setToMax();
+        if (this.attributes.containsKey(MovePoints)) {
+            // Overlord doesn't have move points
+            this.attributes.get(MovePoints).setToMax();
+        }
         this.nActionsExecuted = 0;
     }
 

--- a/src/main/java/games/descent2e/components/tokens/DToken.java
+++ b/src/main/java/games/descent2e/components/tokens/DToken.java
@@ -13,6 +13,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Objects;
 
+// Important: ownerID is idx of hero in list of heroes in game state, NOT player IDX
 public class DToken extends Token {
     ArrayList<TokenAction> effects;
     HashMap<Figure.Attribute, Integer> attributeModifiers;
@@ -36,7 +37,7 @@ public class DToken extends Token {
 
     public void setOwnerId(int ownerId, DescentGameState dgs) {
         if (this.ownerId != -1) {
-            Hero hero = dgs.getHeroes().get(ownerId-1);
+            Hero hero = dgs.getHeroes().get(ownerId);
             // Revert attribute modifiers
             for (Figure.Attribute a: attributeModifiers.keySet()) {
                 int curMax = hero.getAttribute(a).getMaximum();
@@ -49,7 +50,7 @@ public class DToken extends Token {
         }
         super.setOwnerId(ownerId);
         if (this.ownerId != -1) {
-            Hero hero = dgs.getHeroes().get(ownerId-1);
+            Hero hero = dgs.getHeroes().get(ownerId);
             // Add attribute modifiers
             for (Figure.Attribute a: attributeModifiers.keySet()) {
                 int curMax = hero.getAttribute(a).getMaximum();

--- a/src/main/java/games/descent2e/components/tokens/DToken.java
+++ b/src/main/java/games/descent2e/components/tokens/DToken.java
@@ -35,6 +35,12 @@ public class DToken extends Token {
         attributeModifiers = new HashMap<>();
     }
 
+    @Override
+    public void setOwnerId(int ownerId) {
+        super.setOwnerId(ownerId);
+        int a = 0;
+    }
+
     public void setOwnerId(int ownerId, DescentGameState dgs) {
         if (this.ownerId != -1) {
             Hero hero = dgs.getHeroes().get(ownerId);
@@ -86,7 +92,7 @@ public class DToken extends Token {
             copy.effects.add(act.copy());
         }
         copy.attributeModifiers = new HashMap<>(attributeModifiers);
-        copyComponentTo(this);
+        copyComponentTo(copy);
         return copy;
     }
 

--- a/src/main/java/games/descent2e/gui/DescentGridBoardView.java
+++ b/src/main/java/games/descent2e/gui/DescentGridBoardView.java
@@ -223,7 +223,7 @@ public class DescentGridBoardView extends ComponentView {
             g.setStroke(new BasicStroke(5));
 
             //TODO: Remove after testing, added for movement debugging - Marko
-            g.drawString("X:" + x + " Y:" + y, xC + 5, yC + 15);
+//            g.drawString("X:" + x + " Y:" + y, xC + 5, yC + 15);
 
             // Find connectivity in the graph and draw borders to the cell where connection doesn't exist
             List<Vector2D> neighbourCells = getNeighbourhood(x, y, gridWidth, gridHeight, false);


### PR DESCRIPTION
- All heroes go first, then all monsters (by monster group) all controlled by overlord
- Decoupled connection between hero idx (in list of heroes in game state) and player idx
- 2-player variant supported (1 player is the overlord and controls all monsters, the other controls 2 heroes)