### PR TITLE
hot fix for RMHC mutation and accessibility to params and enums in RH…

### DIFF
--- a/src/main/java/players/rhea/RHEAEnums.java
+++ b/src/main/java/players/rhea/RHEAEnums.java
@@ -3,13 +3,13 @@ package players.rhea;
 public class RHEAEnums
 {
 
-    enum SelectionType
+    public enum SelectionType
     {
         RANK,
         TOURNAMENT
     }
 
-    enum CrossoverType
+    public enum CrossoverType
     {
         NONE,
         UNIFORM,

--- a/src/main/java/players/rhea/RHEAParams.java
+++ b/src/main/java/players/rhea/RHEAParams.java
@@ -17,11 +17,11 @@ public class RHEAParams extends PlayerParameters
     public int eliteCount = 2;
     public int childCount = 10;
     public int mutationCount = 1;
-    RHEAEnums.SelectionType selectionType = RHEAEnums.SelectionType.TOURNAMENT;
+    public RHEAEnums.SelectionType selectionType = RHEAEnums.SelectionType.TOURNAMENT;
     public int tournamentSize = 4;
-    RHEAEnums.CrossoverType crossoverType = RHEAEnums.CrossoverType.UNIFORM;
+    public RHEAEnums.CrossoverType crossoverType = RHEAEnums.CrossoverType.UNIFORM;
     public boolean shiftLeft;
-    protected IStateHeuristic heuristic = AbstractGameState::getGameScore;
+    public IStateHeuristic heuristic = AbstractGameState::getGameScore;
     public boolean useMAST;
 
 

--- a/src/main/java/players/rmhc/Individual.java
+++ b/src/main/java/players/rmhc/Individual.java
@@ -28,7 +28,7 @@ public class Individual implements Comparable {
         this.heuristic = heuristic;
 
         // Rollout with random actions and assign fitness value
-        rollout(gs, fm, 0, L, playerID);  // TODO: cheating, init should also count FM calls
+        rollout(gs, fm, 0, playerID);
     }
 
     // Copy constructor
@@ -45,6 +45,7 @@ public class Individual implements Comparable {
 
         value = I.value;
         gen = I.gen;
+        heuristic = I.heuristic;
     }
 
     /**
@@ -61,14 +62,12 @@ public class Individual implements Comparable {
             // Find index from which to mutate individual, random in range of currently valid length
             int startIndex = 0;
             if (length > 1) {
-                gen.nextInt(length - 1);
+                startIndex = gen.nextInt(length - 1);
             }
-            // Last index is maximum intended individual length
-            int endIndex = actions.length;
-            // Game state to start from
+
             AbstractGameState gs = gameStates[startIndex];
             // Perform rollout and return number of FM calls taken
-            return rollout(gs, fm, startIndex, endIndex, playerID);
+            return rollout(gs, fm, startIndex, playerID);
         }
         return 0;
     }
@@ -79,14 +78,14 @@ public class Individual implements Comparable {
      * @param gs - root game state from which to start rollout
      * @param fm - forward model
      * @param startIndex - index in individual from which to start rollout
-     * @param endIndex - index in individual where to end rollout
      * @param playerID - ID of player, used in state evaluation
      * @return - number of calls to the FM.next() function
      */
-    private int rollout(AbstractGameState gs, AbstractForwardModel fm, int startIndex, int endIndex, int playerID) {
+    private int rollout(AbstractGameState gs, AbstractForwardModel fm, int startIndex, int playerID) {
         length = 0;
         int fmCalls = 0;
         double delta = 0;
+
         for (int i = 0; i < startIndex; i++) {
             double score;
             if (this.heuristic != null){
@@ -97,7 +96,8 @@ public class Individual implements Comparable {
 
             delta += Math.pow(discountFactor, i) * score;
         }
-        for (int i = startIndex; i < endIndex; i++){
+
+        for (int i = startIndex; i < actions.length; i++){
             // Rolls from chosen index to the end, randomly changing actions and game states
             // Length of individual is updated depending on if it reaches a terminal game state
             if (gs.isNotTerminal()) {
@@ -139,7 +139,7 @@ public class Individual implements Comparable {
                 break;
             }
         }
-//        this.value = gs.getScore(playerID);
+
         this.value = delta;
         return fmCalls;
     }


### PR DESCRIPTION
…EA/RMHC

Enums and parameters made public for RHEA so they can be set up and used like in other methods (i..e setting heuristic) Hot fix in RMHC so mutation happens at a gene at random rather than always at gene 0. Removed endIndex as it was always used as the actual length of the individual.