### PR TITLE
Random seed fixes

### DIFF
--- a/src/main/java/evaluation/RunArg.java
+++ b/src/main/java/evaluation/RunArg.java
@@ -66,7 +66,7 @@ public enum RunArg {
             "\tFor scores with larger ranges, we recommend scaling kExplore appropriately.",
             1.0,
             new Usage[]{Usage.ParameterSearch}),
-    listener("The full class name of an IGameListener implementation. Or the location\n" +
+    listener("The full class name of an IGameListener implementation. Or, better, the location\n" +
             "\t of a json file from which a listener can be instantiated.\n" +
             "\t Defaults to evaluation.metrics.MetricsGameListener. \n" +
             "\t A pipe-delimited string can be provided to gather many types of statistics \n" +
@@ -128,15 +128,22 @@ public enum RunArg {
             -1,
             new Usage[]{Usage.RunGames}),
     distinctRandomSeeds("If non-zero, then this defines the number of distinct random seeds to use for each game.\n" +
-            "\t For tournament will be run for each individual random seed individually, using the other specified parameters.",
+            "\t For tournament will be run for each individual random seed individually, using the other specified parameters.\n" +
+            "\t If a seedFile is specified, then this is ignored.",
             0,
             new Usage[]{Usage.RunGames}),
     searchSpace("The json-format file of the search space to use. No default.",
             "",
             new Usage[]{Usage.ParameterSearch}),
-    seed("(Optional) Random seed to use for process",
+    seed("(Optional) Random seed to use for process. This is not the seed used for games, but the seed of \n" +
+            "\t the random number generator used to generate these.",
             System.currentTimeMillis(),
             new Usage[]{Usage.RunGames, Usage.ParameterSearch}),
+    seedFile("(Optional) A file containing a list of random seeds to use for individual games. \n" +
+            "\t If this is specified, then the 'seed' and `distinctRandomSeed` arguments are ignored. \n"+
+            "\t Each seed will be used in turn for a full tournament run, as defined by the other parameters.",
+            "",
+            new Usage[]{Usage.RunGames}),
     selfPlay("(Optional) If true, then multiple copies of the same agent can be in one game.\n" +
             "\t Defaults to false",
             false,

--- a/src/main/java/evaluation/metrics/GameMetrics.java
+++ b/src/main/java/evaluation/metrics/GameMetrics.java
@@ -319,6 +319,53 @@ public class GameMetrics implements IMetricsCollection {
         }
     }
 
+
+    public static class Actions2 extends AbstractMetric {
+        public Actions2() {
+            super();
+        }
+
+        public Actions2(Event.GameEvent... args) {
+            super(args);
+        }
+
+        @Override
+        public boolean _run(MetricsGameListener listener, Event e, Map<String, Object> records) {
+            Game g = listener.getGame();
+            AbstractForwardModel fm = g.getForwardModel();
+            AbstractPlayer currentPlayer = g.getPlayers().get(e.playerID);
+            int size = fm.computeAvailableActions(e.state, currentPlayer.getParameters().actionSpace).size();
+
+            records.put("Player", e.playerID);
+            records.put("PlayerType", currentPlayer.toString());
+            records.put("Size", size);
+
+            records.put("Action", e.action == null ? null : e.action.toString());
+            records.put("ActionClass", e.action.getClass().getSimpleName());
+            records.put("ActionDescription", e.action == null ? null : e.action.getString(e.state));
+            return true;
+        }
+
+        @Override
+        public Set<IGameEvent> getDefaultEventTypes() {
+            return Collections.singleton(ACTION_CHOSEN);
+        }
+
+        @Override
+        public Map<String, Class<?>> getColumns(int nPlayersPerGame, Set<String> playerNames) {
+            Map<String, Class<?>> columns = new HashMap<>();
+            columns.put("Player", Integer.class);
+            columns.put("PlayerType", String.class);
+            columns.put("Size", Integer.class);
+            columns.put("Action", String.class);
+            columns.put("ActionClass", String.class);
+            columns.put("ActionDescription", String.class);
+            return columns;
+        }
+    }
+
+
+
     public static class Winner extends AbstractMetric {
         public Winner() {
             super();

--- a/src/main/java/evaluation/metrics/GameMetrics.java
+++ b/src/main/java/evaluation/metrics/GameMetrics.java
@@ -320,12 +320,19 @@ public class GameMetrics implements IMetricsCollection {
     }
 
 
-    public static class Actions2 extends AbstractMetric {
-        public Actions2() {
+    /**
+     * Records the actions taken during the game
+     * This is 'Reduced' compared to the Actions metric in that it does not have separate columns for each player
+     * Instead of having separate columns for 'Player-2', 'Player-3' etc, it has a single column 'Player' with
+     * the player ID taking the action. (And similarly for PlayerName)
+     * This simplifies data analysis in some circumstances (in others the Actions metric is more useful)
+     */
+    public static class ActionsReduced extends AbstractMetric {
+        public ActionsReduced() {
             super();
         }
 
-        public Actions2(Event.GameEvent... args) {
+        public ActionsReduced(Event.GameEvent... args) {
             super(args);
         }
 

--- a/src/main/java/evaluation/tournaments/RandomRRTournament.java
+++ b/src/main/java/evaluation/tournaments/RandomRRTournament.java
@@ -13,7 +13,6 @@ import java.util.stream.IntStream;
 
 public class RandomRRTournament extends RoundRobinTournament {
 
-    private int totalMatchups;
     private IntSupplier idStream;
     private int reportPeriod;
 
@@ -29,10 +28,8 @@ public class RandomRRTournament extends RoundRobinTournament {
 
                               // int totalMatchUps, int reportPeriod, long seed,                              , boolean byTeam) {
         super(agents, gameToPlay, playersPerGame,  gameParams, tournamentMode, config);
-        this.totalMatchups = (int) config.get(RunArg.matchups);
         this.reportPeriod = config.get(RunArg.reportPeriod) == null ? 0 : (int) config.get(RunArg.reportPeriod);
-        long seed = (long) config.get(RunArg.seed);
-        idStream = new PermutationCycler(agents.size(), seed, playersPerGame);
+        idStream = new PermutationCycler(agents.size(), seedRnd, playersPerGame);
     }
 
     /**
@@ -45,12 +42,12 @@ public class RandomRRTournament extends RoundRobinTournament {
     @Override
     public void createAndRunMatchUp(List<Integer> ignored) {
         int nTeams = game.getGameState().getNTeams();
-        for (int i = 0; i < totalMatchups; i++) {
+        for (int i = 0; i < gamesPerMatchUp; i++) {
             List<Integer> matchup = new ArrayList<>(nTeams);
             for (int j = 0; j < nTeams; j++)
                 matchup.add(idStream.getAsInt());
-            evaluateMatchUp(matchup, 1, Collections.singletonList(seedRnd.nextInt()));
-            if(reportPeriod > 0 && (i+1) % reportPeriod == 0 && i != totalMatchups - 1) {
+            evaluateMatchUp(matchup, 1, Collections.singletonList(gameSeeds.get(i)));
+            if(reportPeriod > 0 && (i+1) % reportPeriod == 0 && i != gamesPerMatchUp - 1) {
                 reportResults();
             }
         }
@@ -68,7 +65,8 @@ public class RandomRRTournament extends RoundRobinTournament {
         int nPlayers;
         Random rnd;
 
-        public PermutationCycler(int maxNumberExclusive, long seed, int nPlayers) {
+        public PermutationCycler(int maxNumberExclusive, Random rnd, int nPlayers) {
+            this.rnd = rnd;
             if (maxNumberExclusive >= nPlayers)
                 currentPermutation = IntStream.range(0, maxNumberExclusive).toArray();
             else {
@@ -79,7 +77,6 @@ public class RandomRRTournament extends RoundRobinTournament {
                 }
             }
             currentPosition = -1;
-            rnd = new Random(seed);
             this.nPlayers = nPlayers;
             shuffle();
         }

--- a/src/main/java/evaluation/tournaments/RandomRRTournament.java
+++ b/src/main/java/evaluation/tournaments/RandomRRTournament.java
@@ -49,7 +49,7 @@ public class RandomRRTournament extends RoundRobinTournament {
             List<Integer> matchup = new ArrayList<>(nTeams);
             for (int j = 0; j < nTeams; j++)
                 matchup.add(idStream.getAsInt());
-            evaluateMatchUp(matchup, 1);
+            evaluateMatchUp(matchup, 1, Collections.singletonList(seedRnd.nextInt()));
             if(reportPeriod > 0 && (i+1) % reportPeriod == 0 && i != totalMatchups - 1) {
                 reportResults();
             }

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -23,7 +23,7 @@ import static java.util.stream.Collectors.toList;
 public class RoundRobinTournament extends AbstractTournament {
     private static boolean debug = false;
     public TournamentMode tournamentMode;
-    private final int gamesPerMatchUp;
+    final int gamesPerMatchUp;
     protected List<IGameListener> listeners = new ArrayList<>();
     public boolean verbose = true;
     double[] pointsPerPlayer, winsPerPlayer;
@@ -205,9 +205,7 @@ public class RoundRobinTournament extends AbstractTournament {
                                 matchup.add(agentOrder.get(j % agentOrder.size()));
                             }
                         }
-                        // in pure random mode we don't use the gameSeed List. That is when we
-                        // need to control randomness across multiple runs of the same game with permuted players
-                        evaluateMatchUp(matchup, 1, Collections.singletonList(seedRnd.nextInt()));
+                        evaluateMatchUp(matchup, 1, Collections.singletonList(gameSeeds.get(m)));
                     }
                 }
             }

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -436,6 +436,7 @@ public class RoundRobinTournament extends AbstractTournament {
 
     public void setRandomSeed(Number randomSeed) {
         this.randomSeed = randomSeed.longValue();
+        seedRnd = new Random(this.randomSeed);
     }
 
     public void setRandomGameParams(boolean randomGameParams) {

--- a/src/test/java/evaluation/TunableParametersTest.java
+++ b/src/test/java/evaluation/TunableParametersTest.java
@@ -149,4 +149,12 @@ public class TunableParametersTest {
         assertEquals(0.01, rollout.temperature, 0.001);
         assertEquals(new PuertoRicoActionHeuristic001(), rollout.getActionHeuristic());
     }
+
+    @Test
+    public void copyingParamsChangesRandomSeedOnChildButNotParent() {
+        long startingSeed = params.getRandomSeed();
+        MCTSParams copy = (MCTSParams) params.copy();
+        assertNotEquals(startingSeed, copy.getRandomSeed());
+        assertEquals(startingSeed, params.getRandomSeed());
+    }
 }

--- a/src/test/java/evaluation/tournamentSeeds/Dominion_Agent.json
+++ b/src/test/java/evaluation/tournamentSeeds/Dominion_Agent.json
@@ -1,0 +1,17 @@
+{
+"budgetType":"BUDGET_TIME",
+"rolloutLength":30,
+"opponentTreePolicy":"MultiTree",
+"MASTGamma":0.5,
+"heuristic":{
+"class":"players.heuristics.PureScoreHeuristic"
+},
+"K":1,
+"exploreEpsilon":0.3,
+"treePolicy":"RegretMatching",
+"MAST":"Both",
+"rolloutType":"MAST",
+"information":"Information_Set",
+"class":"players.mcts.MCTSParams",
+"budget": 50
+}

--- a/src/test/java/evaluation/tournamentSeeds/Dominion_Agents/DominionFG_2P_32-ms.json
+++ b/src/test/java/evaluation/tournamentSeeds/Dominion_Agents/DominionFG_2P_32-ms.json
@@ -1,0 +1,17 @@
+{
+"budgetType":"BUDGET_TIME",
+"rolloutLength":30,
+"opponentTreePolicy":"MultiTree",
+"MASTGamma":0.5,
+"heuristic":{
+"class":"players.heuristics.PureScoreHeuristic"
+},
+"K":1,
+"exploreEpsilon":0.1,
+"treePolicy":"RegretMatching",
+"MAST":"Both",
+"rolloutType":"MAST",
+"information":"Information_Set",
+"class":"players.mcts.MCTSParams",
+"budget": 20
+}

--- a/src/test/java/evaluation/tournamentSeeds/Dominion_Agents/DominionFG_4P_16-ms.json
+++ b/src/test/java/evaluation/tournamentSeeds/Dominion_Agents/DominionFG_4P_16-ms.json
@@ -1,0 +1,17 @@
+{
+"budgetType":"BUDGET_TIME",
+"rolloutLength":30,
+"opponentTreePolicy":"SelfOnly",
+"MASTGamma":0.5,
+"heuristic":{
+"class":"players.heuristics.LeaderHeuristic"
+},
+"K":0.01,
+"exploreEpsilon":0.1,
+"treePolicy":"UCB_Tuned",
+"MAST":"Both",
+"rolloutType":"MAST",
+"information":"Information_Set",
+"class":"players.mcts.MCTSParams",
+"budget": 20
+}

--- a/src/test/java/evaluation/tournamentSeeds/Dominion_Agents/DominionFG_4P_32ms.json
+++ b/src/test/java/evaluation/tournamentSeeds/Dominion_Agents/DominionFG_4P_32ms.json
@@ -1,0 +1,17 @@
+{
+"budgetType":"BUDGET_TIME",
+"rolloutLength":30,
+"opponentTreePolicy":"MultiTree",
+"MASTGamma":0.5,
+"heuristic":{
+"class":"players.heuristics.PureScoreHeuristic"
+},
+"K":1,
+"exploreEpsilon":0.3,
+"treePolicy":"RegretMatching",
+"MAST":"Both",
+"rolloutType":"MAST",
+"information":"Information_Set",
+"class":"players.mcts.MCTSParams",
+"budget": 20
+}

--- a/src/test/java/evaluation/tournamentSeeds/TestRandomSeedsInTournaments.java
+++ b/src/test/java/evaluation/tournamentSeeds/TestRandomSeedsInTournaments.java
@@ -17,12 +17,10 @@ public class TestRandomSeedsInTournaments {
         // 10 games in each, with 10 different seeds (seeds the same across each pair of agents)
         RunGames.main(new String[]{"config=Tournament_Focus_Base.json"});
         // 30 games, with 10 different seeds...in each set the Focus player is p1, p1, p2 respectively
-        // TODO: This just uses 30 different seeds, not 10
 
         // the ones below should then replicate all of the above, but with 3 seeds
         RunGames.main(new String[]{"config=Tournament_Random_ThreeSeeds.json"});
         // 30 games, each set of 10 with a different seed
-        // TODO: This just uses 30 different seeds
         RunGames.main(new String[]{"config=Tournament_Exhaustive_ThreeSeeds.json"});
         // 3  * 60 games, with each set of 60 having the same seed
         RunGames.main(new String[]{"config=Tournament_Seq_ThreeSeeds.json"});
@@ -30,7 +28,6 @@ public class TestRandomSeedsInTournaments {
         // 3 * 10 games in each, with 3 different seeds (seeds the same across each pair of agents)
         RunGames.main(new String[]{"config=Tournament_Focus_ThreeSeeds.json"});
         // 3 * 30 games, with 1 seed per set of 30...in each set the Focus player is p1, p1, p2 respectively
-        // todo: This just uses 90 different seeds
     }
 
 }

--- a/src/test/java/evaluation/tournamentSeeds/TestRandomSeedsInTournaments.java
+++ b/src/test/java/evaluation/tournamentSeeds/TestRandomSeedsInTournaments.java
@@ -1,0 +1,36 @@
+package evaluation.tournamentSeeds;
+
+import evaluation.RunGames;
+
+public class TestRandomSeedsInTournaments {
+
+    public static void main(String[] args) {
+
+        // We run each type of tournament (and then manually check the files for seeds)
+
+        RunGames.main(new String[]{"config=Tournament_Random_Base.json"});
+        // Should create 10 rows, each with a different seed
+        RunGames.main(new String[]{"config=Tournament_Exhaustive_Base.json"});
+        // Should create 10 * 6 = 60 rows, with each set of 6 rows having the same seed
+        RunGames.main(new String[]{"config=Tournament_Seq_Base.json"});
+        // Three directories, one for each pair of agents
+        // 10 games in each, with 10 different seeds (seeds the same across each pair of agents)
+        RunGames.main(new String[]{"config=Tournament_Focus_Base.json"});
+        // 30 games, with 10 different seeds...in each set the Focus player is p1, p1, p2 respectively
+        // TODO: This just uses 30 different seeds, not 10
+
+        // the ones below should then replicate all of the above, but with 3 seeds
+        RunGames.main(new String[]{"config=Tournament_Random_ThreeSeeds.json"});
+        // 30 games, each set of 10 with a different seed
+        // TODO: This just uses 30 different seeds
+        RunGames.main(new String[]{"config=Tournament_Exhaustive_ThreeSeeds.json"});
+        // 3  * 60 games, with each set of 60 having the same seed
+        RunGames.main(new String[]{"config=Tournament_Seq_ThreeSeeds.json"});
+        // 3 directories, one for each pair of agents
+        // 3 * 10 games in each, with 3 different seeds (seeds the same across each pair of agents)
+        RunGames.main(new String[]{"config=Tournament_Focus_ThreeSeeds.json"});
+        // 3 * 30 games, with 1 seed per set of 30...in each set the Focus player is p1, p1, p2 respectively
+        // todo: This just uses 90 different seeds
+    }
+
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Exhaustive_Base.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Exhaustive_Base.json
@@ -1,0 +1,13 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "selfPlay" : false,
+        "mode" : "exhaustive",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 0,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\ExBase",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Exhaustive_ThreeSeeds.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Exhaustive_ThreeSeeds.json
@@ -1,0 +1,13 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "selfPlay" : false,
+        "mode" : "exhaustive",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 3,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\ExThreeSeeds",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Focus_Base.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Focus_Base.json
@@ -1,0 +1,14 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "focusPlayer" : "Dominion_Agent.json",
+        "selfPlay" : false,
+        "mode" : "sequential",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 0,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\Focus",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Focus_ThreeSeeds.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Focus_ThreeSeeds.json
@@ -1,0 +1,14 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "focusPlayer" : "Dominion_Agent.json",
+        "selfPlay" : false,
+        "mode" : "sequential",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 3,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\FocusThreeSeeds",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Random_Base.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Random_Base.json
@@ -1,0 +1,13 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "selfPlay" : false,
+        "mode" : "random",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 0,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\Rnd",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Random_ThreeSeeds.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Random_ThreeSeeds.json
@@ -1,0 +1,13 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "selfPlay" : false,
+        "mode" : "random",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 3,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\RndThreeSeeds",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Seq_Base.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Seq_Base.json
@@ -1,0 +1,13 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "selfPlay" : false,
+        "mode" : "sequential",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 0,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\Seq",
+        "seed" : 740334
+}

--- a/src/test/java/evaluation/tournamentSeeds/Tournament_Seq_ThreeSeeds.json
+++ b/src/test/java/evaluation/tournamentSeeds/Tournament_Seq_ThreeSeeds.json
@@ -1,0 +1,13 @@
+{
+        "game" : "Dominion",
+        "nPlayers" : 3,
+        "playerDirectory" : "Dominion_Agents",
+        "selfPlay" : false,
+        "mode" : "sequential",
+        "matchups" : 10,
+        "distinctRandomSeeds" : 3,
+        "verbose" : false,
+        "listener" : "GameResultsListener.json",
+        "destDir" : "SeedTest\\SeqThreeSeeds",
+        "seed" : 740334
+}


### PR DESCRIPTION
This has two main components:

1) The ability to provide a file of specific random seeds to RunGames (e.g. if we find a good one for a game set up and want to run 1000 games with the same starting cards)

2) Fixes for mode=random, mode=sequential and focuPlayer in RunGames. Due to a bug introduced in the main changes for RandomSeeds (Pull Request #263) running a purely random tournament used the same seed for every single game. (It was fine for the default mode=exhaustive). 
All now combinations of modes now tested properly.