### PR TITLE
MCTS memory efficiency and EXP3 fix

### DIFF
--- a/src/main/java/core/interfaces/IStatisticLogger.java
+++ b/src/main/java/core/interfaces/IStatisticLogger.java
@@ -42,7 +42,7 @@ public interface IStatisticLogger {
 
     static IStatisticLogger createLogger(String loggerClass, String logFile) {
         if (logFile.isEmpty())
-            return null;
+            throw new IllegalArgumentException("Must specify logFile");
         IStatisticLogger logger = new SummaryLogger();
         try {
             Class<?> clazz = Class.forName(loggerClass);

--- a/src/main/java/evaluation/RoundRobinTournament.java
+++ b/src/main/java/evaluation/RoundRobinTournament.java
@@ -112,7 +112,6 @@ public class RoundRobinTournament extends AbstractTournament {
         if (listenerClasses.size() > 1 && listenerFiles.size() > 1 && listenerClasses.size() != listenerFiles.size())
             throw new IllegalArgumentException("Lists of log files and listeners must be the same length");
 
-
         LinkedList<AbstractPlayer> agents = new LinkedList<>();
         if (!playerDirectory.equals("")) {
             agents.addAll(PlayerFactory.createPlayers(playerDirectory));

--- a/src/main/java/evaluation/RoundRobinTournament.java
+++ b/src/main/java/evaluation/RoundRobinTournament.java
@@ -89,10 +89,10 @@ public class RoundRobinTournament extends AbstractTournament {
                             "\tlistenerFile= (Optional) Will be used as the IStatisticsLogger log file.\n" +
                             "\t               Defaults to RoundRobinReport.txt\n" +
                             "\t               A pipe-delimited list should be provided if each distinct listener should\n" +
-                            "\t                    use a different log file.\n" +
+                            "\t               use a different log file.\n" +
                             "\tstatsLog=      The file to use for logging agent-specific statistics (e.g. MCTS iterations/depth)\n" +
-                            "\t               A single line will be generated as the average for each agent, implicitly assuming they are" +
-                            "\t               all of the same type. If not supplied, then no logging will take place."
+                            "\t               A single line will be generated as the average for each agent, implicitly assuming they are\n" +
+                            "\t               all of the same type. If not supplied, then no logging will take place.\n"
             );
             return;
         }

--- a/src/main/java/evaluation/TunableParameters.java
+++ b/src/main/java/evaluation/TunableParameters.java
@@ -121,7 +121,7 @@ public abstract class TunableParameters extends AbstractParameters implements IT
             if (matchingValue.isPresent()) {
                 return (T) matchingValue.get();
             }
-            throw new AssertionError("No Enum match found for " + name + " in " + Arrays.toString(defaultValue.getClass().getEnumConstants()));
+            throw new AssertionError("No Enum match found for " + name + " [" + data + "] in " + Arrays.toString(defaultValue.getClass().getEnumConstants()));
         }
         return defaultValue;
     }

--- a/src/main/java/games/diamant/DiamantGameState.java
+++ b/src/main/java/games/diamant/DiamantGameState.java
@@ -11,20 +11,20 @@ import games.GameType;
 import games.diamant.cards.DiamantCard;
 import games.diamant.components.ActionsPlayed;
 
-import java.util.ArrayList;
-import java.util.List;
-import java.util.Objects;
-import java.util.Random;
+import java.util.*;
+import java.util.stream.Collectors;
+
+import static java.util.stream.Collectors.*;
 
 
 public class DiamantGameState extends AbstractGameState implements IPrintable {
-    Deck<DiamantCard>          mainDeck;
-    Deck<DiamantCard>          discardDeck;
-    Deck<DiamantCard>          path;
+    Deck<DiamantCard> mainDeck;
+    Deck<DiamantCard> discardDeck;
+    Deck<DiamantCard> path;
 
-    List<Counter> treasureChests;
-    List<Counter> hands;
-    List<Boolean> playerInCave;
+    int[] treasureChests;
+    int[] hands;
+    boolean[] playerInCave;
 
     // helper data class to store interesting information
     static class PlayerTurnRecord {
@@ -41,11 +41,11 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
 
     List<PlayerTurnRecord> recordOfPlayerActions = new ArrayList<>();
 
-    int nGemsOnPath             = 0;
+    int nGemsOnPath = 0;
     int nHazardPoissonGasOnPath = 0;
-    int nHazardScorpionsOnPath  = 0;
-    int nHazardSnakesOnPath     = 0;
-    int nHazardRockfallsOnPath  = 0;
+    int nHazardScorpionsOnPath = 0;
+    int nHazardSnakesOnPath = 0;
+    int nHazardRockfallsOnPath = 0;
     int nHazardExplosionsOnPath = 0;
 
     int nCave = 0;
@@ -58,7 +58,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
      * Constructor. Initialises some generic game state variables.
      *
      * @param gameParameters - game parameters.
-     * @param nPlayers      - number of players for this game.
+     * @param nPlayers       - number of players for this game.
      */
     public DiamantGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, new StandardTurnOrder(nPlayers), GameType.Diamant);
@@ -70,55 +70,40 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
             add(mainDeck);
             add(discardDeck);
             add(path);
-            addAll(treasureChests);
-            addAll(hands);
-            add(actionsPlayed);
         }};
     }
 
     @Override
-    protected AbstractGameState _copy(int playerId)
-    {
-        Random r = new Random(getGameParameters().getRandomSeed());
-
+    protected AbstractGameState _copy(int playerId) {
         DiamantGameState dgs = new DiamantGameState(gameParameters.copy(), getNPlayers());
 
-        dgs.mainDeck    = mainDeck.copy();
+        dgs.mainDeck = mainDeck.copy();
         dgs.discardDeck = discardDeck.copy();
-        dgs.path        = path.copy();
-        dgs.actionsPlayed  = (ActionsPlayed) actionsPlayed.copy();
+        dgs.path = path.copy();
+        dgs.actionsPlayed = (ActionsPlayed) actionsPlayed.copy();
 
-        dgs.nGemsOnPath             = nGemsOnPath;
+        dgs.nGemsOnPath = nGemsOnPath;
         dgs.nHazardPoissonGasOnPath = nHazardPoissonGasOnPath;
-        dgs.nHazardScorpionsOnPath  = nHazardScorpionsOnPath;
-        dgs.nHazardSnakesOnPath     = nHazardSnakesOnPath;
-        dgs.nHazardRockfallsOnPath  = nHazardRockfallsOnPath;
+        dgs.nHazardScorpionsOnPath = nHazardScorpionsOnPath;
+        dgs.nHazardSnakesOnPath = nHazardSnakesOnPath;
+        dgs.nHazardRockfallsOnPath = nHazardRockfallsOnPath;
         dgs.nHazardExplosionsOnPath = nHazardExplosionsOnPath;
 
-        dgs.nCave          = nCave;
-        dgs.hands          = new ArrayList<>();
-        dgs.treasureChests = new ArrayList<>();
-        dgs.playerInCave   = new ArrayList<>();
+        dgs.nCave = nCave;
         dgs.recordOfPlayerActions.addAll(recordOfPlayerActions);
 
-        for (Counter c : hands)
-            dgs.hands.add(c.copy());
-
-        for (Counter c : treasureChests)
-            dgs.treasureChests.add(c.copy());
+        dgs.hands = hands.clone();
+        dgs.treasureChests = treasureChests.clone();
+        dgs.playerInCave = playerInCave.clone();
 
         // If there is an action played for a player, then copy it
-        for (int i=0; i<getNPlayers(); i++)
-        {
+        for (int i = 0; i < getNPlayers(); i++) {
             if (actionsPlayed.containsKey(i))
                 dgs.actionsPlayed.put(i, actionsPlayed.get(i).copy());
         }
 
-        dgs.playerInCave.addAll(playerInCave);
-
         // mainDeck and is actionsPlayed are hidden.
-        if (getCoreGameParameters().partialObservable && playerId != -1)
-        {
+        if (getCoreGameParameters().partialObservable && playerId != -1) {
             dgs.mainDeck.shuffle(new Random(getGameParameters().getRandomSeed()));
 
             dgs.actionsPlayed.clear();
@@ -128,7 +113,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
             // a competition setting for example, it would be critical. There is no simple way to do this at the moment
             // because history (as part of the super-class) is only copied after we return from this _copy() method.
 
-           // Randomize actions for other players (or any other modelling approach)
+            // Randomize actions for other players (or any other modelling approach)
             // is now the responsibility of the deciding agent (see for example OSLA)
 
         }
@@ -136,10 +121,10 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     }
 
     @Override
-    protected double _getHeuristicScore(int playerId)
-    {
+    protected double _getHeuristicScore(int playerId) {
         return new DiamantHeuristic().evaluateState(this, playerId);
     }
+
     /**
      * This provides the current score in game turns. This will only be relevant for games that have the concept
      * of victory points, etc.
@@ -150,12 +135,11 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
      */
     @Override
     public double getGameScore(int playerId) {
-         return treasureChests.get(playerId).getValue();
+        return treasureChests[playerId];
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId)
-    {
+    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
         ArrayList<Integer> ids = new ArrayList<>();
         ids.add(actionsPlayed.getComponentID());
         return ids;
@@ -163,19 +147,19 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
 
     @Override
     protected void _reset() {
-        mainDeck       = null;
-        discardDeck    = null;
-        path           = null;
-        actionsPlayed  = null;
-        treasureChests = new ArrayList<>();
-        hands          = new ArrayList<>();
-        playerInCave   = new ArrayList<>();
+        mainDeck = null;
+        discardDeck = null;
+        path = null;
+        actionsPlayed = null;
+        treasureChests = new int[getNPlayers()];
+        hands = new int[getNPlayers()];
+        playerInCave = new boolean[getNPlayers()];
 
-        nGemsOnPath             = 0;
+        nGemsOnPath = 0;
         nHazardPoissonGasOnPath = 0;
-        nHazardScorpionsOnPath  = 0;
-        nHazardSnakesOnPath     = 0;
-        nHazardRockfallsOnPath  = 0;
+        nHazardScorpionsOnPath = 0;
+        nHazardSnakesOnPath = 0;
+        nHazardRockfallsOnPath = 0;
         nHazardExplosionsOnPath = 0;
 
         nCave = 0;
@@ -183,38 +167,36 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     }
 
     @Override
-    protected boolean _equals(Object o)
-    {
-        if (this == o)                        return true;
+    protected boolean _equals(Object o) {
+        if (this == o) return true;
         if (!(o instanceof DiamantGameState)) return false;
-        if (!super.equals(o))                 return false;
+        if (!super.equals(o)) return false;
 
         DiamantGameState that = (DiamantGameState) o;
 
-        return nGemsOnPath             == that.nGemsOnPath             &&
-               nHazardExplosionsOnPath == that.nHazardExplosionsOnPath &&
-               nHazardPoissonGasOnPath == that.nHazardPoissonGasOnPath &&
-               nHazardRockfallsOnPath  == that.nHazardRockfallsOnPath  &&
-               nHazardScorpionsOnPath  == that.nHazardScorpionsOnPath  &&
-               nHazardSnakesOnPath     == that.nHazardSnakesOnPath     &&
-               nCave                   == that.nCave                   &&
-               Objects.equals(mainDeck,       that.mainDeck)           &&
-               Objects.equals(discardDeck,    that.discardDeck)        &&
-               Objects.equals(hands,          that.hands)              &&
-               Objects.equals(treasureChests, that.treasureChests)     &&
-               Objects.equals(path,           that.path)               &&
-               Objects.equals(playerInCave,   that.playerInCave)       &&
-               Objects.equals(actionsPlayed,  that.actionsPlayed);
+        return nGemsOnPath == that.nGemsOnPath &&
+                nHazardExplosionsOnPath == that.nHazardExplosionsOnPath &&
+                nHazardPoissonGasOnPath == that.nHazardPoissonGasOnPath &&
+                nHazardRockfallsOnPath == that.nHazardRockfallsOnPath &&
+                nHazardScorpionsOnPath == that.nHazardScorpionsOnPath &&
+                nHazardSnakesOnPath == that.nHazardSnakesOnPath &&
+                nCave == that.nCave &&
+                Objects.equals(mainDeck, that.mainDeck) &&
+                Objects.equals(discardDeck, that.discardDeck) &&
+                Arrays.equals(hands, that.hands) &&
+                Arrays.equals(treasureChests, that.treasureChests) &&
+                Objects.equals(path, that.path) &&
+                Arrays.equals(playerInCave, that.playerInCave) &&
+                Objects.equals(actionsPlayed, that.actionsPlayed);
     }
 
     /**
      * Returns the number of player already in the cave
-    */
+     */
 
-    public int getNPlayersInCave()
-    {
+    public int getNPlayersInCave() {
         int n = 0;
-        for (Boolean b: playerInCave)
+        for (Boolean b : playerInCave)
             if (b) n++;
         return n;
     }
@@ -227,52 +209,61 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     public void printToConsole() {
         String[] strings = new String[13];
 
-        StringBuilder str_gemsOnHand          = new StringBuilder();
-        StringBuilder str_gemsOnTreasureChest = new StringBuilder();
-        StringBuilder str_playersOnCave       = new StringBuilder();
+        StringBuilder str_playersOnCave = new StringBuilder();
 
-        for (Counter c:hands)          { str_gemsOnHand.         append(c.getValue()).append(" "); }
-        for (Counter c:treasureChests) { str_gemsOnTreasureChest.append(c.getValue()).append(" "); }
-        for (Boolean b : playerInCave)
-        {
-            if (b) str_playersOnCave.append("T");
-            else   str_playersOnCave.append("F");
+        for (boolean b : playerInCave) {
+            str_playersOnCave.append(b ? "T" : "F").append(" ");
         }
 
-        strings[0]  = "----------------------------------------------------";
-        strings[1]  = "Cave:                       " + nCave;
-        strings[2]  = "Players on Cave:            " + str_playersOnCave.toString();
-        strings[3]  = "Path:                       " + path.toString();
-        strings[4]  = "Gems on Path:               " + nGemsOnPath;
-        strings[5]  = "Gems on hand:               " + str_gemsOnHand.toString();
-        strings[6]  = "Gems on treasure chest:     " + str_gemsOnTreasureChest.toString();
-        strings[7]  = "Hazard scorpions in Path:   " + nHazardScorpionsOnPath  + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Scorpions);
-        strings[8]  = "Hazard snakes in Path:      " + nHazardSnakesOnPath     + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Snakes);
-        strings[9]  = "Hazard rockfalls in Path:   " + nHazardRockfallsOnPath  + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Rockfalls);
+        strings[0] = "----------------------------------------------------";
+        strings[1] = "Cave:                       " + nCave;
+        strings[2] = "Players on Cave:            " + str_playersOnCave.toString();
+        strings[3] = "Path:                       " + path.toString();
+        strings[4] = "Gems on Path:               " + nGemsOnPath;
+        strings[5] = "Gems on hand:               " + Arrays.stream(hands).mapToObj(String::valueOf).collect(joining(" "));
+        strings[6] = "Gems on treasure chest:     " + Arrays.stream(treasureChests).mapToObj(String::valueOf).collect(joining(" "));
+        strings[7] = "Hazard scorpions in Path:   " + nHazardScorpionsOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Scorpions);
+        strings[8] = "Hazard snakes in Path:      " + nHazardSnakesOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Snakes);
+        strings[9] = "Hazard rockfalls in Path:   " + nHazardRockfallsOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Rockfalls);
         strings[10] = "Hazard poisson gas in Path: " + nHazardPoissonGasOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.PoissonGas);
         strings[11] = "Hazard explosions in Path:  " + nHazardExplosionsOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Explosions);
         strings[12] = "----------------------------------------------------";
 
-        for (String s : strings){
+        for (String s : strings) {
             System.out.println(s);
         }
     }
 
-    private int getNHazardCardsInMainDeck(DiamantCard.HazardType ht)
-    {
+    private int getNHazardCardsInMainDeck(DiamantCard.HazardType ht) {
         int n = 0;
-        for (int i=0; i<mainDeck.getSize(); i++)
-        {
+        for (int i = 0; i < mainDeck.getSize(); i++) {
             if (mainDeck.get(i).getHazardType() == ht)
-                n ++;
+                n++;
         }
         return n;
     }
 
-    public Deck<DiamantCard> getMainDeck()       { return mainDeck;       }
-    public Deck<DiamantCard> getDiscardDeck()    { return discardDeck;    }
-    public List<Counter>     getHands()          { return hands;          }
-    public List<Counter>     getTreasureChests() { return treasureChests; }
-    public Deck<DiamantCard> getPath()           { return path;           }
-    public ActionsPlayed     getActionsPlayed()  { return actionsPlayed;  }
+    public Deck<DiamantCard> getMainDeck() {
+        return mainDeck;
+    }
+
+    public Deck<DiamantCard> getDiscardDeck() {
+        return discardDeck;
+    }
+
+    public int[] getHands() {
+        return hands;
+    }
+
+    public int[] getTreasureChests() {
+        return treasureChests;
+    }
+
+    public Deck<DiamantCard> getPath() {
+        return path;
+    }
+
+    public ActionsPlayed getActionsPlayed() {
+        return actionsPlayed;
+    }
 }

--- a/src/main/java/games/diamant/DiamantHeuristic.java
+++ b/src/main/java/games/diamant/DiamantHeuristic.java
@@ -6,6 +6,7 @@ import core.interfaces.IStateHeuristic;
 import evaluation.TunableParameters;
 import utilities.Utils;
 
+import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -55,14 +56,13 @@ public class DiamantHeuristic extends TunableParameters implements IStateHeurist
             return 1;
 
         DiamantGameState dgs = (DiamantGameState) gs;
-        List<Integer> gemsInOrder = dgs.getTreasureChests().stream()
-                .mapToInt(Counter::getValue)
+        List<Integer> gemsInOrder = Arrays.stream(dgs.treasureChests)
                 .sorted().boxed().collect(Collectors.toList());
 
         int max_ngens = gemsInOrder.get(dgs.getNPlayers()-1);
         int min_ngens = gemsInOrder.get(0);
 
-        int player_gems = dgs.treasureChests.get(playerId).getValue();
+        int player_gems = dgs.treasureChests[playerId];
         double highestExpectedScore = 139.0 / gs.getNPlayers() * 2.0;
         // 1.0 if a player has every single gem in a 2-player game; 67% of gems in a 3-player; 50% in a 4-player....
         double score = FACTOR_SCORE * player_gems / highestExpectedScore;
@@ -73,7 +73,7 @@ public class DiamantHeuristic extends TunableParameters implements IStateHeurist
 
         score += FACTOR_AHEAD * (player_gems - min_ngens) / highestExpectedScore;
 
-        if (dgs.playerInCave.get(playerId)) score += FACTOR_IN_CAVE;  // are we in the cave...for luck-pushing strategies
+        if (dgs.playerInCave[playerId]) score += FACTOR_IN_CAVE;  // are we in the cave...for luck-pushing strategies
 
         return score;
     }

--- a/src/main/java/games/dotsboxes/DBGameState.java
+++ b/src/main/java/games/dotsboxes/DBGameState.java
@@ -13,7 +13,7 @@ import java.util.*;
 
 public class DBGameState extends AbstractGameState {
 
-    IStateHeuristic heuristic = new DotsAndBoxesHeuristic();
+    IStateHeuristic heuristic;
 
     // List of all edges possible
     HashSet<DBEdge> edges;
@@ -55,11 +55,15 @@ public class DBGameState extends AbstractGameState {
         dbgs.nCellsPerPlayer = nCellsPerPlayer.clone();
         dbgs.cellToOwnerMap = (HashMap<DBCell, Integer>) cellToOwnerMap.clone();
         dbgs.edgeToOwnerMap = (HashMap<DBEdge, Integer>) edgeToOwnerMap.clone();
+        dbgs.heuristic = heuristic;
         return dbgs;
     }
 
     @Override
     protected double _getHeuristicScore(int playerId) {
+        if (heuristic == null) { // lazy initialization
+            heuristic = new DotsAndBoxesHeuristic();
+        }
         return heuristic.evaluateState(this, playerId);
     }
 

--- a/src/main/java/games/dotsboxes/DBGameState.java
+++ b/src/main/java/games/dotsboxes/DBGameState.java
@@ -3,6 +3,8 @@ package games.dotsboxes;
 import core.AbstractGameState;
 import core.AbstractParameters;
 import core.components.Component;
+import core.components.GridBoard;
+import core.components.Token;
 import core.interfaces.IStateHeuristic;
 import core.turnorders.AlternatingTurnOrder;
 import games.GameType;

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -15,7 +15,9 @@ public class MCTSEnums {
     }
 
     public enum SelectionPolicy {
-        ROBUST, SIMPLE
+        ROBUST, SIMPLE, TREE
+        // ROBUST uses the most visited, SIMPLE the highest scoring
+        // TREE uses the node tree policy (for EXP3 or Regret Matching)
     }
 
     public enum TreePolicy {

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -134,6 +134,9 @@ public class MCTSParams extends PlayerParameters {
         rolloutClass = (String) getParameterValue("rolloutClass");
         oppModelClass = (String) getParameterValue("oppModelClass");
         gatherExpertIterationData = (boolean) getParameterValue("expertIteration");
+        if (gatherExpertIterationData) {
+            maintainMasterState = true; // this is required!
+        }
         expertIterationFileStem = (String) getParameterValue("expIterFile");
         expertIterationStateFeatures = (String) getParameterValue("expertIterationStateFeatures");
         if (!expertIterationStateFeatures.equals(""))

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -107,6 +107,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("normaliseRewards", true);
         addTunableParameter("nodesStoreScoreDelta", false);
         addTunableParameter("maintainMasterState", false);
+        addTunableParameter("discardStateAfterEachIteration", true);
         addTunableParameter("advantageFunction", IActionHeuristic.nullReturn);
         addTunableParameter("omaVisits", 0);
     }
@@ -160,6 +161,7 @@ public class MCTSParams extends PlayerParameters {
         normaliseRewards = (boolean) getParameterValue("normaliseRewards");
         nodesStoreScoreDelta = (boolean) getParameterValue("nodesStoreScoreDelta");
         maintainMasterState = (boolean) getParameterValue("maintainMasterState");
+        discardStateAfterEachIteration = (boolean) getParameterValue("discardStateAfterEachIteration");
         if (expansionPolicy == MCTSEnums.Strategies.MAST || rolloutType == MCTSEnums.Strategies.MAST
                 || (biasVisits > 0 && advantageFunction == null)) {
             useMAST = true;
@@ -261,6 +263,7 @@ public class MCTSParams extends PlayerParameters {
         retValue.rolloutTermination = rolloutTermination;
         retValue.heuristic = heuristic;
         retValue.opponentHeuristic = opponentHeuristic;
+        retValue.discardStateAfterEachIteration = discardStateAfterEachIteration;
         return retValue;
     }
 

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -62,6 +62,7 @@ public class MCTSParams extends PlayerParameters {
     public boolean normaliseRewards = true;
     public boolean nodesStoreScoreDelta = true;
     public boolean maintainMasterState = false;
+    public boolean discardStateAfterEachIteration = true;  // default will remove reference to OpenLoopState in backup(). Saves memory!
     public MCTSEnums.RolloutTermination rolloutTermination = DEFAULT;
     public IStateHeuristic heuristic = AbstractGameState::getHeuristicScore;
     public IStateHeuristic opponentHeuristic = AbstractGameState::getHeuristicScore;

--- a/src/main/java/players/mcts/MultiTreeNode.java
+++ b/src/main/java/players/mcts/MultiTreeNode.java
@@ -152,7 +152,7 @@ public class MultiTreeNode extends SingleTreeNode {
                     advance(currentState, chosen);
                     // we will create the new node once we get back to a point when it is this player's action again
                 } else {
-                    chosen = currentNode.treePolicyAction();
+                    chosen = currentNode.treePolicyAction(true);
                     lastAction[currentActor] = chosen;
                     if (debug)
                         System.out.printf("Tree action chosen for P%d - %s %n", currentActor, chosen);

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -22,18 +22,18 @@ import static players.PlayerConstants.*;
 import static players.mcts.MCTSEnums.Information.Closed_Loop;
 import static players.mcts.MCTSEnums.OpponentTreePolicy.*;
 import static players.mcts.MCTSEnums.RolloutTermination.DEFAULT;
+import static players.mcts.MCTSEnums.SelectionPolicy.*;
 import static players.mcts.MCTSEnums.Strategies.MAST;
 import static utilities.Utils.entropyOf;
 import static utilities.Utils.noise;
 
 public class SingleTreeNode {
 
+    private final Map<AbstractAction, Integer> nValidVisits = new HashMap<>();
     // State in this node (closed loop)
     protected AbstractGameState state;
     // State in this node (open loop - this is updated by onward trajectory....be very careful about using)
     protected AbstractGameState openLoopState;
-    List<AbstractAction> actionsFromOpenLoopState = new ArrayList<>();
-    Map<AbstractAction, Double> advantagesOfActionsFromOLS = new HashMap<>();
     // Parameters guiding the search
     protected MCTSParams params;
     protected AbstractForwardModel forwardModel;
@@ -45,22 +45,20 @@ public class SingleTreeNode {
     protected int fmCallsCount;
     protected int copyCount;
     protected int paranoidPlayer = -1;
+    // Action taken to reach this node
+    // In vanilla MCTS this will likely be an action taken by some other player (not the decisionPlayer at this node)
+    protected AbstractAction actionToReach;
+    // Number of visits to this node
+    protected int nVisits;
+    protected int rolloutActionsTaken;
+    List<AbstractAction> actionsFromOpenLoopState = new ArrayList<>();
+    Map<AbstractAction, Double> advantagesOfActionsFromOLS = new HashMap<>();
     // Depth of this node
     int depth;
     // the id of the player who makes the decision at this node
     int decisionPlayer;
     int round, turn, turnOwner;
     boolean terminalNode;
-    private final Map<AbstractAction, Integer> nValidVisits = new HashMap<>();
-    // Action taken to reach this node
-    // In vanilla MCTS this will likely be an action taken by some other player (not the decisionPlayer at this node)
-    protected AbstractAction actionToReach;
-    // The total value of all trajectories through this node (one element per player)
-    private double[] totValue;
-    private double[] totSquares;
-    // Number of visits to this node
-    protected int nVisits;
-    protected int rolloutActionsTaken;
     double highReward = Double.NEGATIVE_INFINITY;
     double lowReward = Double.POSITIVE_INFINITY;
     // Root node of tree
@@ -74,6 +72,9 @@ public class SingleTreeNode {
     List<Map<AbstractAction, Pair<Integer, Double>>> MASTStatistics; // a list of one Map per player. Action -> (visits, totValue)
     ToDoubleBiFunction<AbstractAction, AbstractGameState> advantageFunction = (a, s) -> advantagesOfActionsFromOLS.getOrDefault(a, 0.0);
     ToDoubleBiFunction<AbstractAction, AbstractGameState> MASTFunction;
+    // The total value of all trajectories through this node (one element per player)
+    private double[] totValue;
+    private double[] totSquares;
     // Total value of this node
 
 
@@ -429,7 +430,7 @@ public class SingleTreeNode {
                 return cur.expandNode(chosen, nextState);
             } else {
                 // Move to next child given by UCT function
-                AbstractAction chosen = cur.treePolicyAction();
+                AbstractAction chosen = cur.treePolicyAction(true);
                 if (params.information != Closed_Loop) {
                     // We do not need to copy the state, as we advance this as we descend the tree.
                     // In open loop we never re-use the state...the only purpose of storing it on the Node is
@@ -556,9 +557,9 @@ public class SingleTreeNode {
      *
      * @return - child node according to the tree policy
      */
-    protected AbstractAction treePolicyAction() {
+    protected AbstractAction treePolicyAction(boolean explore) {
 
-        if (params.opponentTreePolicy == SelfOnly && openLoopState.getCurrentPlayer() != decisionPlayer)
+        if (params.opponentTreePolicy == SelfOnly && openLoopState != null && openLoopState.getCurrentPlayer() != decisionPlayer)
             throw new AssertionError("An error has occurred. SelfOnly should only call uct when we are moving.");
 
         List<AbstractAction> availableActions = actionsToConsider(actionsFromOpenLoopState, 0);
@@ -578,7 +579,7 @@ public class SingleTreeNode {
                 case EXP3:
                 case RegretMatching:
                     // These construct a distribution over possible actions and then sample from it
-                    actionChosen = sampleFromDistribution(availableActions);
+                    actionChosen = sampleFromDistribution(availableActions, explore ? params.exploreEpsilon : 0.0);
                     break;
                 default:
                     throw new AssertionError("Unknown treepolicy: " + params.treePolicy);
@@ -756,7 +757,7 @@ public class SingleTreeNode {
         return Math.max(0.0, regret);
     }
 
-    private AbstractAction sampleFromDistribution(List<AbstractAction> availableActions) {
+    private AbstractAction sampleFromDistribution(List<AbstractAction> availableActions, double explore) {
         // first we get a value for each of them
         Function<AbstractAction, Double> valueFn;
         switch (params.treePolicy) {
@@ -775,9 +776,9 @@ public class SingleTreeNode {
         // then we normalise to a pdf
         actionToValueMap = Utils.normaliseMap(actionToValueMap);
         // we then add on the exploration bonus
-        double exploreBonus = params.exploreEpsilon / actionToValueMap.size();
+        double exploreBonus = explore / actionToValueMap.size();
         Map<AbstractAction, Double> probabilityOfSelection = actionToValueMap.entrySet().stream().collect(
-                toMap(Map.Entry::getKey, e -> e.getValue() * (1.0 - params.exploreEpsilon) + exploreBonus));
+                toMap(Map.Entry::getKey, e -> e.getValue() * (1.0 - explore) + exploreBonus));
 
         // then we sample a uniform variable in [0, 1] and ascend the cdf to find the selection
         double cdfSample = rnd.nextDouble();
@@ -882,7 +883,7 @@ public class SingleTreeNode {
         while (n != null) {
             if (params.discardStateAfterEachIteration) {
                 n.openLoopState = null; // releases for Garbage Collection
-                if (n.depth> 0 && !params.maintainMasterState)
+                if (n.depth > 0 && !params.maintainMasterState)
                     n.state = null;
             }
             n.nVisits++;
@@ -955,25 +956,28 @@ public class SingleTreeNode {
         MCTSEnums.SelectionPolicy policy = params.selectionPolicy;
         // check to see if all nodes have the same number of visits
         // if they do, then we use average score instead
-        if (params.selectionPolicy == MCTSEnums.SelectionPolicy.ROBUST &&
+        if (params.selectionPolicy == ROBUST &&
                 Arrays.stream(actionVisits()).boxed().collect(toSet()).size() == 1) {
-            policy = MCTSEnums.SelectionPolicy.SIMPLE;
+            policy = SIMPLE;
         }
 
+        if (params.selectionPolicy == TREE) {
+            bestAction = treePolicyAction(false);
+        } else {
+            for (AbstractAction action : children.keySet()) {
+                if (children.get(action) != null) {
+                    double childValue = actionVisits(action); // if ROBUST
+                    if (policy == SIMPLE)
+                        childValue = actionTotValue(action, decisionPlayer) / (actionVisits(action) + params.epsilon);
 
-        for (AbstractAction action : children.keySet()) {
-            if (children.get(action) != null) {
-                double childValue = actionVisits(action); // if ROBUST
-                if (policy == MCTSEnums.SelectionPolicy.SIMPLE)
-                    childValue = actionTotValue(action, decisionPlayer) / (actionVisits(action) + params.epsilon);
+                    // Apply small noise to break ties randomly
+                    childValue = noise(childValue, params.epsilon, rnd.nextDouble());
 
-                // Apply small noise to break ties randomly
-                childValue = noise(childValue, params.epsilon, rnd.nextDouble());
-
-                // Save best value (highest visit count)
-                if (childValue > bestValue) {
-                    bestValue = childValue;
-                    bestAction = action;
+                    // Save best value (highest visit count)
+                    if (childValue > bestValue) {
+                        bestValue = childValue;
+                        bestAction = action;
+                    }
                 }
             }
         }

--- a/src/main/java/players/mcts/TreeStatistics.java
+++ b/src/main/java/players/mcts/TreeStatistics.java
@@ -23,8 +23,8 @@ public class TreeStatistics {
         Queue<SingleTreeNode> nodeQueue = new ArrayDeque<>();
         if (root instanceof MultiTreeNode) {
             throw new AssertionError("Not expected");
-   //         for (SingleTreeNode node : ((MultiTreeNode) root).roots)
-   //             if (node != null) nodeQueue.add(node);
+            //         for (SingleTreeNode node : ((MultiTreeNode) root).roots)
+            //             if (node != null) nodeQueue.add(node);
         } else {
             nodeQueue.add(root);
         }
@@ -36,7 +36,7 @@ public class TreeStatistics {
             SingleTreeNode node = nodeQueue.poll();
             if (node.depth < maxDepth) {
                 nodesAtDepth[node.depth]++;
-                if (!node.getState().isNotTerminal())
+                if (node.terminalNode)
                     gameTerminalNodesAtDepth[node.depth]++;
                 totalActions += node.children.size();
                 if (node.children.size() > maxActions)

--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -220,7 +220,10 @@ public abstract class Utils {
     public static <T> T getArg(String[] args, String name, T defaultValue) {
         Optional<String> raw = Arrays.stream(args).filter(i -> i.toLowerCase().startsWith(name.toLowerCase() + "=")).findFirst();
         if (raw.isPresent()) {
-            String rawString = raw.get().split("=")[1];
+            String[] temp = raw.get().split("=");
+            if (temp.length < 2)
+                throw new IllegalArgumentException("No value provided for argument " + temp[0]);
+            String rawString = temp[1];
             if (defaultValue instanceof Enum) {
                 T[] constants = (T[]) defaultValue.getClass().getEnumConstants();
                 for (T o : constants) {


### PR DESCRIPTION
Contents:

1) MCTSSelectionPolicy now has a 'TREE' option, which will use the tree selection policy to pick the final action chosen after planning. This is to 'fix' EXP3 and Regret Matching rules, which formally should not use the standard UCB bestAction method, as they were previously. [Although it looks as if they perform better when using SIMPLE...]

2) A default setting in MCTSParams (discardStateAfterEachIteration) now specifically removes references to stored game states in the tree. This is to reduce memory bloat when running MCTS for large amounts of time (> 1 second) per decision. 
The few bits of statistical information this was being used for have been moved to SingleTreeNode.

3) Some refactoring of Diamant to reduce unnecessary object creation and speed up copy(). (And also in Dots and Boxes).

4) A couple of improved error messages.