### PR TITLE
Master tournament output

### DIFF
--- a/src/main/java/evaluation/RoundRobinTournament.java
+++ b/src/main/java/evaluation/RoundRobinTournament.java
@@ -155,11 +155,15 @@ public class RoundRobinTournament extends AbstractTournament {
 
             LinkedList<Integer> matchUp = new LinkedList<>();
             createAndRunMatchUp(matchUp, g);
+            int gamesPerPlayer = gameCounter * playersPerGame.get(g) / agents.size();
 
             if (verbose)
                 for (int i = 0; i < this.agents.size(); i++) {
                     System.out.printf("%s got %d points %n", agents.get(i), pointsPerPlayer[i]);
-                    System.out.printf("%s won %.1f%% of the games %n", agents.get(i), 100.0 * pointsPerPlayer[i] / (gamesPerMatchUp * matchUpsRun));
+                    System.out.printf("%s won %.1f%% of the %d games of the tournament. %n",
+                            agents.get(i), 100.0 * pointsPerPlayer[i] / (gamesPerMatchUp * matchUpsRun), gameCounter);
+                    System.out.printf("%s won %.1f%% of the games it played during the tournament. %n",
+                            agents.get(i), 100.0 * pointsPerPlayer[i] / gamesPerPlayer);
                 }
         }
         if (dataLogger != null)

--- a/src/main/java/evaluation/RoundRobinTournament.java
+++ b/src/main/java/evaluation/RoundRobinTournament.java
@@ -168,13 +168,14 @@ public class RoundRobinTournament extends AbstractTournament {
 
             LinkedList<Integer> matchUp = new LinkedList<>();
             createAndRunMatchUp(matchUp, g);
+            int gameCounter = (gamesPerMatchUp * matchUpsRun);
             int gamesPerPlayer = gameCounter * playersPerGame.get(g) / agents.size();
 
             if (verbose)
                 for (int i = 0; i < this.agents.size(); i++) {
                     System.out.printf("%s got %d points %n", agents.get(i), pointsPerPlayer[i]);
                     System.out.printf("%s won %.1f%% of the %d games of the tournament. %n",
-                            agents.get(i), 100.0 * pointsPerPlayer[i] / (gamesPerMatchUp * matchUpsRun), gameCounter);
+                            agents.get(i), 100.0 * pointsPerPlayer[i] / gameCounter, gameCounter);
                     System.out.printf("%s won %.1f%% of the games it played during the tournament. %n",
                             agents.get(i), 100.0 * pointsPerPlayer[i] / gamesPerPlayer);
                 }


### PR DESCRIPTION
I've added another line for each player to the round robin tournament output.
This indicates the win rate of each agent in the games it played. 
Previous shown percentage referred to the number of victories as a percentage of games played in the tournament (independently if the agent played in it or not).

I'm calculating the number of games played per agent in a tournament as: 

```
 int gameCounter = (gamesPerMatchUp * matchUpsRun);
 int gamesPerPlayer = gameCounter * playersPerGame.get(g) / agents.size();
```

but it'd be good a double-check on this.

