### PR TITLE
SushiGo - make PlayCardAction's cardType public

### DIFF
--- a/src/main/java/games/sushigo/actions/PlayCardAction.java
+++ b/src/main/java/games/sushigo/actions/PlayCardAction.java
@@ -12,7 +12,7 @@ import java.util.Objects;
 
 public class PlayCardAction extends AbstractAction {
     final int playerId;
-    final SGCard.SGCardType cardType;
+    public final SGCard.SGCardType cardType;
 
     public PlayCardAction(int playerId, SGCard.SGCardType cardType)
     {


### PR DESCRIPTION
### Pruning

Make `cardType` in `PlayCardAction` public. With this, an MCTS agent can analyze the actions (cards to play) at the selection stage and prune unnecessary moves.