### PR TITLE
Game fixes and MCTS options

### DIFF
--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -495,6 +495,8 @@ public class Game {
 
         // This is the next player to be asked for a decision
         int activePlayer = gameState.getCurrentPlayer();
+        if (!gameState.isNotTerminalForPlayer(activePlayer))
+            throw new AssertionError("Player " + activePlayer + " is not allowed to move");
         AbstractPlayer currentPlayer = players.get(activePlayer);
         if (debug) System.out.printf("Starting oneAction for player %s%n", activePlayer);
 

--- a/src/main/java/core/StandardForwardModel.java
+++ b/src/main/java/core/StandardForwardModel.java
@@ -5,12 +5,9 @@ import core.interfaces.IExtendedSequence;
 import evaluation.metrics.Event;
 
 import java.util.Arrays;
-import java.util.Stack;
 
-import static core.CoreConstants.GameResult.GAME_ONGOING;
-import static core.CoreConstants.GameResult.TIMEOUT;
-import static evaluation.metrics.Event.GameEvent.ROUND_OVER;
-import static evaluation.metrics.Event.GameEvent.TURN_OVER;
+import static core.CoreConstants.GameResult.*;
+import static evaluation.metrics.Event.GameEvent.*;
 
 public abstract class StandardForwardModel extends AbstractForwardModel {
 
@@ -94,7 +91,13 @@ public abstract class StandardForwardModel extends AbstractForwardModel {
      */
     @Override
     public final void endPlayerTurn(AbstractGameState gs) {
-        endPlayerTurn(gs, (gs.turnOwner + 1) % gs.nPlayers);
+        int turnOwner = gs.turnOwner;
+        do {
+            turnOwner = (turnOwner + 1) % gs.nPlayers;
+            if (turnOwner == gs.turnOwner)
+                throw new AssertionError("Infinite loop - apparently all players are terminal, but game state is not");
+        } while (!gs.isNotTerminalForPlayer(turnOwner));
+        endPlayerTurn(gs, turnOwner);
     }
 
     /**

--- a/src/main/java/evaluation/ParameterSearch.java
+++ b/src/main/java/evaluation/ParameterSearch.java
@@ -228,7 +228,7 @@ public class ParameterSearch {
         Pair<Pair<Double, Double>, double[]> bestResult = new Pair<>(new Pair<>(Double.NEGATIVE_INFINITY, Double.NEGATIVE_INFINITY), new double[0]);
         for (int mainLoop = 0; mainLoop < repeats; mainLoop++) {
             landscapeModel.reset();
-            evaluator.statsLogger = IStatisticLogger.createLogger("utilities.SummaryLogger", "Agent_" + String.format("%2d", repeats+1) + "_" + logfile);
+            evaluator.statsLogger = IStatisticLogger.createLogger("evaluation.loggers.SummaryLogger", "Agent_" + String.format("%2d", repeats+1) + "_" + logfile);
             Pair<Double, Double> r = runNTBEA(evaluator, null, searchFramework, iterationsPerRun, iterationsPerRun, evalGames, verbose);
             Pair<Pair<Double, Double>, double[]> retValue = new Pair<>(r, landscapeModel.getBestOfSampled());
             printDetailsOfRun(retValue, searchSpace, logfile, verbose, evaluator.statsLogger);

--- a/src/main/java/games/battlelore/BattleloreForwardModel.java
+++ b/src/main/java/games/battlelore/BattleloreForwardModel.java
@@ -78,11 +78,11 @@ public class BattleloreForwardModel extends StandardForwardModel {
 
         if (checkGameEnd((BattleloreGameState) currentState, playerId) || state.getRoundCounter() >= maxRounds) {
             endGame(currentState);
+        } else {
+            endPlayerTurn(currentState);
+            if (currentState.getCurrentPlayer() == 0)
+                endRound(currentState);
         }
-
-        endPlayerTurn(currentState);
-        if (currentState.getCurrentPlayer() == 0)
-            endRound(currentState);
     }
 
     private void PutLearningScenarioUnits(BattleloreGameState gameState) {

--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -202,9 +202,9 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
         int player = cegs.getCurrentPlayer();
         ArrayList<AbstractAction> actions = new ArrayList<>();
         if (cegs.plannedActions.getSize() == 0) {
-            // actions.add(new DoNothing());
-            //  return actions;
-            throw new AssertionError("Error - no actions available");
+            // this can happen if all players use all their actions to draw cards, and never play any
+            actions.add(new DoNothing());
+            return actions;
         }
 
         int cardIdx = cegs.plannedActions.getSize() - 1;

--- a/src/main/java/games/diamant/DiamantForwardModel.java
+++ b/src/main/java/games/diamant/DiamantForwardModel.java
@@ -89,7 +89,8 @@ public class DiamantForwardModel extends StandardForwardModel {
             playActions(dgs);
             dgs.actionsPlayed.clear();
         }
-        endPlayerTurn(dgs);
+        if (dgs.isNotTerminal())
+            endPlayerTurn(dgs);
     }
 
 

--- a/src/main/java/games/poker/PokerForwardModel.java
+++ b/src/main/java/games/poker/PokerForwardModel.java
@@ -1,4 +1,5 @@
 package games.poker;
+
 import core.AbstractGameState;
 import core.CoreConstants;
 import core.StandardForwardModel;
@@ -50,6 +51,7 @@ public class PokerForwardModel extends StandardForwardModel {
 
     /**
      * Sets up a round for the game, including draw pile, discard deck and player decks, all reset.
+     *
      * @param pgs - current game state.
      */
     private void setupRound(PokerGameState pgs) {
@@ -90,7 +92,7 @@ public class PokerForwardModel extends StandardForwardModel {
 
     private void drawCardsToPlayers(PokerGameState pgs) {
         for (int player = 0; player < pgs.getNPlayers(); player++) {
-            for (int card = 0; card < ((PokerGameParameters)pgs.getGameParameters()).nCardsPerPlayer; card++) {
+            for (int card = 0; card < ((PokerGameParameters) pgs.getGameParameters()).nCardsPerPlayer; card++) {
                 pgs.playerDecks.get(player).add(pgs.drawDeck.draw());
             }
         }
@@ -103,7 +105,7 @@ public class PokerForwardModel extends StandardForwardModel {
         PokerGameParameters pgp = (PokerGameParameters) gameState.getGameParameters();
 
         if (action instanceof Fold) {
-            fold(pgs, ((Fold)action).playerId);
+            fold(pgs, ((Fold) action).playerId);
         }
 
         pgs.playerActStreet[pgs.getCurrentPlayer()] = true;
@@ -114,7 +116,7 @@ public class PokerForwardModel extends StandardForwardModel {
             for (int i = 0; i < pgs.getNPlayers(); i++) {
                 if (pgs.getPlayerResults()[i] != LOSE_GAME && !pgs.playerFold[i]) {
                     stillAlive++;
-                    if (pgs.playerNeedsToCall[i] || !pgs.playerActStreet[i]){
+                    if (pgs.playerNeedsToCall[i] || !pgs.playerActStreet[i]) {
                         remainingDecisions = true;
                     }
                 }
@@ -152,11 +154,13 @@ public class PokerForwardModel extends StandardForwardModel {
                 }
             }
         }
-        endPlayerTurn(pgs);
+        if (pgs.isNotTerminal())
+            endPlayerTurn(pgs);
     }
 
     /**
      * Called when round is over. Calculate winner of round and distribute money.
+     *
      * @param pgs - current game state
      */
     private void roundEnd(PokerGameState pgs) {
@@ -166,7 +170,7 @@ public class PokerForwardModel extends StandardForwardModel {
         HashMap<Integer, Integer> ranks = translated.a;
         HashMap<Integer, HashSet<Integer>> hands = translated.b;
 
-        for (MoneyPot pot: pgs.moneyPots) {
+        for (MoneyPot pot : pgs.moneyPots) {
             // Calculate winners separately for each money pot
             HashSet<Integer> winners = getWinner(pgs, pot, ranks, hands);
             for (int i : winners) {
@@ -215,13 +219,13 @@ public class PokerForwardModel extends StandardForwardModel {
         HashSet<Integer> playersInPot = new HashSet<>(pot.getPlayerContribution().keySet());
 
         int smallestRank = 11;
-        for (int i: playersInPot) {
+        for (int i : playersInPot) {
             if (!pgs.playerFold[i] && pgs.getPlayerResults()[i] != LOSE_GAME && ranks.containsKey(i) && ranks.get(i) < smallestRank) {
                 smallestRank = ranks.get(i);
             }
         }
         HashSet<Integer> winners = new HashSet<>();
-        for (int i: playersInPot) {
+        for (int i : playersInPot) {
             if (!pgs.playerFold[i] && pgs.getPlayerResults()[i] != LOSE_GAME) {
                 if (ranks.get(i) == smallestRank) winners.add(i);
             }
@@ -255,6 +259,7 @@ public class PokerForwardModel extends StandardForwardModel {
 
     /**
      * Game ends when a player has the minimum money required to win. Player with most money wins.
+     *
      * @param pgs - game state
      * @return - true if game ended, false otherwise
      */
@@ -312,8 +317,8 @@ public class PokerForwardModel extends StandardForwardModel {
 
     @Override
     protected List<AbstractAction> _computeAvailableActions(AbstractGameState gameState) {
-        PokerGameState pgs = (PokerGameState)gameState;
-        PokerGameParameters pgp = (PokerGameParameters)gameState.getGameParameters();
+        PokerGameState pgs = (PokerGameState) gameState;
+        PokerGameParameters pgp = (PokerGameParameters) gameState.getGameParameters();
 
         ArrayList<AbstractAction> actions = new ArrayList<>();
         int player = pgs.getCurrentPlayer();
@@ -324,7 +329,8 @@ public class PokerForwardModel extends StandardForwardModel {
         boolean othersAllIn = true;  // True if all others are all in / out of the game, false otherwise
         for (int i = 0; i < gameState.getNPlayers(); i++) {
             if (pgs.getPlayerBet()[i].getValue() > biggestBet) biggestBet = pgs.getPlayerBet()[i].getValue();
-            if (i != player && pgs.getPlayerResults()[i] != LOSE_GAME && !pgs.playerFold[i] && !pgs.playerMoney[i].isMinimum()) othersAllIn = false;
+            if (i != player && pgs.getPlayerResults()[i] != LOSE_GAME && !pgs.playerFold[i] && !pgs.playerMoney[i].isMinimum())
+                othersAllIn = false;
         }
 
         if (pgs.playerNeedsToCall[player] && !pgs.getPlayerMoney()[player].isMinimum()) {

--- a/src/main/java/games/stratego/StrategoForwardModel.java
+++ b/src/main/java/games/stratego/StrategoForwardModel.java
@@ -82,7 +82,7 @@ public class StrategoForwardModel extends StandardForwardModel {
             sgs.setPlayerResult(CoreConstants.GameResult.LOSE_GAME, sgs.getCurrentPlayer());
             sgs.setPlayerResult(CoreConstants.GameResult.WIN_GAME, 1-sgs.getCurrentPlayer());
         } else {
-            if (sgs.getRoundCounter() >= ((StrategoParams)sgs.getGameParameters()).maxRounds) {
+            if (sgs.getTurnCounter() >= ((StrategoParams)sgs.getGameParameters()).maxRounds) {
                 // Max rounds reached, draw
                 sgs.setGameStatus(CoreConstants.GameResult.GAME_END);
                 sgs.setPlayerResult(CoreConstants.GameResult.DRAW_GAME, sgs.getCurrentPlayer());

--- a/src/main/java/games/sushigo/SGForwardModel.java
+++ b/src/main/java/games/sushigo/SGForwardModel.java
@@ -85,8 +85,12 @@ public class SGForwardModel extends StandardForwardModel {
         SGGameState gs = (SGGameState) currentState;
 
         // Check if all players made their choice
-        int turn = gs.getTurnCounter();
-        if ((turn + 1) % gs.getNPlayers() == 0) {
+        int nextPlayer = gs.getCurrentPlayer();
+        do {
+            nextPlayer = (nextPlayer + 1) % gs.getNPlayers();
+        } while (nextPlayer != gs.getCurrentPlayer() && !gs.cardChoices.get(nextPlayer).isEmpty());
+
+        if (nextPlayer == gs.getCurrentPlayer()) {
             // They did! Reveal all cards at once. Process card reveal rules.
             revealCards(gs);
 
@@ -123,7 +127,7 @@ public class SGForwardModel extends StandardForwardModel {
 
         // End player turn
         if (gs.getGameStatus() == CoreConstants.GameResult.GAME_ONGOING) {
-            endPlayerTurn(gs);
+            endPlayerTurn(gs, nextPlayer);
         }
     }
 

--- a/src/main/java/games/sushigo/SGGameState.java
+++ b/src/main/java/games/sushigo/SGGameState.java
@@ -105,10 +105,12 @@ public class SGGameState extends AbstractGameState {
                 if (i == playerId) {
                     copy.cardChoices.add(new ArrayList<>(cardChoices.get(i)));
                 } else {
-                    // Replace others with hidden choices
+                    // Replace others with hidden choices (pick one card at random)
+                    // Note that this is slightly incorrect, and does not hide whether the player is using chopsticks
                     ArrayList<ChooseCard> hiddenChoice = new ArrayList<>();
+                    int cardsInHand = playerHands.get(i).getSize();
                     for (ChooseCard c : cardChoices.get(i)) {
-                        hiddenChoice.add(c.getHiddenChoice());
+                        hiddenChoice.add(c.getHiddenChoice(rnd.nextInt(cardsInHand)));
                     }
                     copy.cardChoices.add(hiddenChoice);
                 }
@@ -141,7 +143,7 @@ public class SGGameState extends AbstractGameState {
     }
 
     /**
-     * we do know the contents of the hands of players to our T to our left, where T is the number of player turns
+     * we do know the contents of the hands of players up to T to our left, where T is the number of player turns
      * so far, as we saw that hand on its way through our own
      *
      * @param playerId   - id of player whose vision we're checking

--- a/src/main/java/games/sushigo/SGGameState.java
+++ b/src/main/java/games/sushigo/SGGameState.java
@@ -96,26 +96,14 @@ public class SGGameState extends AbstractGameState {
 
         if (playerId == -1) {
             for (int i = 0; i < getNPlayers(); i++) {
-                copy.cardChoices.add(new ArrayList<>(cardChoices.get(i)));
+                List<ChooseCard> copiedItems = new ArrayList<>();
+                for (ChooseCard cc : cardChoices.get(i)) {
+                    copiedItems.add(cc.copy());
+                }
+                copy.cardChoices.add(copiedItems);
             }
         } else {
             // Now we need to redeterminise
-            // We don't know what other players have chosen for this round, hide card choices
-            for (int i = 0; i < getNPlayers(); i++) {
-                if (i == playerId) {
-                    copy.cardChoices.add(new ArrayList<>(cardChoices.get(i)));
-                } else {
-                    // Replace others with hidden choices (pick one card at random)
-                    // Note that this is slightly incorrect, and does not hide whether the player is using chopsticks
-                    ArrayList<ChooseCard> hiddenChoice = new ArrayList<>();
-                    int cardsInHand = playerHands.get(i).getSize();
-                    for (ChooseCard c : cardChoices.get(i)) {
-                        hiddenChoice.add(c.getHiddenChoice(rnd.nextInt(cardsInHand)));
-                    }
-                    copy.cardChoices.add(hiddenChoice);
-                }
-            }
-
             // We need to shuffle the hands of other players with the draw deck and then redraw
 
             // Add player hands unseen back to the draw pile
@@ -134,6 +122,17 @@ public class SGGameState extends AbstractGameState {
                     hand.clear();
                     for (int i = 0; i < handSize; i++) {
                         hand.add(copy.drawPile.draw());
+                    }
+                }
+            }
+
+            // We don't know what other players have chosen for this round, hide card choices
+            turnOwner = playerId;
+            for (int i = 0; i < getNPlayers(); i++) {
+                copy.cardChoices.add(new ArrayList<>());
+                if (i == playerId) {
+                    for (ChooseCard cc : cardChoices.get(i)) {
+                        copy.cardChoices.get(i).add(cc.copy());
                     }
                 }
             }

--- a/src/main/java/games/sushigo/actions/ChooseCard.java
+++ b/src/main/java/games/sushigo/actions/ChooseCard.java
@@ -23,10 +23,6 @@ public class ChooseCard extends AbstractAction implements IExtendedSequence {
         this.useChopsticks = useChopsticks;
     }
 
-    public ChooseCard getHiddenChoice(int index) {
-        return new ChooseCard(playerId, index, useChopsticks);
-    }
-
     @Override
     public boolean execute(AbstractGameState gs) {
         ((SGGameState) gs).addCardChoice(this, gs.getCurrentPlayer());

--- a/src/main/java/games/sushigo/actions/ChooseCard.java
+++ b/src/main/java/games/sushigo/actions/ChooseCard.java
@@ -9,7 +9,6 @@ import games.sushigo.SGGameState;
 import games.sushigo.cards.SGCard;
 
 import java.util.*;
-import java.util.stream.Collectors;
 
 public class ChooseCard extends AbstractAction implements IExtendedSequence {
     public final int playerId;
@@ -24,8 +23,8 @@ public class ChooseCard extends AbstractAction implements IExtendedSequence {
         this.useChopsticks = useChopsticks;
     }
 
-    public ChooseCard getHiddenChoice() {
-        return new ChooseCard(playerId, -1, useChopsticks);
+    public ChooseCard getHiddenChoice(int index) {
+        return new ChooseCard(playerId, index, useChopsticks);
     }
 
     @Override

--- a/src/main/java/games/uno/UnoForwardModel.java
+++ b/src/main/java/games/uno/UnoForwardModel.java
@@ -9,8 +9,10 @@ import games.uno.UnoGameParameters.UnoScoring;
 import games.uno.actions.NoCards;
 import games.uno.actions.PlayCard;
 import games.uno.cards.UnoCard;
+import utilities.Pair;
 
 import java.util.*;
+import java.util.stream.IntStream;
 
 import static core.CoreConstants.VisibilityMode.*;
 import static core.CoreConstants.GameResult.GAME_ONGOING;
@@ -183,6 +185,15 @@ public class UnoForwardModel extends StandardForwardModel {
                     roundWinner = playerID;
                     break;
                 }
+            }
+            UnoGameParameters params = (UnoGameParameters) ugs.getGameParameters();
+            if (ugs.getTurnCounter() > params.maxTurnsPerRound) {
+                roundEnd = true;
+                roundWinner = IntStream.range(0, ugs.getNPlayers())
+                        .mapToObj(i -> new Pair<>(i, ugs.playerDecks.get(i).getSize()))
+                        .min(Comparator.comparingInt(p -> p.b))
+                        .orElseThrow(() -> new AssertionError("No min card count found")).a;
+                break;
             }
         }
 

--- a/src/main/java/games/uno/UnoGameParameters.java
+++ b/src/main/java/games/uno/UnoGameParameters.java
@@ -42,6 +42,7 @@ public class UnoGameParameters extends TunableParameters {
     public int nWildPoints = 50;
     public int nWildDrawPoints = 50;
     public int nWinPoints = 500;
+    public int maxTurnsPerRound = 300;
 
     public UnoGameParameters(long seed) {
         super(seed);

--- a/src/main/java/players/mcts/BasicMCTSPlayer.java
+++ b/src/main/java/players/mcts/BasicMCTSPlayer.java
@@ -8,7 +8,7 @@ import core.interfaces.IStateHeuristic;
 import java.util.List;
 import java.util.Random;
 
-import static players.mcts.MCTSEnums.OpponentTreePolicy.Paranoid;
+import static players.mcts.MCTSEnums.OpponentTreePolicy.OneTree;
 import static players.mcts.MCTSEnums.SelectionPolicy.ROBUST;
 import static players.mcts.MCTSEnums.TreePolicy.UCB;
 import static players.mcts.MCTSEnums.Strategies.RANDOM;
@@ -43,7 +43,7 @@ public class BasicMCTSPlayer extends AbstractPlayer {
         this.params.information = MCTSEnums.Information.Closed_Loop;
         this.params.rolloutType = RANDOM;
         this.params.selectionPolicy = ROBUST;
-        this.params.opponentTreePolicy = Paranoid;
+        this.params.opponentTreePolicy = OneTree;
         this.params.treePolicy = UCB;
     }
 

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -21,7 +21,7 @@ public class MCTSEnums {
     }
 
     public enum TreePolicy {
-        UCB, EXP3, AlphaGo, RegretMatching, UCB_Tuned
+        UCB, UCB_Tuned, AlphaGo, EXP3, RegretMatching, RM_Plus, Hedge
     }
 
     public enum RolloutTermination {

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -29,8 +29,8 @@ public class MCTSEnums {
     }
 
     public enum OpponentTreePolicy {
-        SelfOnly(true), Paranoid(false), MaxN(false),
-        MultiTree(true), MultiTreeParanoid(true),
+        SelfOnly(true), OneTree(false),
+        MultiTree(true),
         OMA(false), OMA_All(false);
 
         boolean selfOnlyTree;

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -33,6 +33,7 @@ public class MCTSParams extends PlayerParameters {
     public boolean useMAST = false;
     public double MASTGamma = 0.5;
     public double MASTBoltzmann = 0.1;
+    public double exp3Boltzmann = 0.1;
     public MCTSEnums.Strategies expansionPolicy = RANDOM;
     public MCTSEnums.SelectionPolicy selectionPolicy = ROBUST;
     public MCTSEnums.TreePolicy treePolicy = UCB;
@@ -72,7 +73,8 @@ public class MCTSParams extends PlayerParameters {
     public MCTSParams(long seed) {
         super(seed);
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
-        addTunableParameter("boltzmannTemp", 0.1);
+        addTunableParameter("MASTBoltzmann", 0.1);
+        addTunableParameter("exp3Boltzmann", 0.1);
         addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 10, 30, 100));
         addTunableParameter("maxTreeDepth", 10, Arrays.asList(1, 3, 10, 30, 100));
         addTunableParameter("epsilon", 1e-6);
@@ -128,9 +130,10 @@ public class MCTSParams extends PlayerParameters {
         treePolicy = (MCTSEnums.TreePolicy) getParameterValue("treePolicy");
         opponentTreePolicy = (MCTSEnums.OpponentTreePolicy) getParameterValue("opponentTreePolicy");
         exploreEpsilon = (double) getParameterValue("exploreEpsilon");
-        MASTBoltzmann = (double) getParameterValue("boltzmannTemp");
+        MASTBoltzmann = (double) getParameterValue("MASTBoltzmann");
         MAST = (MCTSEnums.MASTType) getParameterValue("MAST");
         MASTGamma = (double) getParameterValue("MASTGamma");
+        exp3Boltzmann = (double) getParameterValue("exp3Boltzmann");
         rolloutClass = (String) getParameterValue("rolloutClass");
         oppModelClass = (String) getParameterValue("oppModelClass");
         gatherExpertIterationData = (boolean) getParameterValue("expertIteration");
@@ -235,6 +238,7 @@ public class MCTSParams extends PlayerParameters {
         retValue.useMAST = useMAST;
         retValue.MASTGamma = MASTGamma;
         retValue.MASTBoltzmann = MASTBoltzmann;
+        retValue.exp3Boltzmann = exp3Boltzmann;
         retValue.expansionPolicy = expansionPolicy;
         retValue.selectionPolicy = selectionPolicy;
         retValue.treePolicy = treePolicy;

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -20,7 +20,7 @@ import static players.mcts.MCTSEnums.RolloutTermination.DEFAULT;
 import static players.mcts.MCTSEnums.SelectionPolicy.ROBUST;
 import static players.mcts.MCTSEnums.Strategies.PARAMS;
 import static players.mcts.MCTSEnums.Strategies.RANDOM;
-import static players.mcts.MCTSEnums.TreePolicy.UCB;
+import static players.mcts.MCTSEnums.TreePolicy.*;
 
 public class MCTSParams extends PlayerParameters {
 
@@ -34,6 +34,7 @@ public class MCTSParams extends PlayerParameters {
     public double MASTGamma = 0.5;
     public double MASTBoltzmann = 0.1;
     public double exp3Boltzmann = 0.1;
+    public double hedgeBoltzmann = 0.1;
     public MCTSEnums.Strategies expansionPolicy = RANDOM;
     public MCTSEnums.SelectionPolicy selectionPolicy = ROBUST;
     public MCTSEnums.TreePolicy treePolicy = UCB;
@@ -75,6 +76,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
         addTunableParameter("MASTBoltzmann", 0.1);
         addTunableParameter("exp3Boltzmann", 0.1);
+        addTunableParameter("hedgeBoltzmann", 0.1);
         addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 10, 30, 100));
         addTunableParameter("maxTreeDepth", 10, Arrays.asList(1, 3, 10, 30, 100));
         addTunableParameter("epsilon", 1e-6);
@@ -125,15 +127,21 @@ public class MCTSParams extends PlayerParameters {
         rolloutTermination = (MCTSEnums.RolloutTermination) getParameterValue("rolloutTermination");
         oppModelType = (MCTSEnums.Strategies) getParameterValue("oppModelType");
         information = (MCTSEnums.Information) getParameterValue("information");
-        selectionPolicy = (MCTSEnums.SelectionPolicy) getParameterValue("selectionPolicy");
-        expansionPolicy = (MCTSEnums.Strategies) getParameterValue("expansionPolicy");
         treePolicy = (MCTSEnums.TreePolicy) getParameterValue("treePolicy");
+        selectionPolicy = (MCTSEnums.SelectionPolicy) getParameterValue("selectionPolicy");
+        if (selectionPolicy == MCTSEnums.SelectionPolicy.TREE &&
+                (treePolicy == UCB || treePolicy == UCB_Tuned || treePolicy == AlphaGo)) {
+            // in this case TREE is equivalent to SIMPLE
+            selectionPolicy = MCTSEnums.SelectionPolicy.SIMPLE;
+        }
+        expansionPolicy = (MCTSEnums.Strategies) getParameterValue("expansionPolicy");
         opponentTreePolicy = (MCTSEnums.OpponentTreePolicy) getParameterValue("opponentTreePolicy");
         exploreEpsilon = (double) getParameterValue("exploreEpsilon");
         MASTBoltzmann = (double) getParameterValue("MASTBoltzmann");
         MAST = (MCTSEnums.MASTType) getParameterValue("MAST");
         MASTGamma = (double) getParameterValue("MASTGamma");
         exp3Boltzmann = (double) getParameterValue("exp3Boltzmann");
+        hedgeBoltzmann = (double) getParameterValue("hedgeBoltzmann");
         rolloutClass = (String) getParameterValue("rolloutClass");
         oppModelClass = (String) getParameterValue("oppModelClass");
         gatherExpertIterationData = (boolean) getParameterValue("expertIteration");
@@ -239,6 +247,7 @@ public class MCTSParams extends PlayerParameters {
         retValue.MASTGamma = MASTGamma;
         retValue.MASTBoltzmann = MASTBoltzmann;
         retValue.exp3Boltzmann = exp3Boltzmann;
+        retValue.hedgeBoltzmann = hedgeBoltzmann;
         retValue.expansionPolicy = expansionPolicy;
         retValue.selectionPolicy = selectionPolicy;
         retValue.treePolicy = treePolicy;

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -1,9 +1,7 @@
 package players.mcts;
 
 import core.AbstractGameState;
-import core.AbstractParameters;
 import core.AbstractPlayer;
-import core.actions.AbstractAction;
 import core.interfaces.*;
 import evaluation.TunableParameters;
 import org.json.simple.JSONObject;
@@ -13,13 +11,11 @@ import utilities.Utils;
 
 import java.util.Arrays;
 import java.util.Random;
-import java.util.function.ToDoubleBiFunction;
 
 import static players.mcts.MCTSEnums.Information.Closed_Loop;
 import static players.mcts.MCTSEnums.Information.Open_Loop;
 import static players.mcts.MCTSEnums.MASTType.Rollout;
-import static players.mcts.MCTSEnums.OpponentTreePolicy.MaxN;
-import static players.mcts.MCTSEnums.OpponentTreePolicy.Paranoid;
+import static players.mcts.MCTSEnums.OpponentTreePolicy.OneTree;
 import static players.mcts.MCTSEnums.RolloutTermination.DEFAULT;
 import static players.mcts.MCTSEnums.SelectionPolicy.ROBUST;
 import static players.mcts.MCTSEnums.Strategies.PARAMS;
@@ -40,7 +36,8 @@ public class MCTSParams extends PlayerParameters {
     public MCTSEnums.Strategies expansionPolicy = RANDOM;
     public MCTSEnums.SelectionPolicy selectionPolicy = ROBUST;
     public MCTSEnums.TreePolicy treePolicy = UCB;
-    public MCTSEnums.OpponentTreePolicy opponentTreePolicy = Paranoid;
+    public MCTSEnums.OpponentTreePolicy opponentTreePolicy = OneTree;
+    public boolean paranoid = false;
     public MCTSEnums.Strategies rolloutType = RANDOM;
     public MCTSEnums.Strategies oppModelType = RANDOM;
     public String rolloutClass, oppModelClass = "";
@@ -90,7 +87,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("information", Open_Loop, Arrays.asList(MCTSEnums.Information.values()));
         addTunableParameter("selectionPolicy", ROBUST, Arrays.asList(MCTSEnums.SelectionPolicy.values()));
         addTunableParameter("treePolicy", UCB, Arrays.asList(MCTSEnums.TreePolicy.values()));
-        addTunableParameter("opponentTreePolicy", MaxN, Arrays.asList(MCTSEnums.OpponentTreePolicy.values()));
+        addTunableParameter("opponentTreePolicy", OneTree, Arrays.asList(MCTSEnums.OpponentTreePolicy.values()));
         addTunableParameter("exploreEpsilon", 0.1);
         addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
         addTunableParameter("opponentHeuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
@@ -111,6 +108,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("discardStateAfterEachIteration", true);
         addTunableParameter("advantageFunction", IActionHeuristic.nullReturn);
         addTunableParameter("omaVisits", 0);
+        addTunableParameter("paranoid", false);
     }
 
     @Override
@@ -162,6 +160,7 @@ public class MCTSParams extends PlayerParameters {
         normaliseRewards = (boolean) getParameterValue("normaliseRewards");
         nodesStoreScoreDelta = (boolean) getParameterValue("nodesStoreScoreDelta");
         maintainMasterState = (boolean) getParameterValue("maintainMasterState");
+        paranoid = (boolean) getParameterValue("paranoid");
         discardStateAfterEachIteration = (boolean) getParameterValue("discardStateAfterEachIteration");
         if (information == Closed_Loop)
             discardStateAfterEachIteration = false;
@@ -267,6 +266,7 @@ public class MCTSParams extends PlayerParameters {
         retValue.heuristic = heuristic;
         retValue.opponentHeuristic = opponentHeuristic;
         retValue.discardStateAfterEachIteration = discardStateAfterEachIteration;
+        retValue.paranoid = paranoid;
         return retValue;
     }
 

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -83,7 +83,7 @@ public class MCTSPlayer extends AbstractPlayer {
     @Override
     public AbstractAction _getAction(AbstractGameState gameState, List<AbstractAction> actions) {
         // Search for best action from the root
-        if (params.opponentTreePolicy == MultiTree || params.opponentTreePolicy == MultiTreeParanoid)
+        if (params.opponentTreePolicy == MultiTree)
             root = new MultiTreeNode(this, gameState, rnd);
         else
             root = SingleTreeNode.createRootNode(this, gameState, rnd, getFactory());

--- a/src/main/java/players/mcts/MultiTreeNode.java
+++ b/src/main/java/players/mcts/MultiTreeNode.java
@@ -68,7 +68,7 @@ public class MultiTreeNode extends SingleTreeNode {
 
         roots = new SingleTreeNode[state.getNPlayers()];
         roots[this.decisionPlayer] = SingleTreeNode.createRootNode(player, state, rnd, player.getFactory());
-        if (params.opponentTreePolicy == MCTSEnums.OpponentTreePolicy.MultiTreeParanoid)
+        if (params.paranoid)
             roots[this.decisionPlayer].paranoidPlayer = decisionPlayer;
         currentLocation = new SingleTreeNode[state.getNPlayers()];
         currentLocation[this.decisionPlayer] = roots[decisionPlayer];
@@ -112,7 +112,7 @@ public class MultiTreeNode extends SingleTreeNode {
                 // their first action in search; set a root for their tree
                 SingleTreeNode pseudoRoot = SingleTreeNode.createRootNode(mctsPlayer, currentState.copy(), rnd, mctsPlayer.getFactory());
                 pseudoRoot.decisionPlayer = currentActor;
-                if (params.opponentTreePolicy == MCTSEnums.OpponentTreePolicy.MultiTreeParanoid)
+                if (params.paranoid)
                     pseudoRoot.paranoidPlayer = decisionPlayer;
                 roots[currentActor] = pseudoRoot;
                 currentLocation[currentActor] = pseudoRoot;

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -283,10 +283,11 @@ public class SingleTreeNode {
         actionsInRollout = new ArrayList<>();
 
         SingleTreeNode selected = treePolicy(actionsInTree);
-        if (selected == this && nVisits > 3)
+        if (selected == this && openLoopState.isNotTerminalForPlayer(decisionPlayer) && nVisits > 3)
             throw new AssertionError("We have not expanded or selected a new node");
         // by this point (and really earlier) we should have expanded a new node.
         // selected == this is a clear sign that we have a problem in the expansion phase
+        // although if we have no decisions to make - this is fine
 
         // Monte carlo rollout: return value of MC rollout from the newly added node
         int lastActorInTree = actionsInTree.isEmpty() ? decisionPlayer : actionsInTree.get(actionsInTree.size() - 1).a;
@@ -764,7 +765,7 @@ public class SingleTreeNode {
             meanActionValue = Utils.normalise(meanActionValue, root.lowReward, root.highReward);
         else
             meanActionValue = meanActionValue - (totValue[decisionPlayer] / nVisits);
-        double retValue = Math.exp(meanActionValue);
+        double retValue = Math.exp(meanActionValue / params.exp3Boltzmann);
         if (Double.isNaN(retValue))
             throw new AssertionError("We have a non-number in EXP3 somewhere");
         return retValue;

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -929,26 +929,26 @@ public class SingleTreeNode {
                         n.totSquares[j] += squaredResults[root.decisionPlayer];
                     }
                     break;
-                case Paranoid:
-                case MultiTreeParanoid:
-                    int paranoid = root.paranoidPlayer == -1 ? root.decisionPlayer : root.paranoidPlayer;
-                    for (int j = 0; j < result.length; j++) {
-                        if (j == paranoid) {
-                            n.totValue[j] += result[paranoid];
-                            n.totSquares[j] += squaredResults[paranoid];
-                        } else {
-                            n.totValue[j] -= result[paranoid];
-                            n.totSquares[j] += squaredResults[paranoid];
-                        }
-                    }
-                    break;
-                case MaxN:
+                case OneTree:
                 case MultiTree:
                 case OMA_All:
                 case OMA:
-                    for (int j = 0; j < result.length; j++) {
-                        n.totValue[j] += result[j];
-                        n.totSquares[j] += squaredResults[j];
+                    if (params.paranoid) {
+                        int paranoid = root.paranoidPlayer == -1 ? root.decisionPlayer : root.paranoidPlayer;
+                        for (int j = 0; j < result.length; j++) {
+                            if (j == paranoid) {
+                                n.totValue[j] += result[paranoid];
+                                n.totSquares[j] += squaredResults[paranoid];
+                            } else {
+                                n.totValue[j] -= result[paranoid];
+                                n.totSquares[j] += squaredResults[paranoid];
+                            }
+                        }
+                    } else {
+                        for (int j = 0; j < result.length; j++) {
+                            n.totValue[j] += result[j];
+                            n.totSquares[j] += squaredResults[j];
+                        }
                     }
                     break;
             }
@@ -1111,7 +1111,7 @@ public class SingleTreeNode {
         // visits and values for each
         StringBuilder retValue = new StringBuilder();
         String valueString = String.format("%.2f", totValue[decisionPlayer] / nVisits);
-        if (params.opponentTreePolicy == MaxN) {
+        if (params.opponentTreePolicy == OneTree) {
             valueString = Arrays.stream(totValue)
                     .mapToObj(v -> String.format("%.2f", v / nVisits))
                     .collect(joining(", "));
@@ -1131,7 +1131,7 @@ public class SingleTreeNode {
             if (actionName.length() > 50)
                 actionName = actionName.substring(0, 50);
             valueString = String.format("%.2f", actionTotValue(action, decisionPlayer) / actionVisits);
-            if (params.opponentTreePolicy == MaxN) {
+            if (params.opponentTreePolicy == OneTree) {
                 valueString = IntStream.range(0, totValue.length)
                         .mapToObj(p -> String.format("%.2f", actionTotValue(action, p) / actionVisits))
                         .collect(joining(", "));

--- a/src/test/java/test/players/mcts/MCTSNodesAndVisitsTests.java
+++ b/src/test/java/test/players/mcts/MCTSNodesAndVisitsTests.java
@@ -27,7 +27,7 @@ public class MCTSNodesAndVisitsTests {
         // default Parameter settings for later changes
         params = new MCTSParams(9332);
         params.treePolicy = MCTSEnums.TreePolicy.UCB;
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         params.information = MCTSEnums.Information.Information_Set;
         params.maxTreeDepth = 20;
         params.rolloutLength = 10;
@@ -58,7 +58,8 @@ public class MCTSNodesAndVisitsTests {
 
     @Test
     public void paranoid() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.Paranoid;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
+        params.paranoid = true;
         Game game = createGame(params);
         int[] expectedNodes = {200, 200, 200, 200};
         int[] errorMargin = {10, 10, 10, 10};
@@ -67,7 +68,7 @@ public class MCTSNodesAndVisitsTests {
 
     @Test
     public void maxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params);
         int[] expectedNodes = {200, 200, 200, 200};
         int[] errorMargin = {10, 10, 10, 10};
@@ -92,7 +93,7 @@ public class MCTSNodesAndVisitsTests {
 
     @Test
     public void reducedDepth3MaxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         params.maxTreeDepth = 3;
         params.information = MCTSEnums.Information.Closed_Loop;
         params.discardStateAfterEachIteration = false;

--- a/src/test/java/test/players/mcts/MultiTreeMCTSTests.java
+++ b/src/test/java/test/players/mcts/MultiTreeMCTSTests.java
@@ -55,7 +55,7 @@ public class MultiTreeMCTSTests {
         // default Parameter settings for later changes
         params = new MCTSParams(9332);
         params.treePolicy = MCTSEnums.TreePolicy.UCB;
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         params.information = MCTSEnums.Information.Information_Set;
         params.maxTreeDepth = 20;
         params.rolloutLength = 10;
@@ -314,7 +314,8 @@ public class MultiTreeMCTSTests {
     @Test
     public void multiTreeTestLoveLetterRewardsParanoid() {
         params.budget = 1000;
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MultiTreeParanoid;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MultiTree;
+        params.paranoid = true;
         fm = new LoveLetterForwardModel();
         Game game = createLoveLetter(params);
         LoveLetterGameState state = (LoveLetterGameState) game.getGameState();

--- a/src/test/java/test/players/mcts/RewardsForParanoiaTests.java
+++ b/src/test/java/test/players/mcts/RewardsForParanoiaTests.java
@@ -128,14 +128,15 @@ public class RewardsForParanoiaTests {
 
     @Test
     public void loveLetterParanoid() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.Paranoid;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
+        params.paranoid = true;
         Game game = createGame(params, GameType.LoveLetter);
         runGame(game, 4, paranoidNodeValues, atLeastOneSplitNode, checkNodesDistributedAcrossAllPlayers);
     }
 
     @Test
     public void loveLetterMaxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params, GameType.LoveLetter);
         runGame(game, 4, maxNNodeValues, atLeastOneSplitNode, checkNodesDistributedAcrossAllPlayers);
     }
@@ -149,35 +150,36 @@ public class RewardsForParanoiaTests {
 
     @Test
     public void virusParanoid() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.Paranoid;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
+        params.paranoid = true;
         Game game = createGame(params, GameType.Virus);
         runGame(game, 4, paranoidNodeValues, n -> true, checkNodesDistributedAcrossAllPlayers);
     }
 
     @Test
     public void virusMaxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params, GameType.Virus);
         runGame(game, 4, maxNNodeValues, n -> true, checkNodesDistributedAcrossAllPlayers);
     }
 
     @Test
     public void coltExpressMaxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params, GameType.ColtExpress);
         runGame(game, 4, maxNNodeValues, n -> true, checkNodesDistributedAcrossAllPlayers);
     }
 
     @Test
     public void explodingKittensMaxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params, GameType.ExplodingKittens);
         runGame(game, 4, maxNNodeValues, n -> true, checkNodesDistributedAcrossAllPlayers);
     }
 
     @Test
     public void unoMaxN() {
-        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.MaxN;
+        params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params, GameType.Uno);
         runGame(game, 4, maxNNodeValues, n -> true, checkNodesDistributedAcrossAllPlayers);
     }


### PR DESCRIPTION
This incorporates a few odds and sods:
1) Game fixes found in testing after the TurnOrder refactor
- Sushi Go determinisation fix (so this works correctly with Chopsticks, and uses the same convention as other Simultaneous Move games - i.e. copy(playerID) deletes any moves 'made' by the other players, and sets the turn to be that of playerID; they can then decide how they wish to model the other simultaneous moves.
- Diamant/Battlelore did not end cleanly after the TurnOrder refactor
- Uno - added game limit parameter 
- Stratego - this had a game limit parameter, but this looked at Rounds instead of Turns [and Stratego does not use Rounds]
- Colt Express - bug fixed to stop a game crash if all players spend all their actions drawing 3 cards
- Poker - fixed bug with more than 2-players that meant a player who was knocked out was becoming the activePlayer and taking actions

2) Some MCTS tweaks and options
* The major one is a rationalisation of the MCTS parameter for `opponentTreePolicy`. This used to be:
`MaxN, Paranoid, MultiTree, MultiTreeParanoid, SelfOnly, OMA, OMA_All`, 
and is now:
`OneTree, MultiTree, SelfOnly, OMA, OMA_All`, with a new `paranoid` boolean flag. This means we can have OMA Paranoid, without a combinatorial explosion of settings. This is not backwards-compatible with old json files as I have renamed `MaxN` to `OneTree` as possibly clearer.

* I have also added a specific parameter for the temperature to use in an EXP3 selection policy (`exp3Boltzmann`), as this was missing.