### PR TITLE
ForwardModel now included in copy of MCTS/OSLA/RHEA/RMHC players

### DIFF
--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -461,29 +461,23 @@ public abstract class AbstractGameState {
             if (otherScore > playerScore)
                 ordinal++;
             else if (otherScore == playerScore && tiebreakFunction != null && tiebreakFunction.apply(i, 1) != Double.MAX_VALUE) {
-                if (getOrdinalPositionTiebreak(i, tiebreakFunction, 1) > getOrdinalPositionTiebreak(playerId, tiebreakFunction, 1))
-                    ordinal++;
+                int tier = 1;
+                while (tier <= getTiebreakLevels()) {
+                    double otherTiebreak = tiebreakFunction.apply(i, tier);
+                    double playerTiebreak = tiebreakFunction.apply(playerId, tier);
+                    if (otherTiebreak == playerTiebreak) {
+                        tier++;
+                    } else {
+                        if (otherTiebreak > playerTiebreak)
+                            ordinal++;
+                        break;
+                    }
+                }
             }
         }
         return ordinal;
     }
 
-    public int getOrdinalPositionTiebreak(int playerId, BiFunction<Integer, Integer, Double> tiebreakFunction, int tier) {
-        int ordinal = 1;
-        Double playerScore = tiebreakFunction.apply(playerId, tier);
-        if (playerScore == null) return ordinal;
-
-        for (int i = 0, n = getNPlayers(); i < n; i++) {
-            double otherScore = tiebreakFunction.apply(i, tier);
-            if (otherScore > playerScore)
-                ordinal++;
-            else if (otherScore == playerScore && tier < getTiebreakLevels() && tiebreakFunction.apply(i, tier+1) != null) {
-                if (getOrdinalPositionTiebreak(i, tiebreakFunction, tier+1) > getOrdinalPositionTiebreak(playerId, tiebreakFunction, tier+1))
-                    ordinal++;
-            }
-        }
-        return ordinal;
-    }
     public int getOrdinalPosition(int playerId) {
         return getOrdinalPosition(playerId, this::getGameScore, this::getTiebreak);
     }

--- a/src/main/java/games/puertorico/roles/Trader.java
+++ b/src/main/java/games/puertorico/roles/Trader.java
@@ -43,7 +43,7 @@ public class Trader extends PuertoRicoRole<Trader> {
         if (retValue.isEmpty()) {
             retValue.add(new DoNothing());
         } else {
-            retValue.add(new DoNothing());
+            retValue.add(new Sell(null, 0));
         }
         return retValue;
     }

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -138,7 +138,9 @@ public class MCTSPlayer extends AbstractPlayer implements IAnyTimePlayer {
 
     @Override
     public MCTSPlayer copy() {
-        return new MCTSPlayer((MCTSParams) getParameters().copy());
+        MCTSPlayer retValue = new MCTSPlayer((MCTSParams) getParameters().copy());
+        retValue.setForwardModel(getForwardModel().copy());
+        return retValue;
     }
 
     @Override

--- a/src/main/java/players/rhea/RHEAIndividual.java
+++ b/src/main/java/players/rhea/RHEAIndividual.java
@@ -46,7 +46,7 @@ public class RHEAIndividual implements Comparable<RHEAIndividual> {
         length = I.length;
         discountFactor = I.discountFactor;
         heuristic = I.heuristic;
-        rolloutPolicy = I.rolloutPolicy.copy();
+        rolloutPolicy = I.rolloutPolicy;
 
         for (int i = 0; i < length; i++) {
             actions[i] = I.actions[i]; //.copy();

--- a/src/main/java/players/rhea/RHEAPlayer.java
+++ b/src/main/java/players/rhea/RHEAPlayer.java
@@ -129,7 +129,9 @@ public class RHEAPlayer extends AbstractPlayer {
     public RHEAPlayer copy() {
         RHEAParams newParams = (RHEAParams) parameters.copy();
         newParams.setRandomSeed(randomGenerator.nextInt());
-        return new RHEAPlayer(newParams);
+        RHEAPlayer retValue = new RHEAPlayer(newParams);
+        retValue.setForwardModel(getForwardModel().copy());
+        return retValue;
     }
 
     private RHEAIndividual crossover(RHEAIndividual p1, RHEAIndividual p2) {

--- a/src/main/java/players/rmhc/RMHCPlayer.java
+++ b/src/main/java/players/rmhc/RMHCPlayer.java
@@ -80,7 +80,9 @@ public class RMHCPlayer extends AbstractPlayer {
     public RMHCPlayer copy() {
         RMHCParams newParams = (RMHCParams) parameters.copy();
         newParams.setRandomSeed(randomGenerator.nextInt());
-        return new RMHCPlayer(newParams);
+        RMHCPlayer retValue = new RMHCPlayer(newParams);
+        retValue.setForwardModel(getForwardModel().copy());
+        return retValue;
     }
 
     /**

--- a/src/main/java/players/simple/OSLAPlayer.java
+++ b/src/main/java/players/simple/OSLAPlayer.java
@@ -73,7 +73,9 @@ public class OSLAPlayer extends AbstractPlayer {
 
     @Override
     public OSLAPlayer copy() {
-        return new OSLAPlayer(heuristic, new Random(rnd.nextInt()));
+        OSLAPlayer retValue = new OSLAPlayer(heuristic, new Random(rnd.nextInt()));
+        retValue.setForwardModel(getForwardModel().copy());
+        return retValue;
     }
 
     private void advanceToEndOfRoundWithRandomActions(AbstractGameState gsCopy, int startingPlayer) {

--- a/src/test/java/games/puertorico/TestTrader.java
+++ b/src/test/java/games/puertorico/TestTrader.java
@@ -110,7 +110,7 @@ public class TestTrader {
         assertTrue(state.isActionInProgress());
         assertEquals(2, fm.computeAvailableActions(state).size());
         assertEquals(new Sell(COFFEE, 4), fm.computeAvailableActions(state).get(0));
-        assertEquals(new DoNothing(), fm.computeAvailableActions(state).get(1));
+        assertEquals(new Sell(null, 0), fm.computeAvailableActions(state).get(1));
         fm.next(state, fm.computeAvailableActions(state).get(0));
 
         assertEquals(3, state.getMarket().size());


### PR DESCRIPTION
ForwardModel was not copied for MCTS/RHEA/OSLA/RMHCPlayers, which led to null pointer exceptions when copies of these were made - causing an issue for one of the Game AI Sushi Go groups who were using a more sophisticated RHEA rollout policy.

The immediate cause was a copy in RHEAIndividual of the rolloutpolicy, which seemed somewhat redundant (and potentially time-consuming); so I also removed that.
