### PR TITLE
Fixes from Game AI lab

### DIFF
--- a/src/main/java/games/cantstop/CantStopGameState.java
+++ b/src/main/java/games/cantstop/CantStopGameState.java
@@ -98,7 +98,7 @@ public class CantStopGameState extends AbstractGameState implements IPrintable {
 
     @Override
     protected double _getHeuristicScore(int playerId) {
-        if (!isNotTerminal()) {
+        if (isNotTerminal()) {
             return getGameScore(playerId) / ((CantStopParameters) gameParameters).COLUMNS_TO_WIN;
         } else
             return getPlayerResults()[playerId].value;

--- a/src/main/java/games/cantstop/CantStopGameState.java
+++ b/src/main/java/games/cantstop/CantStopGameState.java
@@ -64,6 +64,7 @@ public class CantStopGameState extends AbstractGameState implements IPrintable {
             dice.get(i).setValue(numbers[i]);
         }
     }
+
     public int[] getDice() {
         return dice.stream().mapToInt(Dice::getValue).toArray();
     }
@@ -72,7 +73,7 @@ public class CantStopGameState extends AbstractGameState implements IPrintable {
         return playerMarkerPositions.get(player)[number];
     }
 
-    public int getTemporaryMarkerPosition(int number)  {
+    public int getTemporaryMarkerPosition(int number) {
         return temporaryMarkerPositions.getOrDefault(number, 0);
     }
 
@@ -97,7 +98,10 @@ public class CantStopGameState extends AbstractGameState implements IPrintable {
 
     @Override
     protected double _getHeuristicScore(int playerId) {
-        return getGameScore(playerId);
+        if (!isNotTerminal()) {
+            return getGameScore(playerId) / ((CantStopParameters) gameParameters).COLUMNS_TO_WIN;
+        } else
+            return getPlayerResults()[playerId].value;
         // have not bothered to implement one.
     }
 

--- a/src/main/java/games/coltexpress/ColtExpressHeuristic.java
+++ b/src/main/java/games/coltexpress/ColtExpressHeuristic.java
@@ -41,7 +41,6 @@ public class ColtExpressHeuristic extends TunableParameters implements IStateHeu
     public double evaluateState(AbstractGameState gs, int playerId) {
         ColtExpressGameState cegs = (ColtExpressGameState) gs;
         ColtExpressParameters cep = (ColtExpressParameters) gs.getGameParameters();
-        Utils.GameResult playerResult = gs.getPlayerResults()[playerId];
 
         if (!cegs.isNotTerminal())
             return cegs.getPlayerResults()[playerId].value;

--- a/src/main/java/games/diamant/DiamantForwardModel.java
+++ b/src/main/java/games/diamant/DiamantForwardModel.java
@@ -13,7 +13,6 @@ import games.diamant.components.ActionsPlayed;
 import utilities.Utils;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 
@@ -25,15 +24,21 @@ public class DiamantForwardModel extends AbstractForwardModel {
     protected void _setup(AbstractGameState firstState) {
         DiamantGameState dgs = (DiamantGameState) firstState;
         Random r = new Random(dgs.getGameParameters().getRandomSeed());
-        int players = firstState.getNPlayers();
 
-        dgs.hands = new int[players];
-        dgs.treasureChests = new int[players];
-        Arrays.fill(dgs.playerInCave, true);
+        dgs.hands = new ArrayList<>();
+        dgs.treasureChests = new ArrayList<>();
 
-        dgs.mainDeck = new Deck<>("MainDeck", HIDDEN_TO_ALL);
-        dgs.discardDeck = new Deck<>("DiscardDeck", VISIBLE_TO_ALL);
-        dgs.path = new Deck<>("Path", VISIBLE_TO_ALL);
+        for (int i = 0; i < dgs.getNPlayers(); i++) {
+            String counter_hand_name = "CounterHand" + i;
+            String counter_chest_name = "CounterChest" + i;
+            dgs.hands.add(new Counter(0, 0, 1000, counter_hand_name));
+            dgs.treasureChests.add(new Counter(0, 0, 1000, counter_chest_name));
+            dgs.playerInCave.add(true);
+        }
+
+        dgs.mainDeck = new Deck("MainDeck", HIDDEN_TO_ALL);
+        dgs.discardDeck = new Deck("DiscardDeck", VISIBLE_TO_ALL);
+        dgs.path = new Deck("Path", VISIBLE_TO_ALL);
         dgs.actionsPlayed = new ActionsPlayed();
 
         createCards(dgs);
@@ -131,10 +136,10 @@ public class DiamantForwardModel extends AbstractForwardModel {
 
         for (int p = 0; p < dgs.getNPlayers(); p++) {
             if (dgs.actionsPlayed.get(p) instanceof ExitFromCave) {
-                dgs.hands[p] += gems_to_players;                             // increment hand gems
-                dgs.treasureChests[p] += dgs.hands[p];   // hand gems to chest
-                dgs.hands[p] = 0;                                 // hand gems <- 0
-                dgs.playerInCave[p] = false;                                      // Set to not in Cave
+                dgs.hands.get(p).increment(gems_to_players);                             // increment hand gems
+                dgs.treasureChests.get(p).increment(dgs.hands.get(p).getValue());   // hand gems to chest
+                dgs.hands.get(p).setValue(0);                                 // hand gems <- 0
+                dgs.playerInCave.set(p, false);                                       // Set to not in Cave
             }
         }
     }
@@ -168,7 +173,8 @@ public class DiamantForwardModel extends AbstractForwardModel {
             dgs.nHazardSnakesOnPath = 0;
 
             // All the player will participate in next cave
-            Arrays.fill(dgs.playerInCave, true);
+            for (int p = 0; p < dgs.getNPlayers(); p++)
+                dgs.playerInCave.set(p, true);
 
             drawAndPlayCard(dgs);
         }
@@ -184,7 +190,7 @@ public class DiamantForwardModel extends AbstractForwardModel {
         List<Integer> bestPlayers = new ArrayList<>();
 
         for (int p = 0; p < dgs.getNPlayers(); p++) {
-            int nGems = dgs.treasureChests[p];
+            int nGems = dgs.treasureChests.get(p).getValue();
             if (nGems > maxGems) {
                 bestPlayers.clear();
                 bestPlayers.add(p);
@@ -223,7 +229,7 @@ public class DiamantForwardModel extends AbstractForwardModel {
         ArrayList<AbstractAction> actions = new ArrayList<>();
 
         // If the player is still in the cave
-        if (dgs.playerInCave[gameState.getCurrentPlayer()]) {
+        if (dgs.playerInCave.get(gameState.getCurrentPlayer())) {
             actions.add(new ContinueInCave());
             actions.add(new ExitFromCave());
         } else
@@ -251,8 +257,8 @@ public class DiamantForwardModel extends AbstractForwardModel {
             int gems_to_path = card.getNumberOfGems() % dgs.getNPlayersInCave();
 
             for (int p = 0; p < dgs.getNPlayers(); p++)
-                if (dgs.playerInCave[p])
-                    dgs.hands[p] += gems_to_players;
+                if (dgs.playerInCave.get(p))
+                    dgs.hands.get(p).increment(gems_to_players);
 
             dgs.nGemsOnPath += gems_to_path;
         } else if (card.getCardType() == DiamantCard.DiamantCardType.Hazard) {
@@ -271,8 +277,8 @@ public class DiamantForwardModel extends AbstractForwardModel {
                     dgs.nHazardExplosionsOnPath == dp.nHazardsToDead) {
                 // All active players loose all gems on hand.
                 for (int p = 0; p < dgs.getNPlayers(); p++) {
-                    if (dgs.playerInCave[p]) {
-                        dgs.hands[p] = 0;
+                    if (dgs.playerInCave.get(p)) {
+                        dgs.hands.get(p).setValue(0);
                         dgs.recordOfPlayerActions.add(new DiamantGameState.PlayerTurnRecord(p, dgs.nCave, -1));
                     }
                 }

--- a/src/main/java/games/diamant/DiamantGameState.java
+++ b/src/main/java/games/diamant/DiamantGameState.java
@@ -11,20 +11,20 @@ import games.GameType;
 import games.diamant.cards.DiamantCard;
 import games.diamant.components.ActionsPlayed;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
-import static java.util.stream.Collectors.*;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.Random;
 
 
 public class DiamantGameState extends AbstractGameState implements IPrintable {
-    Deck<DiamantCard> mainDeck;
-    Deck<DiamantCard> discardDeck;
-    Deck<DiamantCard> path;
+    Deck<DiamantCard>          mainDeck;
+    Deck<DiamantCard>          discardDeck;
+    Deck<DiamantCard>          path;
 
-    int[] treasureChests;
-    int[] hands;
-    boolean[] playerInCave;
+    List<Counter> treasureChests;
+    List<Counter> hands;
+    List<Boolean> playerInCave;
 
     // helper data class to store interesting information
     static class PlayerTurnRecord {
@@ -41,11 +41,11 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
 
     List<PlayerTurnRecord> recordOfPlayerActions = new ArrayList<>();
 
-    int nGemsOnPath = 0;
+    int nGemsOnPath             = 0;
     int nHazardPoissonGasOnPath = 0;
-    int nHazardScorpionsOnPath = 0;
-    int nHazardSnakesOnPath = 0;
-    int nHazardRockfallsOnPath = 0;
+    int nHazardScorpionsOnPath  = 0;
+    int nHazardSnakesOnPath     = 0;
+    int nHazardRockfallsOnPath  = 0;
     int nHazardExplosionsOnPath = 0;
 
     int nCave = 0;
@@ -58,7 +58,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
      * Constructor. Initialises some generic game state variables.
      *
      * @param gameParameters - game parameters.
-     * @param nPlayers       - number of players for this game.
+     * @param nPlayers      - number of players for this game.
      */
     public DiamantGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, new StandardTurnOrder(nPlayers), GameType.Diamant);
@@ -70,40 +70,55 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
             add(mainDeck);
             add(discardDeck);
             add(path);
+            addAll(treasureChests);
+            addAll(hands);
+            add(actionsPlayed);
         }};
     }
 
     @Override
-    protected AbstractGameState _copy(int playerId) {
+    protected AbstractGameState _copy(int playerId)
+    {
+        Random r = new Random(getGameParameters().getRandomSeed());
+
         DiamantGameState dgs = new DiamantGameState(gameParameters.copy(), getNPlayers());
 
-        dgs.mainDeck = mainDeck.copy();
+        dgs.mainDeck    = mainDeck.copy();
         dgs.discardDeck = discardDeck.copy();
-        dgs.path = path.copy();
-        dgs.actionsPlayed = (ActionsPlayed) actionsPlayed.copy();
+        dgs.path        = path.copy();
+        dgs.actionsPlayed  = (ActionsPlayed) actionsPlayed.copy();
 
-        dgs.nGemsOnPath = nGemsOnPath;
+        dgs.nGemsOnPath             = nGemsOnPath;
         dgs.nHazardPoissonGasOnPath = nHazardPoissonGasOnPath;
-        dgs.nHazardScorpionsOnPath = nHazardScorpionsOnPath;
-        dgs.nHazardSnakesOnPath = nHazardSnakesOnPath;
-        dgs.nHazardRockfallsOnPath = nHazardRockfallsOnPath;
+        dgs.nHazardScorpionsOnPath  = nHazardScorpionsOnPath;
+        dgs.nHazardSnakesOnPath     = nHazardSnakesOnPath;
+        dgs.nHazardRockfallsOnPath  = nHazardRockfallsOnPath;
         dgs.nHazardExplosionsOnPath = nHazardExplosionsOnPath;
 
-        dgs.nCave = nCave;
+        dgs.nCave          = nCave;
+        dgs.hands          = new ArrayList<>();
+        dgs.treasureChests = new ArrayList<>();
+        dgs.playerInCave   = new ArrayList<>();
         dgs.recordOfPlayerActions.addAll(recordOfPlayerActions);
 
-        dgs.hands = hands.clone();
-        dgs.treasureChests = treasureChests.clone();
-        dgs.playerInCave = playerInCave.clone();
+        for (Counter c : hands)
+            dgs.hands.add(c.copy());
+
+        for (Counter c : treasureChests)
+            dgs.treasureChests.add(c.copy());
 
         // If there is an action played for a player, then copy it
-        for (int i = 0; i < getNPlayers(); i++) {
+        for (int i=0; i<getNPlayers(); i++)
+        {
             if (actionsPlayed.containsKey(i))
                 dgs.actionsPlayed.put(i, actionsPlayed.get(i).copy());
         }
 
+        dgs.playerInCave.addAll(playerInCave);
+
         // mainDeck and is actionsPlayed are hidden.
-        if (getCoreGameParameters().partialObservable && playerId != -1) {
+        if (getCoreGameParameters().partialObservable && playerId != -1)
+        {
             dgs.mainDeck.shuffle(new Random(getGameParameters().getRandomSeed()));
 
             dgs.actionsPlayed.clear();
@@ -113,7 +128,7 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
             // a competition setting for example, it would be critical. There is no simple way to do this at the moment
             // because history (as part of the super-class) is only copied after we return from this _copy() method.
 
-            // Randomize actions for other players (or any other modelling approach)
+           // Randomize actions for other players (or any other modelling approach)
             // is now the responsibility of the deciding agent (see for example OSLA)
 
         }
@@ -121,10 +136,10 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     }
 
     @Override
-    protected double _getHeuristicScore(int playerId) {
+    protected double _getHeuristicScore(int playerId)
+    {
         return new DiamantHeuristic().evaluateState(this, playerId);
     }
-
     /**
      * This provides the current score in game turns. This will only be relevant for games that have the concept
      * of victory points, etc.
@@ -135,11 +150,12 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
      */
     @Override
     public double getGameScore(int playerId) {
-        return treasureChests[playerId];
+         return treasureChests.get(playerId).getValue();
     }
 
     @Override
-    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId) {
+    protected ArrayList<Integer> _getUnknownComponentsIds(int playerId)
+    {
         ArrayList<Integer> ids = new ArrayList<>();
         ids.add(actionsPlayed.getComponentID());
         return ids;
@@ -147,19 +163,19 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
 
     @Override
     protected void _reset() {
-        mainDeck = null;
-        discardDeck = null;
-        path = null;
-        actionsPlayed = null;
-        treasureChests = new int[getNPlayers()];
-        hands = new int[getNPlayers()];
-        playerInCave = new boolean[getNPlayers()];
+        mainDeck       = null;
+        discardDeck    = null;
+        path           = null;
+        actionsPlayed  = null;
+        treasureChests = new ArrayList<>();
+        hands          = new ArrayList<>();
+        playerInCave   = new ArrayList<>();
 
-        nGemsOnPath = 0;
+        nGemsOnPath             = 0;
         nHazardPoissonGasOnPath = 0;
-        nHazardScorpionsOnPath = 0;
-        nHazardSnakesOnPath = 0;
-        nHazardRockfallsOnPath = 0;
+        nHazardScorpionsOnPath  = 0;
+        nHazardSnakesOnPath     = 0;
+        nHazardRockfallsOnPath  = 0;
         nHazardExplosionsOnPath = 0;
 
         nCave = 0;
@@ -167,36 +183,38 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     }
 
     @Override
-    protected boolean _equals(Object o) {
-        if (this == o) return true;
+    protected boolean _equals(Object o)
+    {
+        if (this == o)                        return true;
         if (!(o instanceof DiamantGameState)) return false;
-        if (!super.equals(o)) return false;
+        if (!super.equals(o))                 return false;
 
         DiamantGameState that = (DiamantGameState) o;
 
-        return nGemsOnPath == that.nGemsOnPath &&
-                nHazardExplosionsOnPath == that.nHazardExplosionsOnPath &&
-                nHazardPoissonGasOnPath == that.nHazardPoissonGasOnPath &&
-                nHazardRockfallsOnPath == that.nHazardRockfallsOnPath &&
-                nHazardScorpionsOnPath == that.nHazardScorpionsOnPath &&
-                nHazardSnakesOnPath == that.nHazardSnakesOnPath &&
-                nCave == that.nCave &&
-                Objects.equals(mainDeck, that.mainDeck) &&
-                Objects.equals(discardDeck, that.discardDeck) &&
-                Arrays.equals(hands, that.hands) &&
-                Arrays.equals(treasureChests, that.treasureChests) &&
-                Objects.equals(path, that.path) &&
-                Arrays.equals(playerInCave, that.playerInCave) &&
-                Objects.equals(actionsPlayed, that.actionsPlayed);
+        return nGemsOnPath             == that.nGemsOnPath             &&
+               nHazardExplosionsOnPath == that.nHazardExplosionsOnPath &&
+               nHazardPoissonGasOnPath == that.nHazardPoissonGasOnPath &&
+               nHazardRockfallsOnPath  == that.nHazardRockfallsOnPath  &&
+               nHazardScorpionsOnPath  == that.nHazardScorpionsOnPath  &&
+               nHazardSnakesOnPath     == that.nHazardSnakesOnPath     &&
+               nCave                   == that.nCave                   &&
+               Objects.equals(mainDeck,       that.mainDeck)           &&
+               Objects.equals(discardDeck,    that.discardDeck)        &&
+               Objects.equals(hands,          that.hands)              &&
+               Objects.equals(treasureChests, that.treasureChests)     &&
+               Objects.equals(path,           that.path)               &&
+               Objects.equals(playerInCave,   that.playerInCave)       &&
+               Objects.equals(actionsPlayed,  that.actionsPlayed);
     }
 
     /**
      * Returns the number of player already in the cave
-     */
+    */
 
-    public int getNPlayersInCave() {
+    public int getNPlayersInCave()
+    {
         int n = 0;
-        for (Boolean b : playerInCave)
+        for (Boolean b: playerInCave)
             if (b) n++;
         return n;
     }
@@ -209,61 +227,52 @@ public class DiamantGameState extends AbstractGameState implements IPrintable {
     public void printToConsole() {
         String[] strings = new String[13];
 
-        StringBuilder str_playersOnCave = new StringBuilder();
+        StringBuilder str_gemsOnHand          = new StringBuilder();
+        StringBuilder str_gemsOnTreasureChest = new StringBuilder();
+        StringBuilder str_playersOnCave       = new StringBuilder();
 
-        for (boolean b : playerInCave) {
-            str_playersOnCave.append(b ? "T" : "F").append(" ");
+        for (Counter c:hands)          { str_gemsOnHand.         append(c.getValue()).append(" "); }
+        for (Counter c:treasureChests) { str_gemsOnTreasureChest.append(c.getValue()).append(" "); }
+        for (Boolean b : playerInCave)
+        {
+            if (b) str_playersOnCave.append("T");
+            else   str_playersOnCave.append("F");
         }
 
-        strings[0] = "----------------------------------------------------";
-        strings[1] = "Cave:                       " + nCave;
-        strings[2] = "Players on Cave:            " + str_playersOnCave.toString();
-        strings[3] = "Path:                       " + path.toString();
-        strings[4] = "Gems on Path:               " + nGemsOnPath;
-        strings[5] = "Gems on hand:               " + Arrays.stream(hands).mapToObj(String::valueOf).collect(joining(" "));
-        strings[6] = "Gems on treasure chest:     " + Arrays.stream(treasureChests).mapToObj(String::valueOf).collect(joining(" "));
-        strings[7] = "Hazard scorpions in Path:   " + nHazardScorpionsOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Scorpions);
-        strings[8] = "Hazard snakes in Path:      " + nHazardSnakesOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Snakes);
-        strings[9] = "Hazard rockfalls in Path:   " + nHazardRockfallsOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Rockfalls);
+        strings[0]  = "----------------------------------------------------";
+        strings[1]  = "Cave:                       " + nCave;
+        strings[2]  = "Players on Cave:            " + str_playersOnCave.toString();
+        strings[3]  = "Path:                       " + path.toString();
+        strings[4]  = "Gems on Path:               " + nGemsOnPath;
+        strings[5]  = "Gems on hand:               " + str_gemsOnHand.toString();
+        strings[6]  = "Gems on treasure chest:     " + str_gemsOnTreasureChest.toString();
+        strings[7]  = "Hazard scorpions in Path:   " + nHazardScorpionsOnPath  + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Scorpions);
+        strings[8]  = "Hazard snakes in Path:      " + nHazardSnakesOnPath     + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Snakes);
+        strings[9]  = "Hazard rockfalls in Path:   " + nHazardRockfallsOnPath  + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Rockfalls);
         strings[10] = "Hazard poisson gas in Path: " + nHazardPoissonGasOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.PoissonGas);
         strings[11] = "Hazard explosions in Path:  " + nHazardExplosionsOnPath + ", in Main deck: " + getNHazardCardsInMainDeck(DiamantCard.HazardType.Explosions);
         strings[12] = "----------------------------------------------------";
 
-        for (String s : strings) {
+        for (String s : strings){
             System.out.println(s);
         }
     }
 
-    private int getNHazardCardsInMainDeck(DiamantCard.HazardType ht) {
+    private int getNHazardCardsInMainDeck(DiamantCard.HazardType ht)
+    {
         int n = 0;
-        for (int i = 0; i < mainDeck.getSize(); i++) {
+        for (int i=0; i<mainDeck.getSize(); i++)
+        {
             if (mainDeck.get(i).getHazardType() == ht)
-                n++;
+                n ++;
         }
         return n;
     }
 
-    public Deck<DiamantCard> getMainDeck() {
-        return mainDeck;
-    }
-
-    public Deck<DiamantCard> getDiscardDeck() {
-        return discardDeck;
-    }
-
-    public int[] getHands() {
-        return hands;
-    }
-
-    public int[] getTreasureChests() {
-        return treasureChests;
-    }
-
-    public Deck<DiamantCard> getPath() {
-        return path;
-    }
-
-    public ActionsPlayed getActionsPlayed() {
-        return actionsPlayed;
-    }
+    public Deck<DiamantCard> getMainDeck()       { return mainDeck;       }
+    public Deck<DiamantCard> getDiscardDeck()    { return discardDeck;    }
+    public List<Counter>     getHands()          { return hands;          }
+    public List<Counter>     getTreasureChests() { return treasureChests; }
+    public Deck<DiamantCard> getPath()           { return path;           }
+    public ActionsPlayed     getActionsPlayed()  { return actionsPlayed;  }
 }

--- a/src/main/java/games/diamant/DiamantHeuristic.java
+++ b/src/main/java/games/diamant/DiamantHeuristic.java
@@ -6,7 +6,6 @@ import core.interfaces.IStateHeuristic;
 import evaluation.TunableParameters;
 import utilities.Utils;
 
-import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -56,13 +55,14 @@ public class DiamantHeuristic extends TunableParameters implements IStateHeurist
             return 1;
 
         DiamantGameState dgs = (DiamantGameState) gs;
-        List<Integer> gemsInOrder = Arrays.stream(dgs.treasureChests)
+        List<Integer> gemsInOrder = dgs.getTreasureChests().stream()
+                .mapToInt(Counter::getValue)
                 .sorted().boxed().collect(Collectors.toList());
 
         int max_ngens = gemsInOrder.get(dgs.getNPlayers()-1);
         int min_ngens = gemsInOrder.get(0);
 
-        int player_gems = dgs.treasureChests[playerId];
+        int player_gems = dgs.treasureChests.get(playerId).getValue();
         double highestExpectedScore = 139.0 / gs.getNPlayers() * 2.0;
         // 1.0 if a player has every single gem in a 2-player game; 67% of gems in a 3-player; 50% in a 4-player....
         double score = FACTOR_SCORE * player_gems / highestExpectedScore;
@@ -73,7 +73,7 @@ public class DiamantHeuristic extends TunableParameters implements IStateHeurist
 
         score += FACTOR_AHEAD * (player_gems - min_ngens) / highestExpectedScore;
 
-        if (dgs.playerInCave[playerId]) score += FACTOR_IN_CAVE;  // are we in the cave...for luck-pushing strategies
+        if (dgs.playerInCave.get(playerId)) score += FACTOR_IN_CAVE;  // are we in the cave...for luck-pushing strategies
 
         return score;
     }

--- a/src/main/java/players/mcts/BasicTreeNode.java
+++ b/src/main/java/players/mcts/BasicTreeNode.java
@@ -239,7 +239,10 @@ class BasicTreeNode {
             }
         }
         // Evaluate final state and return normalised score
-        return player.params.getHeuristic().evaluateState(rolloutState, player.getPlayerID());
+        double value = player.params.getHeuristic().evaluateState(rolloutState, player.getPlayerID());
+        if (Double.isNaN(value))
+            throw new AssertionError("Illegal heuristic value - should be a number");
+        return value;
     }
 
     /**

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -832,6 +832,8 @@ public class SingleTreeNode {
 
         for (int i = 0; i < retValue.length; i++) {
             retValue[i] = heuristic.evaluateState(rolloutState, i) - startingValues[i];
+            if (Double.isNaN(retValue[i]))
+                throw new AssertionError("Illegal heuristic value - should be a number");
         }
         return retValue;
     }

--- a/src/main/java/players/rhea/RHEAIndividual.java
+++ b/src/main/java/players/rhea/RHEAIndividual.java
@@ -108,6 +108,8 @@ public class RHEAIndividual implements Comparable<RHEAIndividual> {
         for (int i = 0; i < startIndex; i++) {
             double score;
             score = heuristic.evaluateState(gameStates[i + 1], playerID);
+            if (Double.isNaN(score))
+                throw new AssertionError("Illegal heuristic value - should be a number");
             delta += Math.pow(discountFactor, i) * (score - previousScore);
             previousScore = score;
         }
@@ -155,6 +157,8 @@ public class RHEAIndividual implements Comparable<RHEAIndividual> {
                 // Add value of state, discounted
                 double score;
                 score = heuristic.evaluateState(gameStates[i + 1], playerID);
+                if (Double.isNaN(score))
+                    throw new AssertionError("Illegal heuristic value - should be a number");
                 delta += Math.pow(discountFactor, i) * (score - previousScore);
                 previousScore = score;
 

--- a/src/main/java/players/rmhc/Individual.java
+++ b/src/main/java/players/rmhc/Individual.java
@@ -85,6 +85,7 @@ public class Individual implements Comparable {
         length = 0;
         int fmCalls = 0;
         double delta = 0;
+        double previousScore = 0;
 
         for (int i = 0; i < startIndex; i++) {
             double score;
@@ -95,8 +96,8 @@ public class Individual implements Comparable {
             }
             if (Double.isNaN(score))
                 throw new AssertionError("Illegal heuristic value - should be a number");
-
-            delta += Math.pow(discountFactor, i) * score;
+            delta += Math.pow(discountFactor, i) * (score - previousScore);
+            previousScore = score;
         }
 
         for (int i = startIndex; i < actions.length; i++){
@@ -133,7 +134,8 @@ public class Individual implements Comparable {
                     }
                     if (Double.isNaN(score))
                         throw new AssertionError("Illegal heuristic value - should be a number");
-                    delta += Math.pow(discountFactor, i) * score;
+                    delta += Math.pow(discountFactor, i) * (score - previousScore);
+                    previousScore = score;
                 } else {
                     i--;
                 }

--- a/src/main/java/players/rmhc/Individual.java
+++ b/src/main/java/players/rmhc/Individual.java
@@ -93,6 +93,8 @@ public class Individual implements Comparable {
             } else {
                 score = gameStates[i+1].getHeuristicScore(playerID);
             }
+            if (Double.isNaN(score))
+                throw new AssertionError("Illegal heuristic value - should be a number");
 
             delta += Math.pow(discountFactor, i) * score;
         }
@@ -129,6 +131,8 @@ public class Individual implements Comparable {
                     } else {
                         score = gameStates[i+1].getHeuristicScore(playerID);
                     }
+                    if (Double.isNaN(score))
+                        throw new AssertionError("Illegal heuristic value - should be a number");
                     delta += Math.pow(discountFactor, i) * score;
                 } else {
                     i--;


### PR DESCRIPTION
1) Added error message if heuristic returns NaN in RHEA/RMHC/MCTS/BasicMCTS - previously this was being stored in the expanded node, and causing a crash later during selection. This now fails early to enable rapid pinpointing of the error.

2) Reversed out the changes for Diamant (Components are back)

3) Corrected RMHC rollout to match RHEA - we discount the *changes* in the score at each time-step, not the full state evaluations, which is tremendously wrong.

4) Fixed CantStop._getHeuristicScore() to obey the contract that it is bounded in [-1, +1]