### PR TITLE
Fix firstPlayer and blinds in Poker

### DIFF
--- a/src/main/java/games/poker/PokerGameState.java
+++ b/src/main/java/games/poker/PokerGameState.java
@@ -34,6 +34,7 @@ public class PokerGameState extends AbstractGameState implements IPrintable {
     boolean[] playerFold;  // True if player folded
     boolean[] playerActStreet;  // true if player acted this street, false otherwise
     boolean bet;  // True if a bet was made this street
+    private int bigId; // Stores the id of the previous big blind
 
     enum PokerGamePhase implements IGamePhase {
         Preflop,
@@ -188,6 +189,56 @@ public class PokerGameState extends AbstractGameState implements IPrintable {
 
     public void setBet(boolean bet) {
         this.bet = bet;
+    }
+
+    public int getBigId() { return bigId; }
+
+    public void setBigId(int bigId) { this.bigId = bigId; }
+
+    /***
+     * Increments bigId to the next available player
+     */
+    public void incBigId() {
+        bigId = (getBigId() + 1) % getNPlayers();
+        while (getPlayerResults()[bigId] == LOSE_GAME) {
+            bigId = (bigId + 1) % getNPlayers();
+        }
+    }
+
+    /***
+     * Player to the right of big blind is small blind
+     *
+     * @return the id of the player with small blind
+     */
+    public int getSmallId() {
+        int smallId = (getBigId() + getNPlayers() - 1) % getNPlayers();
+        while (getPlayerResults()[smallId] == LOSE_GAME) {
+            smallId = (smallId + getNPlayers() - 1) % getNPlayers();
+        }
+        return smallId;
+    }
+
+    /***
+     * This is called during PreFlop
+     * Sets firstPlayer to the left of big blind
+     */
+    public void setPreFlopFirstPlayer() {
+        int firstPlayer = (getBigId() + 1) % getNPlayers();
+        while (getPlayerResults()[firstPlayer] == LOSE_GAME) {
+            firstPlayer = (firstPlayer + 1) % getNPlayers();
+        }
+        setFirstPlayer(firstPlayer);
+    }
+
+    /***
+     * Resets turnOwner to the right of firstPlayer
+     */
+    public void resetTurnOwner() {
+        int turnOwner = (getFirstPlayer() + getNPlayers() - 1) % getNPlayers();
+        while (getPlayerResults()[turnOwner] == LOSE_GAME) {
+            turnOwner = (turnOwner + getNPlayers() - 1) % getNPlayers();
+        }
+        setTurnOwner(turnOwner);
     }
 
     @Override


### PR DESCRIPTION
Change first player to rotate clockwise after every round, instead of being permanently fixed on player 0
Change first player to be left of dealer preflop and to be small blind postflop
Change big blind to always be right of first player, instead of being right of small blind
Change small blind to always be right of big blind, instead of being first player