### PR TITLE
Fixes for Dominion

### DIFF
--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -372,6 +372,7 @@ public class Game {
             for (int i = 0; i < gameState.getNPlayers(); i++) {
                 int team = gameState.getTeam(i);
                 AbstractPlayer player = players.get(team);
+                player.setForwardModel(this.forwardModel.copy());
                 this.players.add(player.copy());
             }
         } else

--- a/src/main/java/evaluation/listeners/ActionFeatureListener.java
+++ b/src/main/java/evaluation/listeners/ActionFeatureListener.java
@@ -4,6 +4,7 @@ import core.AbstractGameState;
 import core.actions.AbstractAction;
 import core.interfaces.IActionFeatureVector;
 import core.interfaces.IStateFeatureVector;
+import evaluation.loggers.FileStatsLogger;
 import evaluation.metrics.Event;
 
 import java.util.HashMap;
@@ -28,12 +29,13 @@ public class ActionFeatureListener extends FeatureListener {
     private Map<AbstractAction, Double> actionValues = new HashMap<>();
 
 
-    public ActionFeatureListener(IActionFeatureVector psi, IStateFeatureVector phi, Event.GameEvent frequency, boolean includeActionsNotTaken) {
+    public ActionFeatureListener(IActionFeatureVector psi, IStateFeatureVector phi, Event.GameEvent frequency, boolean includeActionsNotTaken, String fileName) {
         super(frequency, true);
         if (psi == null) throw new AssertionError("Action Features must be provided and cannot be null");
         this.psiFn = psi;
         this.phiFn = phi;
         this.includeActionsNotTaken = includeActionsNotTaken;
+        logger = new FileStatsLogger(fileName);
     }
 
     @Override

--- a/src/main/java/evaluation/listeners/StateFeatureListener.java
+++ b/src/main/java/evaluation/listeners/StateFeatureListener.java
@@ -3,6 +3,7 @@ package evaluation.listeners;
 import core.AbstractGameState;
 import core.actions.AbstractAction;
 import core.interfaces.IStateFeatureVector;
+import evaluation.loggers.FileStatsLogger;
 import evaluation.metrics.Event;
 
 import java.util.regex.Pattern;
@@ -17,9 +18,10 @@ public class StateFeatureListener extends FeatureListener {
 
     IStateFeatureVector phiFn;
 
-    public StateFeatureListener(IStateFeatureVector phi, Event.GameEvent frequency, boolean currentPlayerOnly) {
+    public StateFeatureListener(IStateFeatureVector phi, Event.GameEvent frequency, boolean currentPlayerOnly, String fileName) {
         super(frequency, currentPlayerOnly);
         this.phiFn = phi;
+        logger = new FileStatsLogger(fileName);
     }
 
     @Override

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -239,8 +239,10 @@ public class RoundRobinTournament extends AbstractTournament {
             System.out.printf("Evaluate %s at %tT%n", agentIDsInThisGame.toString(), System.currentTimeMillis());
         LinkedList<AbstractPlayer> matchUpPlayers = new LinkedList<>();
 
+        // If we are in self-play mode, we need to create a copy of the player to avoid them sharing the same state
+        // If not in self-play mode then this is unnecessary, as the same agent will never be in the same game twice
         for (int agentID : agentIDsInThisGame)
-            matchUpPlayers.add(this.agents.get(agentID));
+            matchUpPlayers.add(tournamentMode == SELF_PLAY ? this.agents.get(agentID).copy() : this.agents.get(agentID));
 
         if (verbose) {
             StringBuffer sb = new StringBuffer();

--- a/src/main/java/games/cantstop/CantStopGameState.java
+++ b/src/main/java/games/cantstop/CantStopGameState.java
@@ -24,7 +24,7 @@ public class CantStopGameState extends AbstractGameState implements IPrintable {
 
     private CantStopGameState(CantStopGameState copyFrom) {
         // used by copy method only
-        super(copyFrom.gameParameters, copyFrom.getNPlayers());
+        super(copyFrom.gameParameters.copy(), copyFrom.getNPlayers());
         // TurnOrder will be copied later
         completedColumns = copyFrom.completedColumns.clone();
         playerMarkerPositions = new int[copyFrom.getNPlayers()][];

--- a/src/main/java/games/coltexpress/ColtExpressGameState.java
+++ b/src/main/java/games/coltexpress/ColtExpressGameState.java
@@ -76,7 +76,7 @@ public class ColtExpressGameState extends AbstractGameStateWithTurnOrder impleme
 
     @Override
     protected AbstractGameStateWithTurnOrder __copy(int playerId) {
-        ColtExpressGameState copy = new ColtExpressGameState(gameParameters, getNPlayers());
+        ColtExpressGameState copy = new ColtExpressGameState(gameParameters.copy(), getNPlayers());
 
         // These are always visible
         copy.bulletsLeft = bulletsLeft.clone();

--- a/src/main/java/games/dominion/DominionForwardModel.java
+++ b/src/main/java/games/dominion/DominionForwardModel.java
@@ -24,19 +24,15 @@ public class DominionForwardModel extends StandardForwardModel {
     @Override
     protected void _setup(AbstractGameState firstState) {
         DominionGameState state = (DominionGameState) firstState;
-        state._reset();
         DominionParameters params = state.params;
 
+        Random initialShuffleRnd = params.initialShuffleSeed != -1 ? new Random(params.initialShuffleSeed) : state.getRnd();
         for (int i = 0; i < state.playerCount; i++) {
             for (int j = 0; j < params.STARTING_COPPER; j++)
                 state.playerDrawPiles[i].add(DominionCard.create(CardType.COPPER));
             for (int j = 0; j < params.STARTING_ESTATES; j++)
                 state.playerDrawPiles[i].add(DominionCard.create(CardType.ESTATE));
-            // if we have a separate seed for the initial shuffle, then use this
-            if (params.initialShuffleSeed != -1)
-                state.playerDrawPiles[i].shuffle(new Random(params.initialShuffleSeed));
-            else
-                state.playerDrawPiles[i].shuffle(state.getRnd());
+            state.playerDrawPiles[i].shuffle(initialShuffleRnd);
             for (int k = 0; k < params.HAND_SIZE; k++) state.playerHands[i].add(state.playerDrawPiles[i].draw());
         }
         state.actionsLeftForCurrentPlayer = 1;

--- a/src/main/java/games/dominion/DominionForwardModel.java
+++ b/src/main/java/games/dominion/DominionForwardModel.java
@@ -74,6 +74,8 @@ public class DominionForwardModel extends StandardForwardModel {
     protected void _afterAction(AbstractGameState currentState, AbstractAction action) {
         DominionGameState state = (DominionGameState) currentState;
 
+        if (state.isActionInProgress()) return;
+
         int playerID = state.getCurrentPlayer();
         if (state.gameOver()) {
             endGame(state);
@@ -81,7 +83,7 @@ public class DominionForwardModel extends StandardForwardModel {
 
             switch (state.getGamePhase().toString()) {
                 case "Play":
-                    if ((state.actionsLeftForCurrentPlayer < 1 || action instanceof EndPhase) && !state.isActionInProgress()) {
+                    if (state.actionsLeftForCurrentPlayer < 1 || action instanceof EndPhase) {
                         // change phase
                         // no change to current player
                         state.setGamePhase(DominionGameState.DominionGamePhase.Buy);

--- a/src/main/java/games/dominion/DominionForwardModel.java
+++ b/src/main/java/games/dominion/DominionForwardModel.java
@@ -24,7 +24,7 @@ public class DominionForwardModel extends StandardForwardModel {
     @Override
     protected void _setup(AbstractGameState firstState) {
         DominionGameState state = (DominionGameState) firstState;
-        DominionParameters params = state.params;
+        DominionParameters params = (DominionParameters) state.getGameParameters();
 
         Random initialShuffleRnd = params.initialShuffleSeed != -1 ? new Random(params.initialShuffleSeed) : state.getRnd();
         for (int i = 0; i < state.getNPlayers(); i++) {
@@ -104,7 +104,8 @@ public class DominionForwardModel extends StandardForwardModel {
                         discard.add(table);
                         table.clear();
                         hand.clear();
-                        for (int i = 0; i < state.params.HAND_SIZE; i++)
+                        DominionParameters params = (DominionParameters) state.getGameParameters();
+                        for (int i = 0; i < params.HAND_SIZE; i++)
                             state.drawCard(playerID);
 
                         state.defenceStatus = new boolean[state.getNPlayers()];  // resets to false

--- a/src/main/java/games/dominion/DominionForwardModel.java
+++ b/src/main/java/games/dominion/DominionForwardModel.java
@@ -27,7 +27,7 @@ public class DominionForwardModel extends StandardForwardModel {
         DominionParameters params = state.params;
 
         Random initialShuffleRnd = params.initialShuffleSeed != -1 ? new Random(params.initialShuffleSeed) : state.getRnd();
-        for (int i = 0; i < state.playerCount; i++) {
+        for (int i = 0; i < state.getNPlayers(); i++) {
             for (int j = 0; j < params.STARTING_COPPER; j++)
                 state.playerDrawPiles[i].add(DominionCard.create(CardType.COPPER));
             for (int j = 0; j < params.STARTING_ESTATES; j++)
@@ -40,9 +40,9 @@ public class DominionForwardModel extends StandardForwardModel {
         state.spentSoFar = 0;
         state.additionalSpendAvailable = 0;
         state.delayedActions = new ArrayList<>();
-        state.defenceStatus = new boolean[state.playerCount];  // defaults to false
+        state.defenceStatus = new boolean[state.getNPlayers()];  // defaults to false
 
-        int victoryCards = params.VICTORY_CARDS_PER_PLAYER[state.playerCount];
+        int victoryCards = params.VICTORY_CARDS_PER_PLAYER[state.getNPlayers()];
         state.cardsIncludedInGame = new HashMap<>(16);
         state.cardsIncludedInGame.put(CardType.PROVINCE, victoryCards);
         state.cardsIncludedInGame.put(CardType.DUCHY, victoryCards);
@@ -53,7 +53,7 @@ public class DominionForwardModel extends StandardForwardModel {
         for (CardType ct : params.cardsUsed) {
             int cardsToUse = ct.isVictory ? victoryCards : params.KINGDOM_CARDS_OF_EACH_TYPE;
             if (ct == CardType.CURSE)
-                cardsToUse = (state.playerCount - 1) * params.CURSE_CARDS_PER_PLAYER;
+                cardsToUse = (state.getNPlayers() - 1) * params.CURSE_CARDS_PER_PLAYER;
             state.cardsIncludedInGame.put(ct, cardsToUse);
         }
         state.setGamePhase(DominionGameState.DominionGamePhase.Play);
@@ -107,7 +107,7 @@ public class DominionForwardModel extends StandardForwardModel {
                         for (int i = 0; i < state.params.HAND_SIZE; i++)
                             state.drawCard(playerID);
 
-                        state.defenceStatus = new boolean[state.playerCount];  // resets to false
+                        state.defenceStatus = new boolean[state.getNPlayers()];  // resets to false
 
                         state.actionsLeftForCurrentPlayer = 1;
                         state.spentSoFar = 0;

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -25,7 +25,6 @@ import static java.util.stream.Collectors.toList;
 
 public class DominionGameState extends AbstractGameState implements IPrintable {
 
-    int playerCount;
     DominionParameters params;
     // Counts of cards on the table should be fine
     Map<CardType, Integer> cardsIncludedInGame = new HashMap<>();
@@ -52,7 +51,6 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
      */
     public DominionGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, nPlayers);
-        playerCount = nPlayers;
         params = (DominionParameters) gameParameters;
         this.reset();
     }
@@ -255,11 +253,11 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
      */
     @Override
     protected AbstractGameState _copy(int playerId) {
-        DominionGameState retValue = new DominionGameState(gameParameters.copy(), playerCount);
+        DominionGameState retValue = new DominionGameState(gameParameters.copy(), nPlayers);
         for (CardType ct : cardsIncludedInGame.keySet()) {
             retValue.cardsIncludedInGame.put(ct, cardsIncludedInGame.get(ct));
         }
-        for (int p = 0; p < playerCount; p++) {
+        for (int p = 0; p < nPlayers; p++) {
             if (playerId == -1) {
                 retValue.playerHands[p] = playerHands[p].copy();
                 retValue.playerDrawPiles[p] = playerDrawPiles[p].copy();
@@ -375,17 +373,17 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
      */
     @Override
     protected void reset() {
-        playerHands = new PartialObservableDeck[playerCount];
-        playerDrawPiles = new PartialObservableDeck[playerCount];
-        playerDiscards = new Deck[playerCount];
-        playerTableaux = new Deck[playerCount];
+        playerHands = new PartialObservableDeck[nPlayers];
+        playerDrawPiles = new PartialObservableDeck[nPlayers];
+        playerDiscards = new Deck[nPlayers];
+        playerTableaux = new Deck[nPlayers];
 
         trashPile = new Deck<>("Trash", VISIBLE_TO_ALL);
-        for (int i = 0; i < playerCount; i++) {
-            boolean[] handVisibility = new boolean[playerCount];
+        for (int i = 0; i < nPlayers; i++) {
+            boolean[] handVisibility = new boolean[nPlayers];
             handVisibility[i] = true;
             playerHands[i] = new PartialObservableDeck<>("Hand of Player " + i + 1, handVisibility);
-            playerDrawPiles[i] = new PartialObservableDeck<>("Drawpile of Player " + i + 1, new boolean[playerCount]);
+            playerDrawPiles[i] = new PartialObservableDeck<>("Drawpile of Player " + i + 1, new boolean[nPlayers]);
             playerDiscards[i] = new Deck<>("Discard of Player " + i + 1, VISIBLE_TO_ALL);
             playerTableaux[i] = new Deck<>("Tableau of Player " + i + 1, VISIBLE_TO_ALL);
         }

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -397,8 +397,7 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
     @Override
     protected boolean _equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof DominionGameState)) return false;
-        DominionGameState other = (DominionGameState) o;
+        if (!(o instanceof DominionGameState other)) return false;
         return cardsIncludedInGame.equals(other.cardsIncludedInGame) &&
                 Arrays.equals(playerHands, other.playerHands) &&
                 Arrays.equals(playerResults, other.playerResults) &&

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -25,8 +25,6 @@ import static java.util.stream.Collectors.toList;
 
 public class DominionGameState extends AbstractGameState implements IPrintable {
 
-    DominionParameters params;
-    // Counts of cards on the table should be fine
     Map<CardType, Integer> cardsIncludedInGame = new HashMap<>();
     // Then Decks for each player - Hand, Discard and Draw
     PartialObservableDeck<DominionCard>[] playerHands;
@@ -51,7 +49,6 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
      */
     public DominionGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, nPlayers);
-        params = (DominionParameters) gameParameters;
         this.reset();
     }
 
@@ -76,6 +73,7 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
 
 
     public boolean gameOver() {
+        DominionParameters params = (DominionParameters) gameParameters;
         return cardsIncludedInGame.get(CardType.PROVINCE) == 0 ||
                 cardsIncludedInGame.values().stream().filter(i -> i == 0).count() >= params.PILES_EXHAUSTED_FOR_GAME_END;
     }

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -54,7 +54,7 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
         super(gameParameters, nPlayers);
         playerCount = nPlayers;
         params = (DominionParameters) gameParameters;
-        this._reset();
+        this.reset();
     }
 
     @Override
@@ -373,7 +373,8 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
     /**
      * Resets variables initialised for this game state.
      */
-    protected void _reset() {
+    @Override
+    protected void reset() {
         playerHands = new PartialObservableDeck[playerCount];
         playerDrawPiles = new PartialObservableDeck[playerCount];
         playerDiscards = new Deck[playerCount];
@@ -388,6 +389,7 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
             playerDiscards[i] = new Deck<>("Discard of Player " + i + 1, VISIBLE_TO_ALL);
             playerTableaux[i] = new Deck<>("Tableau of Player " + i + 1, VISIBLE_TO_ALL);
         }
+        super.reset();
     }
 
     /**

--- a/src/main/java/games/dominion/DominionParameters.java
+++ b/src/main/java/games/dominion/DominionParameters.java
@@ -64,40 +64,6 @@ public class DominionParameters extends TunableParameters {
         }
     }
 
-    public static DominionParameters sizeDistortion() {
-        DominionParameters retValue = new DominionParameters();
-        retValue.cardsUsed.add(CardType.ARTISAN);
-        retValue.cardsUsed.add(CardType.BANDIT);
-        retValue.cardsUsed.add(CardType.BUREAUCRAT);
-        retValue.cardsUsed.add(CardType.CHAPEL);
-        retValue.cardsUsed.add(CardType.FESTIVAL);
-        retValue.cardsUsed.add(CardType.GARDENS);
-        retValue.cardsUsed.add(CardType.SENTRY);
-        retValue.cardsUsed.add(CardType.THRONE_ROOM);
-        retValue.cardsUsed.add(CardType.WITCH);
-        retValue.cardsUsed.add(CardType.CURSE);
-        retValue.cardsUsed.add(CardType.WORKSHOP);
-        return retValue;
-    }
-
-    public static DominionParameters improvements() {
-        DominionParameters retValue = new DominionParameters();
-        retValue.cardsUsed.add(CardType.ARTISAN);
-        retValue.cardsUsed.add(CardType.CELLAR);
-        retValue.cardsUsed.add(CardType.MARKET);
-        retValue.cardsUsed.add(CardType.MERCHANT);
-        retValue.cardsUsed.add(CardType.MINE);
-        retValue.cardsUsed.add(CardType.MOAT);
-        retValue.cardsUsed.add(CardType.MONEYLENDER);
-        retValue.cardsUsed.add(CardType.POACHER);
-        retValue.cardsUsed.add(CardType.REMODEL);
-        retValue.cardsUsed.add(CardType.WITCH);
-        retValue.cardsUsed.add(CardType.CURSE);
-        // Note that the three Victory cards and three Treasure cards are always included
-        return retValue;
-    }
-
-
     /**
      * Return a copy of this game parameters object, with the same parameters as in the original.
      *

--- a/src/main/java/games/dominion/DominionParameters.java
+++ b/src/main/java/games/dominion/DominionParameters.java
@@ -64,6 +64,42 @@ public class DominionParameters extends TunableParameters {
         }
     }
 
+    // Used by unit tests only
+    public static DominionParameters sizeDistortion() {
+        DominionParameters retValue = new DominionParameters();
+        retValue.cardsUsed.add(CardType.ARTISAN);
+        retValue.cardsUsed.add(CardType.BANDIT);
+        retValue.cardsUsed.add(CardType.BUREAUCRAT);
+        retValue.cardsUsed.add(CardType.CHAPEL);
+        retValue.cardsUsed.add(CardType.FESTIVAL);
+        retValue.cardsUsed.add(CardType.GARDENS);
+        retValue.cardsUsed.add(CardType.SENTRY);
+        retValue.cardsUsed.add(CardType.THRONE_ROOM);
+        retValue.cardsUsed.add(CardType.WITCH);
+        retValue.cardsUsed.add(CardType.CURSE);
+        retValue.cardsUsed.add(CardType.WORKSHOP);
+        return retValue;
+    }
+
+    // Used by unit tests only
+    public static DominionParameters improvements() {
+        DominionParameters retValue = new DominionParameters();
+        retValue.cardsUsed.add(CardType.ARTISAN);
+        retValue.cardsUsed.add(CardType.CELLAR);
+        retValue.cardsUsed.add(CardType.MARKET);
+        retValue.cardsUsed.add(CardType.MERCHANT);
+        retValue.cardsUsed.add(CardType.MINE);
+        retValue.cardsUsed.add(CardType.MOAT);
+        retValue.cardsUsed.add(CardType.MONEYLENDER);
+        retValue.cardsUsed.add(CardType.POACHER);
+        retValue.cardsUsed.add(CardType.REMODEL);
+        retValue.cardsUsed.add(CardType.WITCH);
+        retValue.cardsUsed.add(CardType.CURSE);
+        // Note that the three Victory cards and three Treasure cards are always included
+        return retValue;
+    }
+
+
     /**
      * Return a copy of this game parameters object, with the same parameters as in the original.
      *

--- a/src/main/java/games/dominion/actions/Merchant.java
+++ b/src/main/java/games/dominion/actions/Merchant.java
@@ -43,7 +43,7 @@ class MerchantBuyEffect implements IDelayedAction {
     @Override
     public void execute(DominionGameState state) {
         if (state.getCurrentPlayer() != player) {
-            throw new AssertionError("Should only be executed when current player if " + player);
+            throw new AssertionError("Should only be executed when current player is " + player);
         }
         Deck<DominionCard> hand = state.getDeck(DominionConstants.DeckType.HAND, player);
         if (hand.stream().anyMatch(c -> c.cardType() == BONUS_SPEND_CARD_TYPE)) {

--- a/src/main/java/games/stratego/StrategoGameState.java
+++ b/src/main/java/games/stratego/StrategoGameState.java
@@ -34,7 +34,7 @@ public class StrategoGameState extends AbstractGameState{
 
     @Override
     protected AbstractGameState _copy(int playerId) {
-        StrategoGameState s = new StrategoGameState(gameParameters, 2);
+        StrategoGameState s = new StrategoGameState(gameParameters.copy(), 2);
         s.gridBoard = gridBoard.emptyCopy();
         Piece.Alliance playerAlliance = null;
 

--- a/src/main/java/games/terraformingmars/TMGameState.java
+++ b/src/main/java/games/terraformingmars/TMGameState.java
@@ -119,7 +119,7 @@ public class TMGameState extends AbstractGameStateWithTurnOrder {
 
     @Override
     protected AbstractGameStateWithTurnOrder __copy(int playerId) {
-        TMGameState copy = new TMGameState(gameParameters, getNPlayers());
+        TMGameState copy = new TMGameState(gameParameters.copy(), getNPlayers());
 
         // General public info
         copy.generation = generation;

--- a/src/main/java/games/wonders7/Wonders7GameState.java
+++ b/src/main/java/games/wonders7/Wonders7GameState.java
@@ -99,6 +99,7 @@ public class Wonders7GameState extends AbstractGameState {
         copy.wonderBoardDeck = wonderBoardDeck.copy();
         copy.cardRnd = new Random(redeterminisationRnd.nextInt());
 
+        // TODO: This does not keep the known information!!!
         if (getCoreGameParameters().partialObservable && playerId != -1) {
             // Player does not know the other players hands and discard pile (except for next players hand)
             // All the cards of other players and discard pile are shuffled
@@ -128,7 +129,7 @@ public class Wonders7GameState extends AbstractGameState {
             copy.turnActions = new AbstractAction[getNPlayers()];
             if (turnActions[playerId] != null)
                 copy.turnActions[playerId] = turnActions[playerId].copy();
-            // we know our action (if one has been chosen, but no one elses
+            // we know our action (if one has been chosen, but no one elses)
         }
         return copy;
     }

--- a/src/main/java/games/wonders7/actions/BuildStage.java
+++ b/src/main/java/games/wonders7/actions/BuildStage.java
@@ -63,6 +63,7 @@ public class BuildStage extends AbstractAction {
         if (!cardFound) {
             throw new AssertionError("Card not found in player hand");
         }
+        // TODO: This is plain wrong - we need to keep these as a separate set of cards (players know which ones they have played, but opponents do not)
         wgs.getDiscardPile().add(card);
 
         wgs.getPlayerWonderBoard(player).changeStage(); // Increases wonderstage value to the next stage

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -68,7 +68,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
         addTunableParameter("MASTBoltzmann", 0.1);
         addTunableParameter("exp3Boltzmann", 0.1);
-        addTunableParameter("hedgeBoltzmann", 100);
+        addTunableParameter("hedgeBoltzmann", 100.0);
         addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 10, 30, 100));
         addTunableParameter("maxTreeDepth", 10, Arrays.asList(1, 3, 10, 30, 100));
         addTunableParameter("rolloutType", RANDOM, Arrays.asList(MCTSEnums.Strategies.values()));

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -33,7 +33,7 @@ public class MCTSParams extends PlayerParameters {
     public double MASTGamma = 0.5;
     public double MASTBoltzmann = 0.1;
     public double exp3Boltzmann = 0.1;
-    public double hedgeBoltzmann = 0.1;
+    public double hedgeBoltzmann = 100;
     public MCTSEnums.Strategies expansionPolicy = RANDOM;
     public MCTSEnums.SelectionPolicy selectionPolicy = SIMPLE;  // In general better than ROBUST
     public MCTSEnums.TreePolicy treePolicy = UCB;
@@ -68,7 +68,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
         addTunableParameter("MASTBoltzmann", 0.1);
         addTunableParameter("exp3Boltzmann", 0.1);
-        addTunableParameter("hedgeBoltzmann", 0.1);
+        addTunableParameter("hedgeBoltzmann", 100);
         addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 10, 30, 100));
         addTunableParameter("maxTreeDepth", 10, Arrays.asList(1, 3, 10, 30, 100));
         addTunableParameter("rolloutType", RANDOM, Arrays.asList(MCTSEnums.Strategies.values()));

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -80,7 +80,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("opponentModelParams", ITunableParameters.class);
         addTunableParameter("opponentModel", new RandomPlayer());
         addTunableParameter("information", Open_Loop, Arrays.asList(MCTSEnums.Information.values()));
-        addTunableParameter("selectionPolicy", ROBUST, Arrays.asList(MCTSEnums.SelectionPolicy.values()));
+        addTunableParameter("selectionPolicy", SIMPLE, Arrays.asList(MCTSEnums.SelectionPolicy.values()));
         addTunableParameter("treePolicy", UCB, Arrays.asList(MCTSEnums.TreePolicy.values()));
         addTunableParameter("opponentTreePolicy", OneTree, Arrays.asList(MCTSEnums.OpponentTreePolicy.values()));
         addTunableParameter("exploreEpsilon", 0.1);

--- a/src/main/java/players/mcts/MCTSTreeActionStatisticsListener.java
+++ b/src/main/java/players/mcts/MCTSTreeActionStatisticsListener.java
@@ -30,8 +30,9 @@ public class MCTSTreeActionStatisticsListener extends ActionFeatureListener {
      * @param actionFeatures - the additional features used for Q
      */
     public MCTSTreeActionStatisticsListener(IStateFeatureVector stateFeatures, IActionFeatureVector actionFeatures,
-                                            int visitThreshold, int maxDepth, ActionTargetType actionTarget) {
-        super(actionFeatures, stateFeatures, Event.GameEvent.ACTION_CHOSEN, true);
+                                            int visitThreshold, int maxDepth, ActionTargetType actionTarget,
+                                            String fileName) {
+        super(actionFeatures, stateFeatures, Event.GameEvent.ACTION_CHOSEN, true, fileName);
         this.actionTarget = actionTarget;
         this.visitThreshold = visitThreshold;
         this.maxDepth = maxDepth;

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -737,6 +737,8 @@ public class SingleTreeNode {
         double regret = potentialValue - nodeValue * nVisits;
         if (params.treePolicy == MCTSEnums.TreePolicy.Hedge) {
             // in this case we exponentiate the regret to get the probability of taking this action
+            // This may be problematic for large regrets, as it is not standardised to number of actions
+            // So the Boltzmann factor needs to be quite large
             double v = Math.exp(regret / params.hedgeBoltzmann);
             if (Double.isNaN(v))
                 throw new AssertionError("We have a non-number in Hedge somewhere");

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -734,7 +734,7 @@ public class SingleTreeNode {
         }
         // potential value is our estimate of our accumulated reward if we had always taken this action
         double potentialValue = actionValue * nVisits / actionVisits;
-        double regret = potentialValue - nodeValue;
+        double regret = potentialValue - nodeValue * nVisits;
         if (params.treePolicy == MCTSEnums.TreePolicy.Hedge) {
             // in this case we exponentiate the regret to get the probability of taking this action
             double v = Math.exp(regret / params.hedgeBoltzmann);


### PR DESCRIPTION
The main content if this is not actually to fix Dominion; but to fix some bugs in RegretMatching and MAST rollouts in MCTS that are particularly useful for Dominion.

1) Regret Matching selection rule was broken in the MCGS refactor (I forgot to rescale the node value baseline in line with the total visits), which led to a pretty flat (i.e. random) distribution over options and hence very poor play,

2) RunGames now explicitly copies the Agent used if in SELF_PLAY mode (in non SELF_PLAY we know we never have duplicate agents in a game). 
The problem was that with MAST rollout enabled (with MASTGamma > 0, so that statistics are retained from turn to turn within one game), the first player's first move was the only one that did not start off with some useful data to guide rollouts. This changes the first player win rate from 53% to 40% - a pretty massive swing for a slightly worse opening move! (Reinforcing all my prejudices about Dominion).

3) While working out all the above, the Dominion code has also been refactored slightly to avoid duplication and use parts of the framework that the author was not properly aware of.