### PR TITLE
Max MCTS

### DIFF
--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -573,6 +573,10 @@ public class Game {
                 if (debug)
                     System.out.printf("About to get action for player %d%n", gameState.getCurrentPlayer());
                 action = currentPlayer.getAction(observation, observedActions);
+                if (!observedActions.contains(action)) {
+                    throw new AssertionError("Action played that was not in the list of available actions: " + action);
+                }
+
                 if (debug)
                     System.out.printf("Game: %2d Tick: %3d\t%s%n", gameState.getGameID(), getTick(), action.getString(gameState));
 

--- a/src/main/java/evaluation/RunArg.java
+++ b/src/main/java/evaluation/RunArg.java
@@ -15,7 +15,11 @@ import static utilities.Utils.getArg;
 public enum RunArg {
 
 
-    NTBEAmode("Defaults to NTBEA. The other options are MultiNTBEA and CoopNTBEA. This last uses the same agent for all players.",
+    NTBEAMode("Defaults to NTBEA. The other options are StableNTBEA, MultiNTBEA and CoopNTBEA.\n" +
+            "The default runs a single game for each iteration. CoopNTBEA uses the same agent for all players.\n" +
+            "StableNTBEA runs P (number of players) for a given random seed, with the tuned agent in each position.\n" +
+            "This is useful for games with strong positional or random seed effects to reduce variance.\n" +
+            "MultiNTBEA is deprecated and should not be used.",
             "NTBEA",
             new Usage[]{Usage.ParameterSearch}),
     addTimeStamp("(Optional) If true (default is false), then the results will be written to a subdirectory of destDir.\n" +

--- a/src/main/java/evaluation/optimisation/GameEvaluator.java
+++ b/src/main/java/evaluation/optimisation/GameEvaluator.java
@@ -141,7 +141,7 @@ public class GameEvaluator implements SolutionEvaluator {
         return retValue;
     }
 
-    private List<AbstractPlayer> setupPlayers(int playerIndex, int nTeams, int[] settings) {
+    private List<AbstractPlayer> setupPlayers(int teamIndex, int nTeams, int[] settings) {
         List<AbstractPlayer> allPlayers = new ArrayList<>(nPlayers);
         // create a random permutation of opponents - this is used if we want to avoid opponent duplicates
         // if we allow duplicates, then we randomise them all independently
@@ -149,7 +149,7 @@ public class GameEvaluator implements SolutionEvaluator {
         Collections.shuffle(opponentOrdering);
         int count = 0;
         for (int i = 0; i < nTeams; i++) {
-            if (params.mode != CoopNTBEA && i != playerIndex) {
+            if (params.mode != CoopNTBEA && i != teamIndex) {
                 int oppIndex = (avoidOppDupes) ? count : rnd.nextInt(opponents.size());
                 count = (count + 1) % nTeams;
                 allPlayers.add(opponents.get(oppIndex).copy());

--- a/src/main/java/evaluation/optimisation/GameEvaluator.java
+++ b/src/main/java/evaluation/optimisation/GameEvaluator.java
@@ -14,6 +14,8 @@ import games.GameType;
 import java.util.*;
 import java.util.stream.IntStream;
 
+import static evaluation.optimisation.NTBEAParameters.Mode.CoopNTBEA;
+import static evaluation.optimisation.NTBEAParameters.Mode.StableNTBEA;
 import static java.util.stream.Collectors.toList;
 
 /**
@@ -24,6 +26,7 @@ import static java.util.stream.Collectors.toList;
  */
 public class GameEvaluator implements SolutionEvaluator {
 
+    NTBEAParameters params;
     public boolean debug = false;
     GameType game;
     AbstractParameters gameParams;
@@ -33,7 +36,6 @@ public class GameEvaluator implements SolutionEvaluator {
     int nEvals = 0;
     Random rnd;
     boolean avoidOppDupes;
-    boolean fullyCoop;
     IStateHeuristic stateHeuristic;
     IGameHeuristic gameHeuristic;
     List<IGameListener> listeners = new ArrayList<>();
@@ -42,35 +44,33 @@ public class GameEvaluator implements SolutionEvaluator {
      * GameEvaluator
      *
      * @param game                    The game that will be run for each trial. After each trial it is reset().
-     * @param parametersToTune        The ITunableParameters object that defines the parameter space we are optimising over.
-     *                                This will vary with whatever is being optimised.
+     * @param params                  The NTBEAParameters object that defines any parameter settings
      * @param opponents               A List of opponents to be played against. In each trial a random set of these opponents will be
      *                                used in addition to the main agent being tested.
      *                                To use the same set of opponents in each game, this should contain N-1 AbstractPlayers, where
      *                                N is the number of players in the game.
-     * @param seed                    Random seed to use
      * @param avoidOpponentDuplicates If this is true, then each individual in opponents will only be used once per game.
      *                                If this is false, then it is important not to use AbstractPlayers that maintain
      *                                any state, or that make any use of their playerId. (So RandomPlayer is fine.)
      */
-    public GameEvaluator(GameType game, ITPSearchSpace parametersToTune,
-                         AbstractParameters gameParams,
+    public GameEvaluator(GameType game,
+                         NTBEAParameters params,
                          int nPlayers,
-                         List<AbstractPlayer> opponents, long seed,
+                         List<AbstractPlayer> opponents,
                          IStateHeuristic stateHeuristic, IGameHeuristic gameHeuristic,
                          boolean avoidOpponentDuplicates) {
         this.game = game;
-        this.gameParams = gameParams;
-        this.searchSpace = parametersToTune;
+        this.params = params;
+        this.gameParams = params.gameParams;
+        this.searchSpace = params.searchSpace;
         this.nPlayers = nPlayers;
         this.stateHeuristic = stateHeuristic;
         this.gameHeuristic = gameHeuristic;
         this.opponents = opponents;
-        this.rnd = new Random(seed);
+        this.rnd = new Random(params.seed);
         this.avoidOppDupes = avoidOpponentDuplicates && opponents.size() > 1;
         if (avoidOppDupes && opponents.size() < nPlayers - 1)
             throw new AssertionError("Insufficient Opponents to avoid duplicates");
-        if (opponents.isEmpty()) fullyCoop = true;
     }
 
     @Override
@@ -104,19 +104,49 @@ public class GameEvaluator implements SolutionEvaluator {
         Game newGame = tuningGame ? (Game) configuredThing : game.createGameInstance(nPlayers, gameParams);
         // we assign one player to each team (the default for a game is each player being their own team of 1)
         int nTeams = newGame.getGameState().getNTeams();
-        List<AbstractPlayer> allPlayers = new ArrayList<>(nTeams);
 
         // We can reduce variance here by cycling the playerIndex on each iteration
         // If we're not tuning the player, then setting index to -99 means we just use the provided opponents list
         int playerIndex = tuningPlayer ? nEvals % nTeams : -99;
 
+
+        // We generally one game per evaluation, unless we are in 'Stable' mode,
+        // in which case we reduce variance by running one game for each position the tuned agent can be in
+        int gamesToRun = params.mode == StableNTBEA ? nPlayers : 1;
+        long seed = rnd.nextLong();
+        double retValue = 0.0;
+        for (int loop = 0; loop < gamesToRun; loop++) {
+            List<AbstractPlayer> allPlayers = setupPlayers((playerIndex + loop) % nTeams, nTeams, settings);
+
+            // always reset the random seed for each new game
+            newGame.reset(allPlayers, seed);
+            newGame.run();
+
+            int playerOnTeam = -1;
+            for (int p = 0; p < newGame.getGameState().getNPlayers(); p++) {
+                if (newGame.getGameState().getTeam(p) == playerIndex) {
+                    playerOnTeam = p;
+                }
+            }
+            if (playerOnTeam == -1)
+                throw new AssertionError("No Player found on team " + playerIndex);
+            retValue += tuningGame ? gameHeuristic.evaluateGame(newGame) : stateHeuristic.evaluateState(newGame.getGameState(), playerOnTeam);
+        }
+        //    System.out.println("GameEvaluator: " + retValue);
+
+        nEvals++;
+        return retValue;
+    }
+
+    private List<AbstractPlayer> setupPlayers(int playerIndex, int nTeams, int[] settings) {
+        List<AbstractPlayer> allPlayers = new ArrayList<>(nPlayers);
         // create a random permutation of opponents - this is used if we want to avoid opponent duplicates
         // if we allow duplicates, then we randomise them all independently
         List<Integer> opponentOrdering = IntStream.range(0, opponents.size()).boxed().collect(toList());
         Collections.shuffle(opponentOrdering);
         int count = 0;
         for (int i = 0; i < nTeams; i++) {
-            if (!fullyCoop && i != playerIndex) {
+            if (params.mode != CoopNTBEA && i != playerIndex) {
                 int oppIndex = (avoidOppDupes) ? count : rnd.nextInt(opponents.size());
                 count = (count + 1) % nTeams;
                 allPlayers.add(opponents.get(oppIndex).copy());
@@ -125,30 +155,13 @@ public class GameEvaluator implements SolutionEvaluator {
                 allPlayers.add(tunedPlayer);
             }
         }
-
-        // always reset the random seed for each new game
-        newGame.reset(allPlayers, rnd.nextLong());
-
-        newGame.run();
-        int playerOnTeam = -1;
-        for (int p = 0; p < newGame.getGameState().getNPlayers(); p++) {
-            if (newGame.getGameState().getTeam(p) == playerIndex) {
-                playerOnTeam = p;
-            }
-        }
-        if (playerOnTeam == -1)
-            throw new AssertionError("No Player found on team " + playerIndex);
-        double retValue = tuningGame ? gameHeuristic.evaluateGame(newGame) : stateHeuristic.evaluateState(newGame.getGameState(), playerOnTeam);
-
-    //    System.out.println("GameEvaluator: " + retValue);
-
-        nEvals++;
-        return retValue;
+        return allPlayers;
     }
 
     public void addListener(IGameListener listener) {
         listeners.add(listener);
     }
+
     public void clearListeners() {
         listeners.clear();
     }

--- a/src/main/java/evaluation/optimisation/NTBEA.java
+++ b/src/main/java/evaluation/optimisation/NTBEA.java
@@ -101,15 +101,12 @@ public class NTBEA {
         // Initialise the GameEvaluator that will do all the heavy lifting
         evaluator = new GameEvaluator(
                 game,
-                params.searchSpace,
-                params.gameParams,
+                params,
                 nPlayers,
                 opponents,
-                params.seed,
                 stateHeuristic,
                 gameHeuristic,
-                true
-        );
+                true);
     }
 
     public void setOpponents(List<AbstractPlayer> opponents) {

--- a/src/main/java/evaluation/optimisation/NTBEAParameters.java
+++ b/src/main/java/evaluation/optimisation/NTBEAParameters.java
@@ -22,7 +22,7 @@ import static utilities.Utils.*;
 public class NTBEAParameters {
 
     public enum Mode {
-        NTBEA, MultiNTBEA, CoopNTBEA
+        NTBEA, MultiNTBEA, CoopNTBEA, StableNTBEA
     }
 
     public boolean tuningGame;
@@ -68,7 +68,7 @@ public class NTBEAParameters {
         gameParams = args.get(RunArg.gameParams).equals("") ? null :
                 AbstractParameters.createFromFile(game, (String) args.get(RunArg.gameParams));
 
-        mode = Mode.valueOf((String) args.get(RunArg.NTBEAmode));
+        mode = Mode.valueOf((String) args.get(RunArg.NTBEAMode));
         logFile = (String) args.get(RunArg.output);
         if (logFile.isEmpty()) logFile = "NTBEA.log";
         listenerClasses = (List<String>) args.get(RunArg.listener);

--- a/src/main/java/evaluation/optimisation/ParameterSearch.java
+++ b/src/main/java/evaluation/optimisation/ParameterSearch.java
@@ -65,13 +65,19 @@ public class ParameterSearch {
         NTBEAParameters params = new NTBEAParameters(config);
         params.printSearchSpaceDetails();
 
-        if (params.mode == NTBEAParameters.Mode.MultiNTBEA) {
-            MultiNTBEA multiNTBEA = new MultiNTBEA(params, game, nPlayers);
-            multiNTBEA.run();
-        } else {
-            NTBEA singleNTBEA = new NTBEA(params, game, nPlayers);
-            singleNTBEA.run();
+        switch (params.mode) {
+            case NTBEA:
+            case CoopNTBEA:
+            case StableNTBEA:
+                NTBEA singleNTBEA = new NTBEA(params, game, nPlayers);
+                singleNTBEA.run();
+                break;
+            case MultiNTBEA:
+                MultiNTBEA multiNTBEA = new MultiNTBEA(params, game, nPlayers);
+                multiNTBEA.run();
+                break;
         }
+
     }
 
 

--- a/src/main/java/games/poker/PokerForwardModel.java
+++ b/src/main/java/games/poker/PokerForwardModel.java
@@ -32,6 +32,7 @@ public class PokerForwardModel extends StandardForwardModel {
         pgs.playerBet = new Counter[firstState.getNPlayers()];
         pgs.playerActStreet = new boolean[pgs.getNPlayers()];
         pgs.moneyPots = new ArrayList<>();
+        pgs.bet = false;
 
         pgs.playerDecks = new ArrayList<>();
         for (int i = 0; i < pgs.getNPlayers(); i++) {

--- a/src/main/java/players/mcts/MCGSNode.java
+++ b/src/main/java/players/mcts/MCGSNode.java
@@ -116,14 +116,14 @@ public class MCGSNode extends SingleTreeNode {
                     nRoot.trajectory.size() + " != " + nRoot.actionsInTree.size());
         }
 
-        for (int i = 0; i < nRoot.trajectory.size(); i++) {
+        for (int i = nRoot.trajectory.size() - 1; i >= 0; i--) {
             String key = nRoot.trajectory.get(i);
             MCGSNode node = nRoot.transpositionMap.get(key);
             AbstractAction action = nRoot.actionsInTree.get(i).b;
             if (node == null) {
                 throw new AssertionError("Node should not be null");
             }
-            node.backUpSingleNode(action, result);
+            result = node.backUpSingleNode(action, result);
         }
         nRoot.trajectory.clear();
     }

--- a/src/main/java/players/mcts/MCTSEnums.java
+++ b/src/main/java/players/mcts/MCTSEnums.java
@@ -21,7 +21,7 @@ public class MCTSEnums {
     }
 
     public enum TreePolicy {
-        UCB, UCB_Tuned, AlphaGo, EXP3, RegretMatching, Hedge
+        UCB, UCB_Tuned, AlphaGo, EXP3, RegretMatching
     }
 
     public enum RolloutTermination {

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -70,7 +70,6 @@ public class MCTSParams extends PlayerParameters {
     public double progressiveBias = 0.0;
     public boolean reuseTree = false;
     public int maxBackupThreshold = 1000000;
-    public boolean recursiveBackup = false;
 
 
     public MCTSParams() {
@@ -119,7 +118,6 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("actionHeuristicRecalculation", 20);
         addTunableParameter("reuseTree", false);
         addTunableParameter("maxBackupThreshold", 1000000);
-        addTunableParameter("recursiveBackup", false);
     }
 
     @Override
@@ -178,7 +176,6 @@ public class MCTSParams extends PlayerParameters {
         actionHeuristicRecalculationThreshold = (int) getParameterValue("actionHeuristicRecalculation");
         reuseTree = (boolean) getParameterValue("reuseTree");
         maxBackupThreshold = (int) getParameterValue("maxBackupThreshold");
-        recursiveBackup = (boolean) getParameterValue("recursiveBackup");
         opponentModel = null;
         rolloutPolicy = null;
         useMASTAsActionHeuristic = (boolean) getParameterValue("useMASTAsActionHeuristic");

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -69,6 +69,8 @@ public class MCTSParams extends PlayerParameters {
     public double progressiveWideningExponent = 0.0;
     public double progressiveBias = 0.0;
     public boolean reuseTree = false;
+    public int maxBackupThreshold = 1000000;
+
 
     public MCTSParams() {
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
@@ -115,6 +117,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("initialiseVisits", 0);
         addTunableParameter("actionHeuristicRecalculation", 20);
         addTunableParameter("reuseTree", false);
+        addTunableParameter("maxBackupThreshold", 1000000);
     }
 
     @Override
@@ -172,6 +175,7 @@ public class MCTSParams extends PlayerParameters {
         initialiseVisits = (int) getParameterValue("initialiseVisits");
         actionHeuristicRecalculationThreshold = (int) getParameterValue("actionHeuristicRecalculation");
         reuseTree = (boolean) getParameterValue("reuseTree");
+        maxBackupThreshold = (int) getParameterValue("maxBackupThreshold");
         opponentModel = null;
         rolloutPolicy = null;
         useMASTAsActionHeuristic = (boolean) getParameterValue("useMASTAsActionHeuristic");

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -29,7 +29,7 @@ public class MCTSParams extends PlayerParameters {
     public MCTSEnums.Information information = Information_Set;  // this should be the default in TAG, given that most games have hidden information
     public MCTSEnums.MASTType MAST = None;
     public boolean useMAST = false;
-    public double MASTGamma = 0.5;
+    public double MASTGamma = 0.0;
     public double MASTDefaultValue = 0.0;
     public double MASTBoltzmann = 0.1;
     public double exp3Boltzmann = 1.0;
@@ -96,7 +96,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("heuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
         addTunableParameter("opponentHeuristic", (IStateHeuristic) AbstractGameState::getHeuristicScore);
         addTunableParameter("MAST", None, Arrays.asList(MCTSEnums.MASTType.values()));
-        addTunableParameter("MASTGamma", 0.5, Arrays.asList(0.0, 0.5, 0.9, 1.0));
+        addTunableParameter("MASTGamma", 0.0, Arrays.asList(0.0, 0.5, 0.9, 1.0));
         addTunableParameter("useMASTAsActionHeuristic", false);
         addTunableParameter("progressiveWideningConstant", 0.0, Arrays.asList(0.0, 1.0, 2.0, 4.0, 8.0, 16.0, 32.0));
         addTunableParameter("progressiveWideningExponent", 0.0, Arrays.asList(0.0, 0.1, 0.2, 0.3, 0.5));

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -70,6 +70,7 @@ public class MCTSParams extends PlayerParameters {
     public double progressiveBias = 0.0;
     public boolean reuseTree = false;
     public int maxBackupThreshold = 1000000;
+    public boolean recursiveBackup = false;
 
 
     public MCTSParams() {
@@ -118,6 +119,7 @@ public class MCTSParams extends PlayerParameters {
         addTunableParameter("actionHeuristicRecalculation", 20);
         addTunableParameter("reuseTree", false);
         addTunableParameter("maxBackupThreshold", 1000000);
+        addTunableParameter("recursiveBackup", false);
     }
 
     @Override
@@ -176,6 +178,7 @@ public class MCTSParams extends PlayerParameters {
         actionHeuristicRecalculationThreshold = (int) getParameterValue("actionHeuristicRecalculation");
         reuseTree = (boolean) getParameterValue("reuseTree");
         maxBackupThreshold = (int) getParameterValue("maxBackupThreshold");
+        recursiveBackup = (boolean) getParameterValue("recursiveBackup");
         opponentModel = null;
         rolloutPolicy = null;
         useMASTAsActionHeuristic = (boolean) getParameterValue("useMASTAsActionHeuristic");

--- a/src/main/java/players/mcts/MCTSPlayer.java
+++ b/src/main/java/players/mcts/MCTSPlayer.java
@@ -235,7 +235,7 @@ public class MCTSPlayer extends AbstractPlayer implements IAnyTimePlayer {
         } else {
             root = newRoot;
         }
-        if (MASTStats != null)
+        if (MASTStats != null && getParameters().MASTGamma > 0.0)
             root.MASTStatistics = MASTStats.stream()
                     .map(m -> Utils.decay(m, getParameters().MASTGamma))
                     .collect(Collectors.toList());

--- a/src/main/java/players/mcts/MultiTreeNode.java
+++ b/src/main/java/players/mcts/MultiTreeNode.java
@@ -76,6 +76,7 @@ public class MultiTreeNode extends SingleTreeNode {
         System.arraycopy(roots, 0, currentLocation, 0, currentLocation.length);
 
         actionsInTree = new ArrayList<>();
+        currentNodeTrajectory = new ArrayList<>();
         actionsInRollout = new ArrayList<>();
         // Keep iterating while the state reached is not terminal and the depth of the tree is not exceeded
         do {
@@ -118,6 +119,7 @@ public class MultiTreeNode extends SingleTreeNode {
                 if (debug)
                     System.out.printf("Tree action chosen for P%d - %s %n", currentActor, chosen);
                 advanceState(currentState, chosen, false);
+                currentNodeTrajectory.add(currentNode);
 
                 if (currentLocation[currentActor].depth >= params.maxTreeDepth)
                     maxDepthReached[currentActor] = true;
@@ -137,13 +139,16 @@ public class MultiTreeNode extends SingleTreeNode {
                 // for each player-specific sub-tree we filter these to just their actions
                 if (p != currentLocation[p].decisionPlayer)
                     throw new AssertionError("We should only be backing up for the decision player");
-                int finalP = p;
-                currentLocation[p].root.actionsInTree = actionsInTree.stream()
-                        .filter(a -> a.a == finalP)
-                        .collect(Collectors.toList());
-//                singleTreeNode.root.actionsInRollout = actionsInRollout.stream()
-//                        .filter(a -> a.a == singleTreeNode.decisionPlayer)
-//                        .collect(Collectors.toList());
+
+                currentLocation[p].root.actionsInTree = new ArrayList<>();
+                currentLocation[p].root.currentNodeTrajectory = new ArrayList<>();
+                for (int i = 0; i < actionsInTree.size(); i++) {
+                    if (actionsInTree.get(i).a == p) {
+                        currentLocation[p].root.actionsInTree.add(actionsInTree.get(i));
+                        if (i < currentNodeTrajectory.size())
+                            currentLocation[p].root.currentNodeTrajectory.add(currentNodeTrajectory.get(i));
+                    }
+                }
                 currentLocation[p].backUp(finalValues);
             }
         }

--- a/src/main/java/players/mcts/OMATreeNode.java
+++ b/src/main/java/players/mcts/OMATreeNode.java
@@ -60,7 +60,7 @@ public class OMATreeNode extends SingleTreeNode {
             int finalPlayer = player;
             List<AbstractAction> selfActionsOnly = root.actionsInTree.stream()
                     .filter(p -> p.a == finalPlayer).map(p -> p.b)
-                    .collect(toList());
+                    .toList();
             List<OMATreeNode> nodes = new ArrayList<>();
             OMATreeNode currentNode = this;
             do {

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -849,12 +849,6 @@ public class SingleTreeNode {
         return params.progressiveBias * actionValueEstimates.getOrDefault(action, 0.0) / (actionVisits + 1);
     }
 
-    private int sampleFromPotentials(double[] values) {
-        // then we need
-        return Utils.sampleFrom(values, rnd.nextDouble());
-    }
-
-
     /**
      * Perform a Monte Carlo rollout from this node.
      *

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -2,6 +2,7 @@ package players.mcts;
 
 import core.*;
 import core.actions.AbstractAction;
+import core.actions.DoNothing;
 import core.interfaces.IActionHeuristic;
 import players.PlayerConstants;
 import utilities.*;
@@ -920,7 +921,8 @@ public class SingleTreeNode {
      */
     protected void backUp(double[] delta) {
         normaliseRewardsAfterIteration(delta);
-        double[] result = processResultsForParanoidOrSelfOnly(delta);
+        double[] baseReward = processResultsForParanoidOrSelfOnly(delta);
+        double[] result = baseReward;
         // we need to go backwards up the tree, as the result may change
         for (int i = root.currentNodeTrajectory.size() - 1; i >= 0; i--) {
             int actingPlayer = root.actionsInTree.get(i).a;
@@ -1011,7 +1013,36 @@ public class SingleTreeNode {
             throw new AssertionError("We have somehow failed to find the action taken in the list of actions");
         if (stats.validVisits == 0)
             throw new AssertionError("We have somehow failed to find the action taken in the list of valid actions");
-        stats.update(result);
+        double localResult[] = result;
+        if (nVisits > params.maxBackupThreshold) {
+            localResult = result.clone();
+            // in this case we mix in a max backup
+            // *if* we took an action other than the one with the current best estimate
+            AbstractAction bestAction = null;
+            double maxValue = -Double.MAX_VALUE;
+            for (AbstractAction action : actionsToConsider) {
+                double value = actionValues.get(action).nVisits == 0 ? -Double.MAX_VALUE :
+                        actionValues.get(action).totValue[decisionPlayer] / actionValues.get(action).nVisits;
+                if (value > maxValue) {
+                    maxValue = value;
+                    bestAction = action;
+                }
+            }
+            if (bestAction == null) {
+                throw new AssertionError("We have somehow failed to find the action taken in the list of actions");
+            }
+            if (!bestAction.equals(actionTaken)) {
+                double maxWeight = nVisits / (double) (nVisits + params.maxBackupThreshold);
+                // we mix for all players, based on the counterfactual decision of the acting player
+                for (int i = 0; i < result.length; i++) {
+                    localResult[i] = (1 - maxWeight) * result[i] + maxWeight * maxValue;
+                }
+            }
+        }
+
+        stats.update(localResult);
+        if (params.recursiveBackup)
+            return localResult;
         return result;
     }
 

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -745,7 +745,9 @@ public class SingleTreeNode {
         // default to standard UCB
         int effectiveTotalVisits = validVisitsFor(action);
         // use first play urgency as replacement for exploration term if action not previously taken
-        double explorationTerm = params.firstPlayUrgency;
+        // we add in the second term based on the AlphaGo selection rule, so that the exploration term is monotonically increasing with N
+        // this will come into play for small values of FPU and acts as soft-pruning rather than the harder form if FPU is a fixed constant
+        double explorationTerm = Math.max(params.firstPlayUrgency, params.K * Math.sqrt(effectiveTotalVisits));
         if (actionVisits > 0) {
             explorationTerm = switch (params.treePolicy) {
                 case UCB_Tuned -> {
@@ -1074,7 +1076,7 @@ public class SingleTreeNode {
             policy = SIMPLE;
         }
         if (params.selectionPolicy == TREE || params.treePolicy == EXP3) {
-            // EXP3, Hedge use the tree policy (without exploration)
+            // EXP3 uses the tree policy (without exploration)
             bestAction = treePolicyAction(false);
         } else if (params.treePolicy == RegretMatching && !regretMatchingAverage.isEmpty()) {
             // RM uses a special policy as the average of all previous root policies

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -629,10 +629,10 @@ public class SingleTreeNode {
                         yield availableActions.get(rnd.nextInt(availableActions.size()));
                     }
                     double[] pdf = Utils.pdf(actionValues);
-                    if (nVisits % Math.min(actionValues.length, 10) == 1) {
+                    if (params.treePolicy == RegretMatching && nVisits > actionValues.length && nVisits % Math.min(actionValues.length, 10) == 1) {
                         // we update the average policy each time we have had the opportunity to take each action once
                         for (int i = 0; i < actionValues.length; i++) {
-                            regretMatchingAverage.merge(availableActions.get(i), pdf[i], Double::sum);
+                            root.regretMatchingAverage.merge(availableActions.get(i), pdf[i], Double::sum);
                         }
                     }
                     long nonZeroActions = Arrays.stream(actionValues).filter(v -> v > 0.0).count();

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -589,7 +589,7 @@ public class SingleTreeNode {
      * @return - child node according to the tree policy
      */
     protected AbstractAction treePolicyAction(boolean explore) {
-        if (params.opponentTreePolicy == SelfOnly && openLoopState != null && openLoopState.getCurrentPlayer() != decisionPlayer)
+        if (params.opponentTreePolicy == SelfOnly && parent != null && openLoopState != null && openLoopState.getCurrentPlayer() != decisionPlayer)
             throw new AssertionError("An error has occurred. SelfOnly should only call uct when we are moving.");
 
         // actionsToConsider takes care of any Progressive Widening in play, so we only consider the
@@ -629,7 +629,7 @@ public class SingleTreeNode {
                         yield availableActions.get(rnd.nextInt(availableActions.size()));
                     }
                     double[] pdf = Utils.pdf(actionValues);
-                    if (params.treePolicy == RegretMatching && nVisits > actionValues.length && nVisits % Math.min(actionValues.length, 10) == 1) {
+                    if (this == root && params.treePolicy == RegretMatching && nVisits > actionValues.length && nVisits % Math.min(actionValues.length, 10) == 1) {
                         // we update the average policy each time we have had the opportunity to take each action once
                         for (int i = 0; i < actionValues.length; i++) {
                             root.regretMatchingAverage.merge(availableActions.get(i), pdf[i], Double::sum);

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -1032,7 +1032,9 @@ public class SingleTreeNode {
                 }
             }
             if (bestAction == null) {
-                throw new AssertionError("We have somehow failed to find the action taken in the list of actions");
+                // this can happen for low maxBackupCounts with no actions available
+                // we default to ignoring Max functionality
+                bestAction = actionTaken;
             }
             if (!bestAction.equals(actionTaken)) {
                 double maxWeight = nVisits / (double) (nVisits + params.maxBackupThreshold);
@@ -1082,7 +1084,7 @@ public class SingleTreeNode {
         if (params.selectionPolicy == TREE || params.treePolicy == Hedge || params.treePolicy == EXP3) {
             // EXP3, Hedge use the tree policy (without exploration)
             bestAction = treePolicyAction(false);
-        } else if (params.treePolicy == RegretMatching) {
+        } else if (params.treePolicy == RegretMatching && !regretMatchingAverage.isEmpty()) {
             // RM uses a special policy as the average of all previous root policies
             bestAction = regretMatchingAverage();
         } else {

--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -184,7 +184,7 @@ public abstract class Utils {
         // convert potentials into legal pdf
         double[] pdf = new double[potentials.length];
         double sum = Arrays.stream(potentials).sum();
-        if (sum <= 0.0)  // default to uniform distribution
+        if (sum <= 0.0 || Double.isNaN(sum))  // default to uniform distribution
             return Arrays.stream(potentials).map(d -> 1.0 / potentials.length).toArray();
         for (int i = 0; i < potentials.length; i++) {
             if (potentials[i] < 0.0) {

--- a/src/test/java/players/mcts/BackupTests.java
+++ b/src/test/java/players/mcts/BackupTests.java
@@ -1,0 +1,171 @@
+package players.mcts;
+
+import core.actions.AbstractAction;
+import org.junit.Test;
+import utilities.Pair;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+
+import static org.junit.Assert.assertEquals;
+
+public class BackupTests {
+
+
+    LMRForwardModel fm = new LMRForwardModel();
+    LMRGame game = new LMRGame(new LMTParameters(302));
+    MCTSParams params = new MCTSParams();
+    TestMCTSPlayer player;
+    Random rnd = new Random(303897);
+    STNWithTestInstrumentation root;
+
+    List<AbstractAction> baseActions = List.of(new LMRAction("Left"), new LMRAction("Middle"), new LMRAction("Right"));
+    List<SingleTreeNode> nodeTrajectory001;
+    List<Pair<Integer, AbstractAction>> actionTrajectory001;
+    SingleTreeNode lastNode;
+
+
+    public void setupPlayer() {
+        fm.setup(game);
+        player = new TestMCTSPlayer(params, STNWithTestInstrumentation::new);
+        player.setForwardModel(fm);
+        root = (STNWithTestInstrumentation) SingleTreeNode.createRootNode(player, game, rnd, STNWithTestInstrumentation::new);
+
+        // we construct a known tree on which we will then apply some backups
+        // This assumes we will be back-propagating a trajectory of Middle, Left, Right, Middle
+
+        for (int i = 0; i < 50; i++) {
+            root.backUpSingleNode(new LMRAction("Middle"), new double[]{1.0});
+        }
+        for (int i = 0; i < 25; i++) {
+            root.backUpSingleNode(new LMRAction("Left"), new double[]{0.0});
+        }
+        for (int i = 0; i < 25; i++) {
+            root.backUpSingleNode(new LMRAction("Right"), new double[]{0.5});
+        }
+        // We now have a root node with 100 visits; with values of 1.0 for Middle, 0.0 for Left, 0.5 for Right
+
+        // level 1
+        for (int i = 0; i < 3; i++) {
+            root.expandNode(baseActions.get(i), game);
+        }
+        SingleTreeNode levelOneMiddle = root.getChildren().get(baseActions.get(1))[0];
+        for (int i = 0; i < 25; i++) {
+            levelOneMiddle.backUpSingleNode(new LMRAction("Left"), new double[]{0.9});
+        }
+        for (int i = 0; i < 15; i++) {
+            levelOneMiddle.backUpSingleNode(new LMRAction("Middle"), new double[]{0.0});
+        }
+        for (int i = 0; i < 10; i++) {
+            levelOneMiddle.backUpSingleNode(new LMRAction("Right"), new double[]{1.0});
+        }
+        // We now have a level 1 node with 50 visits; with values of 0.9 for Left, 0.0 for Middle, 1.0 for Right
+
+        // level 2
+        for (int i = 0; i < 3; i++) {
+            levelOneMiddle.expandNode(baseActions.get(i), game);
+        }
+        SingleTreeNode levelTwoLeft = levelOneMiddle.getChildren().get(baseActions.get(0))[0];
+        for (int i = 0; i < 10; i++) {
+            levelTwoLeft.backUpSingleNode(new LMRAction("Left"), new double[]{1.0});
+        }
+        for (int i = 0; i < 10; i++) {
+            levelTwoLeft.backUpSingleNode(new LMRAction("Middle"), new double[]{1.0});
+        }
+        for (int i = 0; i < 5; i++) {
+            levelTwoLeft.backUpSingleNode(new LMRAction("Right"), new double[]{0.0});
+        }
+        // We now have a level 2 node with 25 visits; with values of 1.0 for Left, 1.0 for Middle, 0.0 for Right
+
+        // level 3
+        for (int i = 0; i < 3; i++) {
+            levelTwoLeft.expandNode(baseActions.get(i), game);
+        }
+        SingleTreeNode levelThreeRight = levelTwoLeft.getChildren().get(baseActions.get(2))[0];
+        for (int i = 0; i < 2; i++) {
+            levelThreeRight.backUpSingleNode(new LMRAction("Left"), new double[]{1.0});
+        }
+        for (int i = 0; i < 2; i++) {
+            levelThreeRight.backUpSingleNode(new LMRAction("Middle"), new double[]{0.7});
+        }
+        for (int i = 0; i < 1; i++) {
+            levelThreeRight.backUpSingleNode(new LMRAction("Right"), new double[]{0.2});
+        }
+
+        for (int i = 0; i < 3; i++) {
+            levelThreeRight.expandNode(baseActions.get(i), game);
+        }
+        SingleTreeNode levelFourLeaf = levelThreeRight.getChildren().get(baseActions.get(1))[0];
+
+        assertEquals(100, root.getVisits());
+        assertEquals(50, levelOneMiddle.getVisits());
+        assertEquals(25, levelTwoLeft.getVisits());
+        assertEquals(5, levelThreeRight.getVisits());
+        assertEquals(0, levelFourLeaf.getVisits());
+
+        nodeTrajectory001 = List.of(root, levelOneMiddle, levelTwoLeft, levelThreeRight);
+        actionTrajectory001 = List.of(new Pair<>(0, new LMRAction("Middle")),
+                new Pair<>(0, new LMRAction("Left")),
+                new Pair<>(0, new LMRAction("Right")),
+                new Pair<>(0, new LMRAction("Middle")));
+        root.currentNodeTrajectory = nodeTrajectory001;
+        root.actionsInTree = actionTrajectory001;
+        root.actionsInRollout = new ArrayList<>();
+        lastNode = levelFourLeaf;
+    }
+
+    @Test
+    public void standardBackup() {
+        setupPlayer();
+        lastNode.backUp(new double[]{0.5});
+
+        assertEquals(101, root.getVisits());
+        assertEquals(51, nodeTrajectory001.get(1).getVisits());
+        assertEquals(26, nodeTrajectory001.get(2).getVisits());
+        assertEquals(6, nodeTrajectory001.get(3).getVisits());
+        assertEquals(0, lastNode.getVisits());
+
+        assertEquals(51, root.getActionStats(new LMRAction("Middle")).nVisits);
+        assertEquals(50.5, root.getActionStats(new LMRAction("Middle")).totValue[0], 0.0001);
+
+        assertEquals(26, nodeTrajectory001.get(1).actionValues.get(new LMRAction("Left")).nVisits);
+        assertEquals(25 * 0.9 + 0.5, nodeTrajectory001.get(1).actionValues.get(new LMRAction("Left")).totValue[0], 0.0001);
+
+        assertEquals(6, nodeTrajectory001.get(2).actionValues.get(new LMRAction("Right")).nVisits);
+        assertEquals(0.5, nodeTrajectory001.get(2).actionValues.get(new LMRAction("Right")).totValue[0], 0.0001);
+
+        assertEquals(3, nodeTrajectory001.get(3).actionValues.get(new LMRAction("Middle")).nVisits);
+        assertEquals(0.7 + 0.7 + 0.5, nodeTrajectory001.get(3).actionValues.get(new LMRAction("Middle")).totValue[0], 0.0001);
+    }
+
+
+    @Test
+    public void maxBackup001() {
+        // This will just affect the root and first level nodes
+        // But, since the best action is already taken from the root, it will not affect the final result
+        // It will affect the level 1 node
+        setupPlayer();
+        params.maxBackupThreshold = 30; // we set this now to avoid interfering with the tree construction
+        lastNode.backUp(new double[]{0.5});
+
+        assertEquals(101, root.getVisits());
+        assertEquals(51, nodeTrajectory001.get(1).getVisits());
+        assertEquals(26, nodeTrajectory001.get(2).getVisits());
+        assertEquals(6, nodeTrajectory001.get(3).getVisits());
+        assertEquals(0, lastNode.getVisits());
+
+        assertEquals(51, root.getActionStats(new LMRAction("Middle")).nVisits);
+        assertEquals(50.5, root.getActionStats(new LMRAction("Middle")).totValue[0], 0.0001);
+
+        double update = 30.0/81.0 * 0.5 + 51.0 / 81.0 * 1.0;
+        assertEquals(26, nodeTrajectory001.get(1).actionValues.get(new LMRAction("Left")).nVisits);
+        assertEquals(25 * 0.9 + update, nodeTrajectory001.get(1).actionValues.get(new LMRAction("Left")).totValue[0], 0.00001);
+
+        assertEquals(6, nodeTrajectory001.get(2).actionValues.get(new LMRAction("Right")).nVisits);
+        assertEquals(0.5, nodeTrajectory001.get(2).actionValues.get(new LMRAction("Right")).totValue[0], 0.0001);
+
+        assertEquals(3, nodeTrajectory001.get(3).actionValues.get(new LMRAction("Middle")).nVisits);
+        assertEquals(0.7 + 0.7 + 0.5, nodeTrajectory001.get(3).actionValues.get(new LMRAction("Middle")).totValue[0], 0.0001);
+    }
+}

--- a/src/test/java/players/mcts/MCTSNodesAndVisitsTests.java
+++ b/src/test/java/players/mcts/MCTSNodesAndVisitsTests.java
@@ -68,7 +68,7 @@ public class MCTSNodesAndVisitsTests {
     }
 
     @Test
-    public void maxN() {
+    public void oneTree() {
         params.opponentTreePolicy = MCTSEnums.OpponentTreePolicy.OneTree;
         Game game = createGame(params);
         int[] expectedNodes = {200, 200, 200, 200};

--- a/src/test/java/players/mcts/MCTSTreeSelectionTests.java
+++ b/src/test/java/players/mcts/MCTSTreeSelectionTests.java
@@ -184,6 +184,26 @@ public class MCTSTreeSelectionTests {
 
 
     @Test
+    public void rm10VisitsFinalSelection() {
+        rm10Visits();
+        int[] counts = new int[3];
+        for (int i = 0; i < 1000; i++) {
+            AbstractAction action = node.bestAction();
+            if (action.equals(new LMRAction("Left"))) {
+                counts[0]++;
+            } else if (action.equals(new LMRAction("Middle"))) {
+                counts[1]++;
+            } else {
+                counts[2]++;
+            }
+        }
+        assertEquals(1000, counts[0] + counts[1] + counts[2]);
+        assertEquals(0, counts[0], 0);
+        assertEquals(679, counts[1], 100);
+        assertEquals(321, counts[2], 100);
+    }
+
+    @Test
     public void rm10VisitsWithExploration() {
         params.treePolicy = RegretMatching;
         params.exploreEpsilon = 0.3;

--- a/src/test/java/players/mcts/MCTSTreeSelectionTests.java
+++ b/src/test/java/players/mcts/MCTSTreeSelectionTests.java
@@ -340,41 +340,6 @@ public class MCTSTreeSelectionTests {
 
 
     @Test
-    public void hedge_10Visits() {
-        params.treePolicy = Hedge;
-        params.exploreEpsilon = 0.1;
-        params.normaliseRewards = false;
-        params.hedgeBoltzmann = 0.8;
-        setupPlayer();
-        first10Visits(node);
-
-        // Regrets are:
-        // -1.31 / 0.19 / 0.09
-
-        double[] actionValues = node.actionValues(baseActions);
-        assertEquals(Math.exp(-1.31 * 10 / 0.8), actionValues[0], 0.01);  // 0.00
-        assertEquals(Math.exp(0.19 * 10 / 0.80), actionValues[1], 0.01); // 10.75
-        assertEquals(Math.exp(0.09 * 10 / 0.80), actionValues[2], 0.01); // 3.08
-        // The final choice of action is then stochastic
-        int[] counts = new int[3];
-        for (int i = 0; i < 1000; i++) {
-            AbstractAction action = node.treePolicyAction(true);
-            if (action.equals(new LMRAction("Left"))) {
-                counts[0]++;
-            } else if (action.equals(new LMRAction("Middle"))) {
-                counts[1]++;
-            } else {
-                counts[2]++;
-            }
-        }
-        // expected probability distribution is 0%, 78%, 22%  [not including the 10% exploration]
-        assertEquals(1000, counts[0] + counts[1] + counts[2]);
-        assertEquals(0.00 * 900 + 33, counts[0], 15);
-        assertEquals(0.78 * 900 + 33, counts[1], 50);
-        assertEquals(0.22 * 900 + 33, counts[2], 50);
-    }
-
-    @Test
     public void bias10Visits() {
         params.treePolicy = UCB;
         params.normaliseRewards = true;

--- a/src/test/java/players/mcts/MCTSTreeSelectionTests.java
+++ b/src/test/java/players/mcts/MCTSTreeSelectionTests.java
@@ -27,7 +27,6 @@ public class MCTSTreeSelectionTests {
         player = new TestMCTSPlayer(params, STNWithTestInstrumentation::new);
         player.setForwardModel(fm);
         node = (STNWithTestInstrumentation) SingleTreeNode.createRootNode(player, game, rnd, STNWithTestInstrumentation::new);
-
     }
 
     @Test
@@ -58,13 +57,16 @@ public class MCTSTreeSelectionTests {
 
     private void first10Visits(STNWithTestInstrumentation node) {
         node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Left")));
+        node.currentNodeTrajectory = List.of(node);
         node.backUp(new double[]{-1.0});
 
         node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Middle")));
+        node.currentNodeTrajectory = List.of(node);
         for (int i = 0; i < 5; i++) {
             node.backUp(new double[]{0.5});
         }
         node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Right")));
+        node.currentNodeTrajectory = List.of(node);
         for (int i = 0; i < 4; i++) {
             node.backUp(new double[]{0.4});
         }
@@ -454,13 +456,16 @@ public class MCTSTreeSelectionTests {
 
         // For this test we don't use first10Visits() as the initial visit parameter changes the visit counts
         node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Left")));
+        node.currentNodeTrajectory = List.of(node);
         node.backUp(new double[]{-1.0});
 
         node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Middle")));
+        node.currentNodeTrajectory = List.of(node);
         for (int i = 0; i < 5; i++) {
             node.backUp(new double[]{0.5});
         }
         node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Right")));
+        node.currentNodeTrajectory = List.of(node);
         for (int i = 0; i < 4; i++) {
             node.backUp(new double[]{0.4});
         }
@@ -477,8 +482,8 @@ public class MCTSTreeSelectionTests {
         // With seeding, we change both the value of the action, and the exploration term
         double[] actionValues = node.actionValues(baseActions);
         assertEquals((-1.0 + 0.3 * 4) / 5.0 + Math.sqrt(Math.log(22) / 5), actionValues[0], 0.01);
-        assertEquals(2.5 / 9.0 +  Math.sqrt(Math.log(22) / 9), actionValues[1], 0.01);
-        assertEquals((0.4 * 4 + 4.0) / 8.0 +  Math.sqrt(Math.log(22) / 8), actionValues[2], 0.01);
+        assertEquals(2.5 / 9.0 + Math.sqrt(Math.log(22) / 9), actionValues[1], 0.01);
+        assertEquals((0.4 * 4 + 4.0) / 8.0 + Math.sqrt(Math.log(22) / 8), actionValues[2], 0.01);
         assertEquals(new LMRAction("Right"), node.treePolicyAction(false));
     }
 
@@ -500,15 +505,16 @@ public class MCTSTreeSelectionTests {
         // The second action should become available at the 4th visits (2 = sqrt(N))
         for (int i = 0; i < 3; i++) {
             // Check that the correct number of actions are available (just the one)
-      //      System.out.println("Actions: " + node.actionsToConsider(node.actionsFromOpenLoopState));
+            //      System.out.println("Actions: " + node.actionsToConsider(node.actionsFromOpenLoopState));
             assertEquals(3, node.actionsFromOpenLoopState.size());
             assertEquals(1, node.actionsToConsider(node.actionsFromOpenLoopState).size());
             assertEquals(new LMRAction("Right"), node.actionsToConsider(node.actionsFromOpenLoopState).get(0));
             node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Right")));
+            node.currentNodeTrajectory = List.of(node);
             node.backUp(new double[]{-1.0});
 
             // then check that only the available actions are updated
-            assertEquals(i+1, node.getActionStats(new LMRAction("Right")).validVisits);
+            assertEquals(i + 1, node.getActionStats(new LMRAction("Right")).validVisits);
             assertEquals(i == 2 ? 1 : 0, node.getActionStats(new LMRAction("Left")).validVisits);
             assertEquals(0, node.getActionStats(new LMRAction("Middle")).validVisits);
         }
@@ -558,6 +564,7 @@ public class MCTSTreeSelectionTests {
             assertEquals(new LMRAction("Right"), node.actionsToConsider(node.actionsFromOpenLoopState).get(0));
             assertEquals(new LMRAction("Left"), node.actionsToConsider(node.actionsFromOpenLoopState).get(1));
             node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Right")));
+            node.currentNodeTrajectory = List.of(node);
             node.backUp(new double[]{-1.0});
         }
         assertEquals(3, node.actionsToConsider(node.actionsFromOpenLoopState).size());
@@ -586,6 +593,7 @@ public class MCTSTreeSelectionTests {
             assertEquals(1, node.actionsToConsider(node.actionsFromOpenLoopState).size());
             assertEquals(new LMRAction("Right"), node.treePolicyAction(true));
             node.actionsInTree = List.of(new Pair<>(0, new LMRAction("Right")));
+            node.currentNodeTrajectory = List.of(node);
             node.backUp(new double[]{1.0});
         }
         assertEquals(2, node.actionsToConsider(node.actionsFromOpenLoopState).size());
@@ -621,8 +629,8 @@ public class MCTSTreeSelectionTests {
         first10Visits(node);
         assertEquals(new LMRAction("Right"), node.treePolicyAction(false));
         actionValues = node.actionValues(baseActions);
-        assertEquals( 0.0 + 0.3 / 1.3 * Math.sqrt(Math.log(10)), actionValues[0], 0.01);
-        assertEquals( 1.0, actionValues[1], 0.01);
-        assertEquals( 1.4/1.5 + 1.0 / 1.3 * Math.sqrt(Math.log(10) / 4), actionValues[2], 0.01);
+        assertEquals(0.0 + 0.3 / 1.3 * Math.sqrt(Math.log(10)), actionValues[0], 0.01);
+        assertEquals(1.0, actionValues[1], 0.01);
+        assertEquals(1.4 / 1.5 + 1.0 / 1.3 * Math.sqrt(Math.log(10) / 4), actionValues[2], 0.01);
     }
 }

--- a/src/test/java/players/mcts/MultiTreeMCTSTests.java
+++ b/src/test/java/players/mcts/MultiTreeMCTSTests.java
@@ -179,7 +179,7 @@ public class MultiTreeMCTSTests {
         Game game = createTicTacToe(params, 4);
         TicTacToeGameState state = (TicTacToeGameState) game.getGameState();
 
-        AbstractAction actionChosen = game.getPlayers().get(state.getCurrentPlayer())
+        game.getPlayers().get(state.getCurrentPlayer())
                 ._getAction(state, fm.computeAvailableActions(state));
 
         TreeStatistics stats = new TreeStatistics(mctsPlayer.getRoot(0));


### PR DESCRIPTION
1) Added Max-backups for MCTS. This uses the new MCTSParameters setting of maxBackupThreshold. If the visits to a node, N, exceeds this value (the default is 1 million, so 'off') then the backup will weight the actual received reward (weight = threshold) and the expected value of the best action that *could* have been taken instead (weight = N - threshold). This only happens if the cation taken was not the bext expected action.
This should be helpful in games with a larger number of poor actions, as exploration of these will not cause us to be pessimistic further up the tree. (The risk instead is of careless optimism, so this is not universally helpful.)

2) Regret Matching and EXP3 selection rules now use the correct rule when picking the final action after search. For RM this uses a policy averaged over all MCTS iterations, and for EXP3 this uses the current selection policy with no exploration.

3) Hedge selection rule removed as it was causing too many numerical instability issues. (Use RegretMatching instead)

4) Fix for MAST being a CPU-hog unnecessarily with small MCTS budgets and MASTGamma=0.

5) A new NTBEA mode has been added in ParameterSearch. 'StableNTBEA'. The default NTBEA uses one game for each parameter test. StableNTBEA is suitable for games with a high level of impact from the random seed (e.g. Poker, Seven Wonders, Sushi Go). Instead of a single game it runs P games (where P is the number of player); each of these uses the same random seed and differs only in the position the parameterised agent plays in. This hugely reduces variance. (It will not help deterministic games...and will reduce the effective sample size for these by a factor of P.)