### PR TITLE
Alpha-Rank and other Tournament improvements

### DIFF
--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -21,7 +21,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 
 import static core.CoreConstants.GameResult.GAME_ONGOING;
-import static java.util.stream.Collectors.toList;
 
 /**
  * Contains all game state information.
@@ -161,6 +160,10 @@ public abstract class AbstractGameState {
         return gameType;
     }
 
+
+    protected void setHistoryAt(int index, Pair<Integer, AbstractAction> action) {
+        history.set(index, action);
+    }
     /**
      * @return All actions that have been executed on this state since reset()/initialisation
      */
@@ -178,7 +181,7 @@ public abstract class AbstractGameState {
      * In general getCurrentPlayer() should be used to find the current player.
      * getTurnOwner() will give a different answer if an Extended Action Sequence is in progress.
      * In this case getTurnOwner() returns the underlying player on whose turn the Action Sequence was initiated.
-     * @return
+     * @return the player whose turn it currently is (which may be different to the next player to act)
      */
     public int getTurnOwner() {return turnOwner;}
     public int getFirstPlayer() {return firstPlayer;}
@@ -212,7 +215,7 @@ public abstract class AbstractGameState {
      * Use this as a default; there is no need to create your own.
      * The one exception to this guideline is in the copy() method, where redeterminisation should *not* use this generator.
      * It should use redeterminisationRnd instead.
-     * @return
+     * @return the Random to use for game decisions/events
      */
     public Random getRnd() {
         return rnd;
@@ -462,7 +465,7 @@ public abstract class AbstractGameState {
     /**
      * This sets the number of tieBreak levels in a game.
      * If we reach this level then we stop recursing.
-     * @return
+     * @return the number of levels of tiebreaks in the game
      */
     public int getTiebreakLevels() {return 5;}
 
@@ -524,8 +527,7 @@ public abstract class AbstractGameState {
 
     private List<Integer> unknownComponents(IComponentContainer<?> container, int player) {
         ArrayList<Integer> retValue = new ArrayList<>();
-        if (container instanceof PartialObservableDeck<?>) {
-            PartialObservableDeck<?> pod = (PartialObservableDeck<?>) container;
+        if (container instanceof PartialObservableDeck<?> pod) {
             for (int i = 0; i < pod.getSize(); i++) {
                 if (!pod.getVisibilityForPlayer(i, player))
                     retValue.add(pod.get(i).getComponentID());
@@ -535,18 +537,18 @@ public abstract class AbstractGameState {
                 case VISIBLE_TO_ALL:
                     break;
                 case HIDDEN_TO_ALL:
-                    retValue.addAll(container.getComponents().stream().map(Component::getComponentID).collect(toList()));
+                    retValue.addAll(container.getComponents().stream().map(Component::getComponentID).toList());
                     break;
                 case VISIBLE_TO_OWNER:
                     if (((Component) container).getOwnerId() != player)
-                        retValue.addAll(container.getComponents().stream().map(Component::getComponentID).collect(toList()));
+                        retValue.addAll(container.getComponents().stream().map(Component::getComponentID).toList());
                     break;
-                case FIRST_VISIBLE_TO_ALL:
+                case TOP_VISIBLE_TO_ALL:
                     // add everything as unseen, and then remove the first element
-                    retValue.addAll(container.getComponents().stream().map(Component::getComponentID).collect(toList()));
+                    retValue.addAll(container.getComponents().stream().map(Component::getComponentID).toList());
                     retValue.remove(container.getComponents().get(0).getComponentID());
                     break;
-                case LAST_VISIBLE_TO_ALL:
+                case BOTTOM_VISIBLE_TO_ALL:
                     // add in the ID of the last item only
                     int length = container.getComponents().size();
                     retValue.add(container.getComponents().get(length - 1).getComponentID());
@@ -607,15 +609,12 @@ public abstract class AbstractGameState {
 
     /**
      * The equals method is final, but is left here so it is next to hashcode, which is not final
-     * @param o
-     * @return
      */
 
     @Override
     public final boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof AbstractGameState)) return false;
-        AbstractGameState gameState = (AbstractGameState) o;
+        if (!(o instanceof AbstractGameState gameState)) return false;
         return Objects.equals(gameParameters, gameState.gameParameters) &&
                 gameStatus == gameState.gameStatus &&
                 nPlayers == gameState.nPlayers && roundCounter == gameState.roundCounter &&
@@ -635,13 +634,11 @@ public abstract class AbstractGameState {
     /**
      * Override the hashCode as needed for individual game states
      * (It is OK for two java objects to be not equal and have the same hashcode)
-     *
      *         we deliberately exclude history and allComponents from the hashcode
      *         this is because history is deliberately erased at times to hide hidden information (and is read-only)
      *         and allComponents is not always populated (it is a convenience to get hold of all components in a game
      *         at the superclass level - the actually important components are instantiated in sub-classes, and should be
      *         included in the hashCode() method implemented there
-     * @return
      */
     @Override
     public int hashCode() {

--- a/src/main/java/core/CoreConstants.java
+++ b/src/main/java/core/CoreConstants.java
@@ -34,7 +34,7 @@ public class CoreConstants {
      * this should cover almost all future eventualities.
      */
     public enum VisibilityMode {
-        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, FIRST_VISIBLE_TO_ALL, LAST_VISIBLE_TO_ALL, MIXED_VISIBILITY
+        VISIBLE_TO_ALL, HIDDEN_TO_ALL, VISIBLE_TO_OWNER, TOP_VISIBLE_TO_ALL, BOTTOM_VISIBLE_TO_ALL, MIXED_VISIBILITY
     }
 
     // Default game phases: main, player reaction, end.

--- a/src/main/java/core/components/Deck.java
+++ b/src/main/java/core/components/Deck.java
@@ -2,6 +2,7 @@ package core.components;
 
 import core.CoreConstants;
 import core.interfaces.IComponentContainer;
+import org.jetbrains.annotations.NotNull;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -21,7 +22,7 @@ import static core.CoreConstants.VisibilityMode;
  * * components played on the player's area
  * * Discomponent pile
  */
-public class Deck<T extends Component> extends Component implements IComponentContainer<T> {
+public class Deck<T extends Component> extends Component implements IComponentContainer<T>, Iterable<T> {
 
     protected int capacity;  // Capacity of the deck (maximum number of elements)
     protected List<T> components;  // List of components in this deck
@@ -33,7 +34,7 @@ public class Deck<T extends Component> extends Component implements IComponentCo
 
     public Deck(String name, int ownerId, VisibilityMode visibility) {
         super(CoreConstants.ComponentType.DECK, name);
-        this.components = new ArrayList<>();
+        this.components = new LinkedList<>();   // we always add new components to element 0...so an ArrayList is inefficient
         this.ownerId = ownerId;
         this.capacity = -1;
         this.visibility = visibility;
@@ -41,11 +42,34 @@ public class Deck<T extends Component> extends Component implements IComponentCo
 
     protected Deck(String name, int ownerId, int ID, VisibilityMode visibility) {
         super(CoreConstants.ComponentType.DECK, name, ID);
-        this.components = new ArrayList<>();
+        this.components = new LinkedList<>();
         this.capacity = -1;
         this.ownerId = ownerId;
         this.visibility = visibility;
     }
+
+    @NotNull
+    @Override
+    public Iterator<T> iterator() {
+        return new DeckIterator();
+    }
+
+
+    // Iterator implementation
+    private class DeckIterator implements Iterator<T> {
+        private int currentIndex = 0;
+
+        @Override
+        public boolean hasNext() {
+            return currentIndex < getSize();
+        }
+
+        @Override
+        public T next() {
+            return components.get(currentIndex++);
+        }
+    }
+
 
     /**
      * Loads all decks of cards from a given JSON file.
@@ -117,7 +141,7 @@ public class Deck<T extends Component> extends Component implements IComponentCo
      * @return the component in position idx from the deck
      */
     public T pick(int idx) {
-        if (components.size() > 0 && idx < components.size() && idx >= 0) {
+        if (!components.isEmpty() && idx < components.size() && idx >= 0) {
             T c = components.get(idx);
             components.remove(idx);
             return c;
@@ -167,7 +191,7 @@ public class Deck<T extends Component> extends Component implements IComponentCo
      * @return The component peeked.
      */
     public T peek(int idx) {
-        if (components.size() > 0 && idx < components.size()) {
+        if (!components.isEmpty() && idx < components.size()) {
             return components.get(idx);
         }
         return null;
@@ -207,9 +231,9 @@ public class Deck<T extends Component> extends Component implements IComponentCo
      * @return true if within capacity, false otherwise.
      */
     public boolean addToBottom(T c) {
-        if (components.size() == 0)
+        if (components.isEmpty())
             return add(c, 0);
-        else return add(c, components.size() - 1);
+        else return add(c, components.size());
     }
 
     /**
@@ -340,7 +364,7 @@ public class Deck<T extends Component> extends Component implements IComponentCo
      *
      * @param components - new components for the deck, overrides old content.
      */
-    public void setComponents(ArrayList<T> components) {
+    public void setComponents(List<T> components) {
         this.components = components;
         for (T comp : components) {
             comp.setOwnerId(ownerId);
@@ -411,8 +435,9 @@ public class Deck<T extends Component> extends Component implements IComponentCo
         return dp;
     }
 
+    @SuppressWarnings("unchecked")
     protected void copyTo(Deck<T> deck) {
-        List<T> newComponents = new ArrayList<>();
+        List<T> newComponents = new LinkedList<>();
         for (T c : components) {
             newComponents.add((T) c.copy());
         }
@@ -424,8 +449,9 @@ public class Deck<T extends Component> extends Component implements IComponentCo
     }
 
 
+    @SuppressWarnings("unchecked")
     protected void copyTo(Deck<T> deck, int playerId) {
-        List<T> newComponents = new ArrayList<>();
+        List<T> newComponents = new LinkedList<>();
         for (T c : components) {
             newComponents.add((T) c.copy(playerId));
         }
@@ -444,7 +470,7 @@ public class Deck<T extends Component> extends Component implements IComponentCo
             sb.append(",");
         }
 
-        if (sb.length() > 0)
+        if (!sb.isEmpty())
             sb.deleteCharAt(sb.length() - 1);
         else
             sb.append("EmptyDeck");
@@ -455,9 +481,8 @@ public class Deck<T extends Component> extends Component implements IComponentCo
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof Deck)) return false;
+        if (!(o instanceof Deck<?> deck)) return false;
         if (!super.equals(o)) return false;
-        Deck<?> deck = (Deck<?>) o;
         return capacity == deck.capacity &&
                 Objects.equals(components, deck.components);
     }

--- a/src/main/java/core/components/PartialObservableDeck.java
+++ b/src/main/java/core/components/PartialObservableDeck.java
@@ -2,12 +2,11 @@ package core.components;
 
 import core.AbstractGameState;
 import core.CoreConstants.VisibilityMode;
+import org.jetbrains.annotations.NotNull;
+import utilities.DeterminisationUtilities;
 import utilities.Pair;
 
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.List;
-import java.util.Random;
+import java.util.*;
 
 public class PartialObservableDeck<T extends Component> extends Deck<T> {
 
@@ -16,7 +15,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
     protected boolean[] deckVisibility;
 
     // Visibility of each component in the deck, order corresponds to order of elements in the deck;
-    protected List<boolean[]> elementVisibility = new ArrayList<>();
+    protected List<boolean[]> elementVisibility = new LinkedList<>();
 
     public boolean getVisibilityForPlayer(int elementIdx, int playerID) {
         return elementVisibility.get(elementIdx)[playerID];
@@ -26,25 +25,27 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
         return elementVisibility.get(elementIdx);
     }
 
-    public PartialObservableDeck(String id, boolean[] defaultVisibility) {
-        this(id, -1, defaultVisibility);
-    }
 
     public PartialObservableDeck(String id, int ownerID, boolean[] defaultVisibility) {
         super(id, ownerID, VisibilityMode.MIXED_VISIBILITY);
         this.deckVisibility = defaultVisibility;
     }
 
-    public PartialObservableDeck(String id, int nPlayers) {
-        this(id, -1, new boolean[nPlayers]);
-    }
-
-    public PartialObservableDeck(String id, int ownerID, VisibilityMode visibilityMode) {
+    public PartialObservableDeck(String id, int ownerID, int nPlayers, VisibilityMode visibilityMode) {
         super(id, ownerID, visibilityMode);
-    }
-
-    public PartialObservableDeck(String id, int ownerID, int nPlayers) {
-        this(id, ownerID, new boolean[nPlayers]);
+        deckVisibility = new boolean[nPlayers];
+        switch (visibilityMode) {
+            case VISIBLE_TO_ALL:
+                for (int i = 0; i < nPlayers; i++)
+                    deckVisibility[i] = true;
+                break;
+            case VISIBLE_TO_OWNER:
+                deckVisibility[ownerID] = true;
+                break;
+            default:
+                // more complicated. Needs to be set elsewhere
+                break;
+        }
     }
 
     private PartialObservableDeck(String name, int ownerID, boolean[] defaultVisibility, int ID) {
@@ -54,17 +55,17 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
 
     /**
      * Retrieves the components in this deck visible by the given player.
-     *
+     * <p>
      * It always returns a List of the correct length, but with a NULL entry for hidden components
      *
      * @param playerID - ID of player observing the deck.
      * @return - ArrayList of components observed by the player.
      */
-    public ArrayList<T> getVisibleComponents(int playerID) {
+    public List<T> getVisibleComponents(int playerID) {
         if (playerID < 0 || playerID >= deckVisibility.length)
             throw new IllegalArgumentException("playerID " + playerID + " needs to be in range [0," + (deckVisibility.length - 1) + "]");
 
-        ArrayList<T> visibleComponents = new ArrayList<>(components.size());
+        List<T> visibleComponents = new ArrayList<>(components.size());
         for (int i = 0; i < components.size(); i++) {
             boolean[] b = elementVisibility.get(i);
             if (b[playerID])
@@ -88,6 +89,13 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
         return elementVisibility.get(idx)[playerID];
     }
 
+
+    @Override
+    public void setVisibility(VisibilityMode visibilityMode) {
+        super.setVisibility(visibilityMode);
+        applyVisibilityMode();
+    }
+
     /**
      * Sets the components in this deck with associated visibility for each player.
      *
@@ -96,22 +104,31 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
      *                            indicating which player can see the specific component (true if player can see it,
      *                            false otherwise).
      */
-    public void setComponents(ArrayList<T> components, ArrayList<boolean[]> visibilityPerPlayer) {
+    public void setComponents(List<T> components, List<boolean[]> visibilityPerPlayer) {
         super.setComponents(components);
         this.elementVisibility = visibilityPerPlayer;
     }
+
 
     /**
      * Sets the visibility for each component in the deck.
      *
      * @param visibility - new list of component visibility.
      */
-    public void setVisibility(ArrayList<boolean[]> visibility) {
+    public void setVisibility(List<boolean[]> visibility) {
         for (boolean[] b : visibility)
             if (b.length != this.deckVisibility.length)
                 throw new IllegalArgumentException("All entries of visibility need to have length " + deckVisibility.length +
                         " but at least one entry is of length " + b.length);
         this.elementVisibility = visibility;
+    }
+    private void applyVisibilityMode() {
+        if (getVisibilityMode() == VisibilityMode.TOP_VISIBLE_TO_ALL)
+            for (int j = 0; j < deckVisibility.length; j++)
+                elementVisibility.get(0)[j] = true;
+        if (getVisibilityMode() == VisibilityMode.BOTTOM_VISIBLE_TO_ALL)
+            for (int j = 0; j < deckVisibility.length; j++)
+                elementVisibility.get(components.size() - 1)[j] = true;
     }
 
     /**
@@ -126,9 +143,9 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
             if (playerID >= 0 && playerID < deckVisibility.length)
                 this.elementVisibility.get(index)[playerID] = visibility;
             else
-                throw new IllegalArgumentException("playerID " + playerID + "needs to be in range [0," + (deckVisibility.length-1) + "]");
+                throw new IllegalArgumentException("playerID " + playerID + "needs to be in range [0," + (deckVisibility.length - 1) + "]");
         } else {
-            throw new IllegalArgumentException("component index " + index + " needs to be in range [0," + (components.size()-1) + "]");
+            throw new IllegalArgumentException("component index " + index + " needs to be in range [0," + (components.size() - 1) + "]");
         }
     }
 
@@ -139,7 +156,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
      * @param visibility - true if player can see this component, false otherwise.
      */
     public void setVisibilityOfComponent(int index, boolean[] visibility) {
-        if (index >= 0 && index < elementVisibility.size()) {
+        if (index >= 0 && index < elementVisibility.size() && visibility.length == deckVisibility.length) {
             this.elementVisibility.set(index, visibility.clone());
         } else {
             throw new IllegalArgumentException("component index " + index + " needs to be in range [0," + components.size() + "]");
@@ -169,7 +186,9 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
      */
     public boolean add(T c, int index, boolean[] visibilityPerPlayer) {
         this.elementVisibility.add(index, visibilityPerPlayer.clone());
-        return super.add(c, index);
+        boolean retValue = super.add(c, index);
+        applyVisibilityMode();
+        return retValue;
     }
 
     /**
@@ -179,47 +198,38 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
      * @param index - the position in which the elements of d should be inserted in this deck.
      * @return true if not over capacity, false otherwise.
      */
+    @Override
     public boolean add(Deck<T> d, int index) {
-        for (int i = 0; i < d.components.size(); i++) {
-            this.elementVisibility.add(index, deckVisibility.clone());
+        if (d instanceof PartialObservableDeck<T> pod) {
+            int length = d.components.size();
+            for (int i = 0; i < length; i++) {
+                // Add in reverse order to keep the order of the deck
+                // this is to ties up with addAll() of components in super.add() a few lines down
+                this.elementVisibility.add(index, pod.elementVisibility.get(length - i - 1).clone());
+            }
+        } else {
+            for (int i = 0; i < d.components.size(); i++) {
+                this.elementVisibility.add(index, deckVisibility.clone());
+            }
         }
-        return super.add(d, index);
-    }
-
-    /**
-     * Adds a full other deck to this deck, ignoring capacity, and copies visibility as well.
-     *
-     * @param d - other deck to add to this deck.
-     * @return true if not over capacity, false otherwise.
-     */
-    public boolean add(PartialObservableDeck<T> d) {
-        if (d == null)
-            throw new IllegalArgumentException("d cannot be null");
-        elementVisibility.addAll(d.elementVisibility);
-        for (int i = 0; i < deckVisibility.length; i++) {
-            deckVisibility[i] &= d.deckVisibility[i];
-        }
-        return super.add(d);
+        boolean retValue = super.add(d, index);
+        applyVisibilityMode();
+        return retValue;
     }
 
     @Override
     public boolean add(Deck<T> d) {
-        if (d == null)
-            throw new IllegalArgumentException("d cannot be null");
-        for (int i = 0; i < d.getSize(); i++) {
-            elementVisibility.add(deckVisibility.clone());
-        }
-        return super.add(d);
+        return add(d, 0);
     }
 
     @Override
-    public void setComponents(ArrayList<T> components) {
+    public void setComponents(List<T> components) {
         super.setComponents(components);
-
         elementVisibility.clear();
         for (int i = 0; i < components.size(); i++) {
             elementVisibility.add(deckVisibility.clone());
         }
+        applyVisibilityMode();
     }
 
     @Override
@@ -239,9 +249,9 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
 
     @Override
     public boolean addToBottom(T c) {
-        if(components.size() == 0)
+        if (components.isEmpty())
             return add(c, 0, deckVisibility);
-        else return add(c, components.size() -1, deckVisibility);
+        return add(c, components.size(), deckVisibility);
     }
 
     @Override
@@ -264,21 +274,29 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
         elementVisibility.clear();
     }
 
+    /**
+     * Shuffles the deck, and updates the visibility of the components accordingly.
+     * After a shuffle players will no longer know the position of the cards they could see before the shuffle
+     * (this resets the visibility of all components to the default deck visibility).
+     * @param rnd
+     */
     @Override
     public void shuffle(Random rnd) {
-        Pair<List<T>, List<boolean[]>> shuffled = shuffleLists(components, elementVisibility, rnd);
-        components = shuffled.a;
-        elementVisibility = shuffled.b;
+        elementVisibility.replaceAll(ignored -> deckVisibility.clone());
+        super.shuffle(rnd);
+        applyVisibilityMode();
     }
 
     /**
-     * Shuffles a deck in its entirety, and resets the visibility of all components to the default visibility of the deck.
+     * Shuffles a deck in its entirety, but players can see any card that they could see before the shuffle (in the new position)
+     *
      * @param rnd random number generator to be used in shuffling.
      */
-    public void shuffleAndResetVisibility(Random rnd)
-    {
-        shuffle(rnd);
-        elementVisibility.replaceAll(ignored -> deckVisibility.clone());
+    public void shuffleAndKeepVisibility(Random rnd) {
+        Pair<List<T>, List<boolean[]>> shuffled = shuffleLists(components, elementVisibility, rnd);
+        components = shuffled.a;
+        elementVisibility = shuffled.b;
+        applyVisibilityMode();
     }
 
 
@@ -291,10 +309,10 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
      * @return - both lists shuffled, keeping the mapping from component to visibility at the same index.
      */
     private Pair<List<T>, List<boolean[]>> shuffleLists(List<T> comps, List<boolean[]> vis, Random rnd) {
-        List<T> tmp_components = new ArrayList<>();
-        List<boolean[]> tmp_visibility = new ArrayList<>();
+        List<T> tmp_components = new LinkedList<>();
+        List<boolean[]> tmp_visibility = new LinkedList<>();
 
-        List<Integer> indexList = new ArrayList<>();
+        List<Integer> indexList = new ArrayList<>(comps.size());
         for (int i = 0; i < comps.size(); i++)
             indexList.add(i);
         Collections.shuffle(indexList, rnd);
@@ -305,7 +323,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
             tmp_visibility.add(targetIndex, vis.get(sourceIndex));
         }
 
-        return new Pair(tmp_components, tmp_visibility);
+        return new Pair<>(tmp_components, tmp_visibility);
     }
 
     /**
@@ -313,36 +331,9 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
      *
      * @param rnd      - random object to use for shuffling.
      * @param playerId - player observing the deck.
-     * @param visible  - if true, shuffles only visible cards; otherwise, shuffles only hidden cards.
      */
-    public void shuffleVisible(Random rnd, int playerId, boolean visible) {
-        ArrayList<T> visibleComponents = new ArrayList<>();
-        ArrayList<boolean[]> visibility = new ArrayList<>();
-        for (int i = 0; i < components.size(); i++) {
-            boolean[] b = elementVisibility.get(i);
-            if (b[playerId] == visible) {
-                visibleComponents.add(components.get(i));
-                visibility.add(b);
-            }
-        }
-        Pair<List<T>, List<boolean[]>> shuffled = shuffleLists(visibleComponents, visibility, rnd);
-
-        int n = 0;
-        for (int i = 0; i < components.size(); i++) {
-            boolean[] b = elementVisibility.get(i);
-            if (b[playerId] == visible) {
-                // Draw element from shuffled lists
-                components.set(i, shuffled.a.get(n));
-                /*
-                if other players can see a card, we know which card position they can see, but
-                not the actual card (otherwise, it would by definition be visible to us). Therefore
-                we do *not* shuffle element visibility, and keep this in the same order
-                */
-                if (visible)
-                    elementVisibility.set(i, shuffled.b.get(n));
-                n++;
-            }
-        }
+    public void redeterminiseUnknown(Random rnd, int playerId) {
+        DeterminisationUtilities.reshuffle(playerId, List.of(this), c -> true, rnd);
     }
 
     public boolean[] getDeckVisibility() {
@@ -354,21 +345,18 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
         PartialObservableDeck<T> dp = new PartialObservableDeck<>(componentName, ownerId, deckVisibility, componentID);
         this.copyTo(dp); // Copy super
 
-        dp.deckVisibility = deckVisibility.clone();
-
-        ArrayList<boolean[]> newVisibility = new ArrayList<>();
-        for (boolean[] visibility : elementVisibility) {
-            newVisibility.add(visibility.clone());
-        }
-        dp.elementVisibility = newVisibility;
-
-        return dp;
+        return commonCopy(dp);
     }
 
     public PartialObservableDeck<T> copy(int playerId) {
         PartialObservableDeck<T> dp = new PartialObservableDeck<>(componentName, ownerId, deckVisibility, componentID);
         this.copyTo(dp, playerId); // Copy super
 
+        return commonCopy(dp);
+    }
+
+    @NotNull
+    private PartialObservableDeck<T> commonCopy(PartialObservableDeck<T> dp) {
         dp.deckVisibility = deckVisibility.clone();
 
         ArrayList<boolean[]> newVisibility = new ArrayList<>();
@@ -390,7 +378,7 @@ public class PartialObservableDeck<T extends Component> extends Deck<T> {
             sb.append(",");
         }
 
-        if (sb.length() > 0)
+        if (!sb.isEmpty())
             sb.deleteCharAt(sb.length() - 1);
         else
             sb.append("EmptyDeck");

--- a/src/main/java/core/interfaces/ITunableParameters.java
+++ b/src/main/java/core/interfaces/ITunableParameters.java
@@ -60,8 +60,26 @@ public interface ITunableParameters {
 
     /**
      * @return A JSONString of these Tunable Parameters
+     * This is required for interfacing with the NTBEA library
+     * It is a representation of the parameter space (use instanceToJSON() for a representation of the current settings)
      */
     String getJSONDescription();
+
+    /**
+     * @return a TunableParameters object instantiated from JSON
+     * This only supports specific settings, and not the full range of possible settings
+     * (For that use a SearchSpace)
+     * @param jsonObject
+     */
+    ITunableParameters instanceFromJSON(JSONObject jsonObject);
+
+    /**
+     *
+     * @return a JSON representation of the current parameter settings
+     * This is designed to be used for saving the current settings to a file for later instantiation
+     * with fromJSON
+     */
+    JSONObject instanceToJSON(boolean excludeDefaultValues);
 
     /**
      * Retrieves the default values of all parameters (as per original game).

--- a/src/main/java/evaluation/ForwardModelTester.java
+++ b/src/main/java/evaluation/ForwardModelTester.java
@@ -36,6 +36,10 @@ public class ForwardModelTester {
     }
 
     public ForwardModelTester(String... args) {
+        this(null, args);
+    }
+
+    public ForwardModelTester(AbstractParameters params, String... args) {
         String agentToPlay = Utils.getArg(args, "agent", "random");
         int numberOfGames = Utils.getArg(args, "nGames", 1);
         String gameToRun = Utils.getArg(args, "game", "TicTacToe");
@@ -43,7 +47,7 @@ public class ForwardModelTester {
         boolean verbose = Arrays.asList(args).contains("verbose");
         GameType gt = GameType.valueOf(gameToRun);
         long seed = Utils.getArg(args, "seed", System.currentTimeMillis());
-        Game game = gt.createGameInstance(nPlayers, seed);
+        Game game = params == null ? gt.createGameInstance(nPlayers, seed) : gt.createGameInstance(nPlayers, params);
         List<AbstractPlayer> allPlayers = new ArrayList<>();
         AbstractPlayer agent = PlayerFactory.createPlayer(agentToPlay);
         for (int i = 0; i < nPlayers; i++)

--- a/src/main/java/evaluation/RunGames.java
+++ b/src/main/java/evaluation/RunGames.java
@@ -58,10 +58,10 @@ public class RunGames implements IGameRunner {
 
         /* 1. Settings for the tournament */
         RunGames runGames = new RunGames();
-        runGames.config = parseConfig(args, Usage.RunGames);
+        runGames.config = parseConfig(args, Collections.singletonList(Usage.RunGames));
 
         String setupFile = runGames.config.getOrDefault(RunArg.config, "").toString();
-        if (!setupFile.equals("")) {
+        if (!setupFile.isEmpty()) {
             // Read from file instead
             try {
                 FileReader reader = new FileReader(setupFile);

--- a/src/main/java/evaluation/optimisation/GameEvaluator.java
+++ b/src/main/java/evaluation/optimisation/GameEvaluator.java
@@ -10,6 +10,7 @@ import evaluation.listeners.IGameListener;
 import evodef.SearchSpace;
 import evodef.SolutionEvaluator;
 import games.GameType;
+import players.IAnyTimePlayer;
 
 import java.util.*;
 import java.util.stream.IntStream;
@@ -156,6 +157,12 @@ public class GameEvaluator implements SolutionEvaluator {
             } else {
                 AbstractPlayer tunedPlayer = (AbstractPlayer) searchSpace.getAgent(settings); // we create for each, in case this is coop
                 allPlayers.add(tunedPlayer);
+            }
+        }
+        if (params.budget > 0) {
+            for (AbstractPlayer player : allPlayers) {
+                if (player instanceof IAnyTimePlayer anyTime)
+                    anyTime.setBudget(params.budget);
             }
         }
         return allPlayers;

--- a/src/main/java/evaluation/optimisation/ITPSearchSpace.java
+++ b/src/main/java/evaluation/optimisation/ITPSearchSpace.java
@@ -2,6 +2,7 @@ package evaluation.optimisation;
 
 import core.interfaces.ITunableParameters;
 import evodef.AgentSearchSpace;
+import org.jetbrains.annotations.NotNull;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -69,6 +70,9 @@ public class ITPSearchSpace extends AgentSearchSpace<Object> {
         super(convertToSuperFormatJSON(json, tunableParameters),
                 allParameterTypesWithRecursion(json, tunableParameters));
         initialiseITP(tunableParameters);
+        if (tunableParameters instanceof TunableParameters tp) {
+            tp.setRawJSON(json);
+        }
     }
 
     @SuppressWarnings("unchecked")
@@ -186,15 +190,24 @@ public class ITPSearchSpace extends AgentSearchSpace<Object> {
         return getSearchKeys().indexOf(parameter);
     }
 
-    public Object getAgent(int[] settings) {
+    public Object getAgent(@NotNull int[] settings) {
         // we first need to update itp with the specified parameters, and then instantiate
+        setTo(settings);
+        return itp.instantiate();
+    }
+    public JSONObject getAgentJSON(int[] settings) {
+        // we first need to update itp with the specified parameters, and then instantiate
+        setTo(settings);
+        return itp.instanceToJSON(true);
+    }
+
+    private void setTo(int[] settings) {
         for (int i = 0; i < settings.length; i++) {
             String pName = tunedIndexToParameterName.get(i);
             Object value = value(i, settings[i]);
             //   Object value = itp.getPossibleValues(pName).get(settings[i]);
             itp.setParameterValue(pName, value);
         }
-        return itp.instantiate();
     }
 
 }

--- a/src/main/java/evaluation/optimisation/NTBEA.java
+++ b/src/main/java/evaluation/optimisation/NTBEA.java
@@ -12,6 +12,7 @@ import org.apache.commons.math3.util.CombinatoricsUtils;
 import games.GameType;
 import ntbea.NTupleBanditEA;
 import ntbea.NTupleSystem;
+import players.IAnyTimePlayer;
 import players.PlayerFactory;
 import players.heuristics.OrdinalPosition;
 import players.heuristics.PureScoreHeuristic;
@@ -65,6 +66,13 @@ public class NTBEA {
         // if we are in coop mode, then we have no opponents. This is indicated by leaving the list empty.
         List<AbstractPlayer> opponents = params.mode == NTBEAParameters.Mode.CoopNTBEA ? new ArrayList<>()
                 : PlayerFactory.createPlayers(params.opponentDescriptor);
+        if (params.budget > 0) {
+            for (AbstractPlayer opponent : opponents) {
+                if (opponent instanceof IAnyTimePlayer anyTimePlayer) {
+                    anyTimePlayer.setBudget(params.budget);
+                }
+            }
+        }
 
         if (params.tuningGame) {
             if (new File(params.evalMethod).exists()) {

--- a/src/main/java/evaluation/optimisation/NTBEA.java
+++ b/src/main/java/evaluation/optimisation/NTBEA.java
@@ -81,7 +81,6 @@ public class NTBEA {
                 } catch (NoSuchMethodException e) {
                     throw new AssertionError("evaluation.heuristics." + params.evalMethod + " has no no-arg constructor");
                 } catch (ReflectiveOperationException e) {
-                    e.printStackTrace();
                     throw new AssertionError("evaluation.heuristics." + params.evalMethod + " reflection error");
                 }
             }
@@ -118,6 +117,14 @@ public class NTBEA {
         elites.add(settings);
     }
 
+    public void writeAgentJSON(int[] settings, String fileName) {
+        try(FileWriter writer = new FileWriter(fileName)) {
+            writer.write(JSONUtils.prettyPrint(params.searchSpace.getAgentJSON(settings), 1));
+        } catch (IOException e) {
+            throw new AssertionError("Error writing agent settings to file " + fileName);
+        }
+    }
+
     /**
      * This returns the optimised object, plus the settings that produced it (indices to the values in the search space)
      *
@@ -127,6 +134,8 @@ public class NTBEA {
 
         for (currentIteration = 0; currentIteration < params.repeats; currentIteration++) {
             runIteration();
+            writeAgentJSON(winnerSettings.get(winnerSettings.size() - 1),
+                    params.destDir + File.separator + "Recommended_" + currentIteration + ".json");
         }
 
         // After all runs are complete, if tournamentGames are specified, then we allow all the
@@ -211,6 +220,8 @@ public class NTBEA {
             // we don't log the final run to file to avoid duplication
             printDetailsOfRun(bestResult);
         }
+        writeAgentJSON(bestResult.b,
+                params.destDir + File.separator + "Recommended_Final.json");
         return new Pair<>(params.searchSpace.getAgent(bestResult.b), bestResult.b);
     }
 

--- a/src/main/java/evaluation/optimisation/NTBEA.java
+++ b/src/main/java/evaluation/optimisation/NTBEA.java
@@ -67,13 +67,6 @@ public class NTBEA {
         // if we are in coop mode, then we have no opponents. This is indicated by leaving the list empty.
         List<AbstractPlayer> opponents = params.mode == NTBEAParameters.Mode.CoopNTBEA ? new ArrayList<>()
                 : PlayerFactory.createPlayers(params.opponentDescriptor);
-        if (params.budget > 0) {
-            for (AbstractPlayer opponent : opponents) {
-                if (opponent instanceof IAnyTimePlayer anyTimePlayer) {
-                    anyTimePlayer.setBudget(params.budget);
-                }
-            }
-        }
 
         if (params.tuningGame) {
             if (new File(params.evalMethod).exists()) {

--- a/src/main/java/evaluation/optimisation/NTBEA.java
+++ b/src/main/java/evaluation/optimisation/NTBEA.java
@@ -12,6 +12,7 @@ import org.apache.commons.math3.util.CombinatoricsUtils;
 import games.GameType;
 import ntbea.NTupleBanditEA;
 import ntbea.NTupleSystem;
+import org.json.simple.JSONObject;
 import players.IAnyTimePlayer;
 import players.PlayerFactory;
 import players.heuristics.OrdinalPosition;
@@ -125,9 +126,12 @@ public class NTBEA {
         elites.add(settings);
     }
 
+    @SuppressWarnings("unchecked")
     public void writeAgentJSON(int[] settings, String fileName) {
         try(FileWriter writer = new FileWriter(fileName)) {
-            writer.write(JSONUtils.prettyPrint(params.searchSpace.getAgentJSON(settings), 1));
+            JSONObject json = params.searchSpace.getAgentJSON(settings);
+            json.put("budget", params.budget);
+            writer.write(JSONUtils.prettyPrint(json, 1));
         } catch (IOException e) {
             throw new AssertionError("Error writing agent settings to file " + fileName);
         }
@@ -181,6 +185,7 @@ public class NTBEA {
                 config.put(matchups, gamesPerMatchup);
                 config.put(byTeam, false);
                 config.put(RunArg.distinctRandomSeeds, 0);
+                config.put(RunArg.budget, params.budget);
                 RoundRobinTournament tournament = new RoundRobinTournament(players, game, nPlayers, params.gameParams,
                         NO_SELF_PLAY, config);
                 tournament.verbose = false;

--- a/src/main/java/evaluation/optimisation/NTBEAParameters.java
+++ b/src/main/java/evaluation/optimisation/NTBEAParameters.java
@@ -14,10 +14,8 @@ import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.IntStream;
 
-import static evaluation.RunArg.gameParams;
 import static java.util.stream.Collectors.joining;
 import static utilities.JSONUtils.parser;
-import static utilities.Utils.*;
 
 public class NTBEAParameters {
 

--- a/src/main/java/evaluation/optimisation/NTBEAParameters.java
+++ b/src/main/java/evaluation/optimisation/NTBEAParameters.java
@@ -28,6 +28,7 @@ public class NTBEAParameters {
     public boolean tuningGame;
     public int iterationsPerRun;
     public int repeats;
+    public int budget;
     public int evalGames;
     public double kExplore;
     public int tournamentGames;
@@ -59,6 +60,7 @@ public class NTBEAParameters {
         kExplore = (double) args.get(RunArg.kExplore);
         neighbourhoodSize = (int) args.get(RunArg.neighbourhood);
         opponentDescriptor = (String) args.get(RunArg.opponent);
+        budget = (int) args.get(RunArg.budget);
         evalMethod = (String) args.get(RunArg.evalMethod);
         useThreeTuples = (boolean) args.get(RunArg.useThreeTuples);
         verbose = (boolean) args.get(RunArg.verbose);

--- a/src/main/java/evaluation/optimisation/ParameterSearch.java
+++ b/src/main/java/evaluation/optimisation/ParameterSearch.java
@@ -57,7 +57,7 @@ public class ParameterSearch {
             return;
         }
         String searchSpaceFile = config.get(RunArg.searchSpace).toString();
-        if (searchSpaceFile.equals("")) {
+        if (searchSpaceFile.isEmpty()) {
             System.out.println("No search space file provided. Please provide a search space file.");
             return;
         }

--- a/src/main/java/evaluation/optimisation/ParameterSearch.java
+++ b/src/main/java/evaluation/optimisation/ParameterSearch.java
@@ -25,7 +25,7 @@ public class ParameterSearch {
         }
 
         // Config
-        Map<RunArg, Object> config = parseConfig(args, RunArg.Usage.ParameterSearch);
+        Map<RunArg, Object> config = parseConfig(args, Collections.singletonList(RunArg.Usage.ParameterSearch));
 
         String setupFile = config.getOrDefault(RunArg.config, "").toString();
         if (!setupFile.isEmpty()) {

--- a/src/main/java/evaluation/optimisation/TunableParameters.java
+++ b/src/main/java/evaluation/optimisation/TunableParameters.java
@@ -381,6 +381,36 @@ public abstract class TunableParameters extends AbstractParameters implements IT
         return retValue.toJSONString();
     }
 
+    @Override
+    public JSONObject instanceToJSON(boolean excludeDefaults) {
+        // this is very similar to getJSONDescription(), but only
+        // considers the current Parameter settings
+        // we will recurse over nested ITunableParameters (but do not jump over intervening non-Tunable objects)
+        JSONObject retValue = new JSONObject();
+        retValue.put("class", this.getClass().getName());
+        for (String name : parameterNames) {
+            Object value = getParameterValue(name);
+            if (value != null) {
+                // check for defaults
+                if (excludeDefaults && value.equals(getDefaultParameterValue(name))) {
+                    continue;
+                }
+                if (value instanceof ITunableParameters tp) {
+                    value = tp.instanceToJSON(excludeDefaults);
+                } else if (value instanceof Enum) {
+                    value = value.toString();
+                }
+                retValue.put(name, value);
+            }
+        }
+        return retValue;
+    }
+
+    @Override
+    public ITunableParameters instanceFromJSON(JSONObject jsonObject) {
+        return JSONUtils.loadClassFromJSON(jsonObject);
+    }
+
     /**
      * Retrieve the values of all parameters.
      *

--- a/src/main/java/evaluation/optimisation/TunableParameters.java
+++ b/src/main/java/evaluation/optimisation/TunableParameters.java
@@ -418,6 +418,8 @@ public abstract class TunableParameters extends AbstractParameters implements IT
                         value instanceof Boolean)) {
                     // in this case we need to extract from the original rawJSON
                     if (rawJSON == null) {
+                        if (getDefaultParameterValue(name).equals(value))
+                            continue; // in this case we have the default, so no need to pull in
                         throw new AssertionError("No rawJSON available to extract value for " + name);
                     }
                     value = rawJSON.get(name);

--- a/src/main/java/evaluation/tournaments/AbstractTournament.java
+++ b/src/main/java/evaluation/tournaments/AbstractTournament.java
@@ -5,6 +5,8 @@ import core.AbstractPlayer;
 import core.Game;
 import core.interfaces.IGameRunner;
 import games.GameType;
+import players.IAnyTimePlayer;
+
 import java.util.List;
 
 public abstract class AbstractTournament implements IGameRunner {

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -7,6 +7,7 @@ import evaluation.listeners.IGameListener;
 import evaluation.listeners.TournamentMetricsGameListener;
 import evaluation.tournaments.AbstractTournament.TournamentMode;
 import games.GameType;
+import players.IAnyTimePlayer;
 import utilities.LinearRegression;
 import utilities.Pair;
 
@@ -37,6 +38,7 @@ public class RoundRobinTournament extends AbstractTournament {
     protected LinkedHashMap<Integer, Pair<Double, Double>> finalOrdinalRanking; // contains index of agent in agents
     LinkedList<Integer> allAgentIds;
     private int totalGamesRun;
+    private int budget;
     protected boolean randomGameParams;
     public String name;
     public boolean byTeam;
@@ -71,6 +73,12 @@ public class RoundRobinTournament extends AbstractTournament {
 
         this.gamesPerMatchUp = (int) config.getOrDefault(RunArg.matchups, 100);
         this.tournamentMode = tournamentMode;
+        this.budget = (int) config.get(RunArg.budget);
+        for (AbstractPlayer player : agents) {
+            if (player instanceof IAnyTimePlayer) {
+                ((IAnyTimePlayer) player).setBudget(this.budget);
+            }
+        }
         this.pointsPerPlayer = new double[agents.size()];
         this.pointsPerPlayerSquared = new double[agents.size()];
         this.winsPerPlayer = new double[agents.size()];
@@ -123,7 +131,7 @@ public class RoundRobinTournament extends AbstractTournament {
             if (tournamentSeeds > 0) {
                 // use the same seed for each game in the tournament
                 // allSeeds contains the ones loaded from file - if empty then use a random one
-                int nextRnd =  allSeeds.isEmpty() ? seedRnd.nextInt() : allSeeds.get(iter);
+                int nextRnd = allSeeds.isEmpty() ? seedRnd.nextInt() : allSeeds.get(iter);
                 gameSeeds = IntStream.range(0, gamesPerMatchUp).mapToObj(i -> nextRnd).collect(toList());
             } else {
                 // use a seed per matchup
@@ -147,7 +155,6 @@ public class RoundRobinTournament extends AbstractTournament {
             }
             return new ArrayList<>(seeds);
         } catch (Exception e) {
-            e.printStackTrace();
             throw new IllegalArgumentException("Could not load seeds from file " + seedFile);
         }
 

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -542,7 +542,7 @@ public class RoundRobinTournament extends AbstractTournament {
             }
             for (int i = 0; i < agents.size(); i++) {
                 for (int j = i; j < agents.size(); j++) {
-                    if (i != j && B.getEntry(i, j) > 0.7) {
+                    if (i != j && B.getEntry(i, j) > 0.5) { // a somewhat arbitrary threshold
                         str = String.format("\tAgents %s and %s have similar profiles\n", agents.get(i), agents.get(j));
                         dataDump.add(str);
                         if (verbose) System.out.print(str);

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -640,29 +640,31 @@ public class RoundRobinTournament extends AbstractTournament {
             }
 
             // print the cluster membership
-            String str = "The following agents cluster together, and may be considered equivalent: ";
-            dataDump.add(str + "\n");
-            if (verbose) System.out.println(str);
-            for (int i = 0; i < agents.size(); i++) {
-                // get all agents in this cluster
-                boolean clusterExists = false;
-                for (int j = 0; j < agents.size(); j++) {
-                    if (clusterMembership[j] != null && clusterMembership[j].equals(agents.get(i).toString())) {
-                        if (!clusterExists) {
-                            str = String.format("\tCluster for %s%n", agents.get(i));
+            if (alphaRankDetails && Arrays.stream(clusterMembership).anyMatch(Objects::nonNull)) {
+
+                String str = "The following agents cluster together, and may be considered equivalent: ";
+                dataDump.add(str + "\n");
+                if (verbose) System.out.println(str);
+                for (int i = 0; i < agents.size(); i++) {
+                    // get all agents in this cluster
+                    boolean clusterExists = false;
+                    for (int j = 0; j < agents.size(); j++) {
+                        if (clusterMembership[j] != null && clusterMembership[j].equals(agents.get(i).toString())) {
+                            if (!clusterExists) {
+                                str = String.format("\tCluster for %s%n", agents.get(i));
+                                dataDump.add(str);
+                                if (verbose) System.out.print(str);
+                            }
+                            clusterExists = true;
+                            str = String.format("\t\t%s%n", agents.get(j));
                             dataDump.add(str);
                             if (verbose) System.out.print(str);
                         }
-                        clusterExists = true;
-                        str = String.format("\t\t%s%n", agents.get(j));
-                        dataDump.add(str);
-                        if (verbose) System.out.print(str);
                     }
                 }
+                dataDump.add("\n");
+                if (verbose) System.out.println();
             }
-
-            dataDump.add("\n");
-            if (verbose) System.out.println();
         }
         return retValue;
     }

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -381,7 +381,7 @@ public class RoundRobinTournament extends AbstractTournament {
             double stdDev = Math.sqrt(pointsPerPlayerSquared[i] / nGamesPlayed[i] - (pointsPerPlayer[i] / nGamesPlayed[i])
                     * (pointsPerPlayer[i] / nGamesPlayed[i]));
             finalWinRanking.put(i, new Pair<>(pointsPerPlayer[i] / nGamesPlayed[i], stdDev / sqrt(nGamesPlayed[i])));
-            stdDev = rankPerPlayerSquared[i] / nGamesPlayed[i] - (rankPerPlayer[i] / nGamesPlayed[i]) * (rankPerPlayer[i] / nGamesPlayed[i]);
+            stdDev = Math.sqrt(rankPerPlayerSquared[i] / nGamesPlayed[i] - (rankPerPlayer[i] / nGamesPlayed[i]) * (rankPerPlayer[i] / nGamesPlayed[i]));
             finalOrdinalRanking.put(i, new Pair<>(rankPerPlayer[i] / nGamesPlayed[i], stdDev / sqrt(nGamesPlayed[i])));
         }
         // Sort by points.

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -42,7 +42,7 @@ public class RoundRobinTournament extends AbstractTournament {
     public boolean byTeam;
 
     protected long randomSeed = System.currentTimeMillis();
-    List<Integer> gameSeeds = new ArrayList();
+    List<Integer> gameSeeds = new ArrayList<>();
     int tournamentSeeds;
     String seedFile;
     Random seedRnd = new Random(randomSeed);

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -604,7 +604,7 @@ public class RoundRobinTournament extends AbstractTournament {
             }
 
             // Now we cluster based on the bibliometrically symmetrised matrix B
-            double thresholdForCluster = 0.2 * sqrt(agents.size());
+            double thresholdForCluster = 0.15 * sqrt(agents.size());
             String[] clusterMembership = new String[agents.size()];
             for (int i = 0; i < agents.size(); i++) {
                 for (int j = i; j < agents.size(); j++) {

--- a/src/main/java/evaluation/tournaments/SkillLadder.java
+++ b/src/main/java/evaluation/tournaments/SkillLadder.java
@@ -146,7 +146,10 @@ public class SkillLadder {
 
                 Pair<Object, int[]> results = ntbea.run();
                 allAgents.add((AbstractPlayer) results.a);
-                currentBestSettings = results.b;
+                if (!Arrays.equals(results.b, currentBestSettings)) {
+                    currentBestSettings = results.b;
+                    ntbea.writeAgentJSON(currentBestSettings, destDir + File.separator + "NTBEA_Budget_" + newBudget + ".json");
+                }
             } else {
                 allAgents.add(PlayerFactory.createPlayer(player, s -> s.replaceAll("-999", String.valueOf(newBudget))));
             }

--- a/src/main/java/evaluation/tournaments/SkillLadder.java
+++ b/src/main/java/evaluation/tournaments/SkillLadder.java
@@ -92,6 +92,7 @@ public class SkillLadder {
         }
         firstAgent.setName("Budget " + startingTimeBudget);
         allAgents.add(firstAgent);
+        int matchups = (int) config.get(RunArg.matchups);
 
         for (int i = 0; i < iterations; i++) {
             int newBudget = (int) (Math.pow(timeBudgetMultiplier, i + 1) * startingTimeBudget);
@@ -120,6 +121,8 @@ public class SkillLadder {
             allAgents.get(i + 1).setName("Budget " + newBudget);
             if (newBudget < startGridBudget) // we fast forward to where we want to start the grid
                 continue;
+            if (matchups == 0)
+                continue; // we are just using this for progressive NTBEA tuning
             // for each iteration we run a round robin tournament; either against just the previous agent (with the previous budget), or
             // if we have grid set to true, then against all previous agents, one after the other
             boolean runAgainstAllAgents = (boolean) config.get(RunArg.grid);
@@ -130,7 +133,7 @@ public class SkillLadder {
                     continue;
                 List<AbstractPlayer> agents = Arrays.asList(allAgents.get(i + 1), allAgents.get(agentIndex));
                 Map<RunArg, Object> finalConfig = new HashMap<>();
-                finalConfig.put(RunArg.matchups, config.get(RunArg.matchups));
+                finalConfig.put(RunArg.matchups, matchups);
                 finalConfig.put(RunArg.byTeam, false);
                 finalConfig.put(RunArg.budget, newBudget);
                 RoundRobinTournament RRT = new RoundRobinTournament(agents, gameType, nPlayers, params, ONE_VS_ALL, finalConfig);

--- a/src/main/java/games/GameType.java
+++ b/src/main/java/games/GameType.java
@@ -306,6 +306,7 @@ public enum GameType {
                 return (AbstractParameters) constructorGS.newInstance(seed);
             }
         } catch (InstantiationException | IllegalAccessException | InvocationTargetException e) {
+            e.printStackTrace();
             throw new RuntimeException(e);
         }
     }

--- a/src/main/java/games/catan/CatanActionFactory.java
+++ b/src/main/java/games/catan/CatanActionFactory.java
@@ -112,7 +112,7 @@ public class CatanActionFactory {
      */
     public static List<AbstractAction> getPlayerTradeOfferActions(CatanGameState gs, ActionSpace actionSpace, int playerID, OfferPlayerTrade tradeOffer) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        HashMap<CatanParameters.Resource, Counter> resources = gs.getPlayerResources(playerID);
+        Map<CatanParameters.Resource, Counter> resources = gs.getPlayerResources(playerID);
         int n_players = gs.getNPlayers();
         if (tradeOffer == null) {
             // Construct new offer
@@ -499,7 +499,7 @@ public class CatanActionFactory {
      */
     public static List<AbstractAction> getDefaultTradeActions(CatanGameState gs, ActionSpace actionSpace, int player) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        HashMap<CatanParameters.Resource, Counter> playerExchangeRate = gs.getExchangeRates(player);
+        Map<CatanParameters.Resource, Counter> playerExchangeRate = gs.getExchangeRates(player);
         for (Map.Entry<CatanParameters.Resource, Counter> res: gs.playerResources.get(player).entrySet()) {
             if (res.getKey() == CatanParameters.Resource.WILD) continue;
 

--- a/src/main/java/games/catan/CatanActionFactory.java
+++ b/src/main/java/games/catan/CatanActionFactory.java
@@ -81,6 +81,11 @@ public class CatanActionFactory {
         OfferPlayerTrade opt = (OfferPlayerTrade) gs.tradeOffer;
 
         if (opt != null) {
+
+            if (opt.offeringPlayerID == player) {
+                throw new AssertionError("Player cannot trade with themselves");
+            }
+
             // Reject the trade offer
             actions.add(new EndNegotiation(player, opt.offeringPlayerID));
 

--- a/src/main/java/games/catan/CatanActionFactory.java
+++ b/src/main/java/games/catan/CatanActionFactory.java
@@ -117,7 +117,7 @@ public class CatanActionFactory {
      */
     public static List<AbstractAction> getPlayerTradeOfferActions(CatanGameState gs, ActionSpace actionSpace, int playerID, OfferPlayerTrade tradeOffer) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        HashMap<CatanParameters.Resource, Counter> resources = gs.getPlayerResources(playerID);
+        Map<CatanParameters.Resource, Counter> resources = gs.getPlayerResources(playerID);
         int n_players = gs.getNPlayers();
         if (tradeOffer == null) {
             // Construct new offer
@@ -504,7 +504,7 @@ public class CatanActionFactory {
      */
     public static List<AbstractAction> getDefaultTradeActions(CatanGameState gs, ActionSpace actionSpace, int player) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        HashMap<CatanParameters.Resource, Counter> playerExchangeRate = gs.getExchangeRates(player);
+        Map<CatanParameters.Resource, Counter> playerExchangeRate = gs.getExchangeRates(player);
         for (Map.Entry<CatanParameters.Resource, Counter> res: gs.playerResources.get(player).entrySet()) {
             if (res.getKey() == CatanParameters.Resource.WILD) continue;
 
@@ -520,7 +520,7 @@ public class CatanActionFactory {
                         trades.add(new DefaultTrade(resToGive, resToGet, nGive, player));
                     }
                 }
-                if (trades.size() > 0) {
+                if (!trades.isEmpty()) {
                     if (actionSpace.structure != ActionSpace.Structure.Deep) {  // Flat is default
                         actions.addAll(trades);
                     } else {

--- a/src/main/java/games/catan/CatanActionFactory.java
+++ b/src/main/java/games/catan/CatanActionFactory.java
@@ -81,11 +81,6 @@ public class CatanActionFactory {
         OfferPlayerTrade opt = (OfferPlayerTrade) gs.tradeOffer;
 
         if (opt != null) {
-
-            if (opt.offeringPlayerID == player) {
-                throw new AssertionError("Player cannot trade with themselves");
-            }
-
             // Reject the trade offer
             actions.add(new EndNegotiation(player, opt.offeringPlayerID));
 
@@ -117,7 +112,7 @@ public class CatanActionFactory {
      */
     public static List<AbstractAction> getPlayerTradeOfferActions(CatanGameState gs, ActionSpace actionSpace, int playerID, OfferPlayerTrade tradeOffer) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        Map<CatanParameters.Resource, Counter> resources = gs.getPlayerResources(playerID);
+        HashMap<CatanParameters.Resource, Counter> resources = gs.getPlayerResources(playerID);
         int n_players = gs.getNPlayers();
         if (tradeOffer == null) {
             // Construct new offer
@@ -504,7 +499,7 @@ public class CatanActionFactory {
      */
     public static List<AbstractAction> getDefaultTradeActions(CatanGameState gs, ActionSpace actionSpace, int player) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        Map<CatanParameters.Resource, Counter> playerExchangeRate = gs.getExchangeRates(player);
+        HashMap<CatanParameters.Resource, Counter> playerExchangeRate = gs.getExchangeRates(player);
         for (Map.Entry<CatanParameters.Resource, Counter> res: gs.playerResources.get(player).entrySet()) {
             if (res.getKey() == CatanParameters.Resource.WILD) continue;
 
@@ -520,7 +515,7 @@ public class CatanActionFactory {
                         trades.add(new DefaultTrade(resToGive, resToGet, nGive, player));
                     }
                 }
-                if (!trades.isEmpty()) {
+                if (trades.size() > 0) {
                     if (actionSpace.structure != ActionSpace.Structure.Deep) {  // Flat is default
                         actions.addAll(trades);
                     } else {

--- a/src/main/java/games/catan/CatanForwardModel.java
+++ b/src/main/java/games/catan/CatanForwardModel.java
@@ -266,7 +266,7 @@ public class CatanForwardModel extends StandardForwardModel {
             mainActions.addAll(CatanActionFactory.getDefaultTradeActions(cgs, actionSpace, player));
 
             // Trade With other players, unless already too many trades this turn
-            if (cgs.nTradesThisTurn < cp.max_trade_actions_allowed) {
+            if (cp.tradingAllowed && cgs.nTradesThisTurn < cp.max_trade_actions_allowed) {
                 mainActions.addAll(CatanActionFactory.getPlayerTradeActions(cgs, actionSpace, player));
             }
 

--- a/src/main/java/games/catan/CatanForwardModel.java
+++ b/src/main/java/games/catan/CatanForwardModel.java
@@ -164,14 +164,13 @@ public class CatanForwardModel extends StandardForwardModel {
                     gs.setTurnOwner(opt.offeringPlayerID);
                     gs.nTradesThisTurn++;
                 } else {
+
                     // Trade offer reply needed, swap player between offering and other in action
                     switch (opt.stage) {
                         case Offer:
                             gs.setTurnOwner(opt.otherPlayerID);
-                            break;
                         case CounterOffer:
                             gs.setTurnOwner(opt.offeringPlayerID);
-                            break;
                     }
                 }
             }

--- a/src/main/java/games/catan/CatanForwardModel.java
+++ b/src/main/java/games/catan/CatanForwardModel.java
@@ -164,13 +164,14 @@ public class CatanForwardModel extends StandardForwardModel {
                     gs.setTurnOwner(opt.offeringPlayerID);
                     gs.nTradesThisTurn++;
                 } else {
-
                     // Trade offer reply needed, swap player between offering and other in action
                     switch (opt.stage) {
                         case Offer:
                             gs.setTurnOwner(opt.otherPlayerID);
+                            break;
                         case CounterOffer:
                             gs.setTurnOwner(opt.offeringPlayerID);
+                            break;
                     }
                 }
             }

--- a/src/main/java/games/catan/CatanForwardModel.java
+++ b/src/main/java/games/catan/CatanForwardModel.java
@@ -36,7 +36,6 @@ public class CatanForwardModel extends StandardForwardModel {
 
         CatanGameState state = (CatanGameState) firstState;
         CatanParameters params = (CatanParameters) state.getGameParameters();
-        firstState.getCoreGameParameters().setMaxRounds(params.maxRounds);
 
         state.setBoard(generateBoard(params, state.getRnd()));
         state.setGraph(extractGraphFromBoard(state.getBoard(), params, state.getRnd()));
@@ -134,7 +133,7 @@ public class CatanForwardModel extends StandardForwardModel {
         else if (gs.getGamePhase() == Main) {
 
             // Win condition
-            if (gs.getGameScore(player) + gs.getVictoryPoints()[player] >= params.points_to_win || gs.getRoundCounter() >= gs.getCoreGameParameters().getMaxRounds()) {
+            if (gs.getGameScore(player) + gs.getVictoryPoints()[player] >= params.points_to_win) {
                 endGame(currentState);
                 if (gs.getCoreGameParameters().verbose) {
                     System.out.println("Game over! winner = " + player);

--- a/src/main/java/games/catan/CatanGameState.java
+++ b/src/main/java/games/catan/CatanGameState.java
@@ -23,14 +23,14 @@ public class CatanGameState extends AbstractGameState {
     protected int[] scores; // score for each player
     protected int[] victoryPoints; // secret points from victory cards
     protected int[] knights, roadLengths; // knight count and road length for each player
-    protected List<HashMap<CatanParameters.Resource, Counter>> exchangeRates; // exchange rate with bank for each resource
+    protected List<Map<CatanParameters.Resource, Counter>> exchangeRates; // exchange rate with bank for each resource
     protected int largestArmyOwner; // playerID of the player currently holding the largest army
     protected int longestRoadOwner; // playerID of the player currently holding the longest road
     protected int longestRoadLength, largestArmySize;
     int rollValue;
 
-    List<HashMap<CatanParameters.Resource, Counter>> playerResources;
-    List<HashMap<BuyAction.BuyType, Counter>> playerTokens;
+    List<Map<CatanParameters.Resource, Counter>> playerResources;
+    List<Map<BuyAction.BuyType, Counter>> playerTokens;
     List<Deck<CatanCard>> playerDevCards;
     HashMap<CatanParameters.Resource, Counter> resourcePool;
     Deck<CatanCard> devCards;
@@ -48,7 +48,7 @@ public class CatanGameState extends AbstractGameState {
         this.tradeOffer = tradeOffer;
     }
 
-    public List<HashMap<BuyAction.BuyType, Counter>> getPlayerTokens() {
+    public List<Map<BuyAction.BuyType, Counter>> getPlayerTokens() {
         return playerTokens;
     }
 
@@ -192,7 +192,7 @@ public class CatanGameState extends AbstractGameState {
         return victoryPoints.clone();
     }
 
-    public HashMap<CatanParameters.Resource, Counter> getPlayerResources(int playerID) {
+    public Map<CatanParameters.Resource, Counter> getPlayerResources(int playerID) {
         return playerResources.get(playerID);
     }
 
@@ -232,7 +232,7 @@ public class CatanGameState extends AbstractGameState {
         return scores;
     }
 
-    public HashMap<CatanParameters.Resource, Counter> getExchangeRates(int playerID) {
+    public Map<CatanParameters.Resource, Counter> getExchangeRates(int playerID) {
         return exchangeRates.get(playerID);
     }
 
@@ -417,30 +417,30 @@ public class CatanGameState extends AbstractGameState {
         copy.playerTokens = new ArrayList<>();
         copy.victoryPoints = victoryPoints.clone();
 
-        // Resources in hand are shuffled if PO
-        List<CatanParameters.Resource> availableRes = new ArrayList<>();
-
-        // PO
-        if (playerId != -1 || !getCoreGameParameters().partialObservable) {
-            for (CatanParameters.Resource r : resourcePool.keySet()) {
-                int nAvailable = ((CatanParameters) gameParameters).n_resource_cards - resourcePool.get(r).getValue();
-                if (nAvailable > 0) {
-                    for (int j = 0; j < nAvailable; j++) {
-                        availableRes.add(r);
-                    }
-                }
-            }
-        }
+//        // Resources in hand are shuffled if PO
+//        List<CatanParameters.Resource> availableRes = new ArrayList<>();
+//
+//        // PO
+//        if (playerId != -1 || !getCoreGameParameters().partialObservable) {
+//            for (CatanParameters.Resource r : resourcePool.keySet()) {
+//                int nAvailable = ((CatanParameters) gameParameters).n_resource_cards - resourcePool.get(r).getValue();
+//                if (nAvailable > 0) {
+//                    for (int j = 0; j < nAvailable; j++) {
+//                        availableRes.add(r);
+//                    }
+//                }
+//            }
+//        }
 
         for (int i = 0; i < getNPlayers(); i++) {
-            HashMap<CatanParameters.Resource, Counter> exchangeRate = new HashMap<>();
+            Map<CatanParameters.Resource, Counter> exchangeRate = new HashMap<>();
             for (Map.Entry<CatanParameters.Resource, Counter> e: exchangeRates.get(i).entrySet()) {
                 exchangeRate.put(e.getKey(), e.getValue().copy());
             }
             copy.exchangeRates.add(exchangeRate);
 
             // Resources in hand
-            HashMap<CatanParameters.Resource, Counter> playerRes = new HashMap<>();
+            Map<CatanParameters.Resource, Counter> playerRes = new HashMap<>();
             for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
                 playerRes.put(e.getKey(), e.getValue().copy());
             }
@@ -453,24 +453,24 @@ public class CatanGameState extends AbstractGameState {
             if (playerId != -1 || !getCoreGameParameters().partialObservable) {
                 if (i != playerId) {
                     // Resources in hand are hidden
-                    for (CatanParameters.Resource r : playerResources.get(i).keySet()) {
-                        copy.playerResources.get(i).get(r).setValue(0);
-                    }
+//                    for (CatanParameters.Resource r : playerResources.get(i).keySet()) {
+//                        copy.playerResources.get(i).get(r).setValue(0);
+//                    }
 
                     // VP from dev cards hidden too
                     copy.victoryPoints[i] = 0;
                 } else {
-                    // Remove from list of resources that may be in other player's hands the ones we know are in our hand
-                    for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
-                        for (int j = 0; j < e.getValue().getValue(); j++) {
-                            availableRes.remove(e.getKey());
-                        }
-                    }
+//                    // Remove from list of resources that may be in other player's hands the ones we know are in our hand
+//                    for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
+//                        for (int j = 0; j < e.getValue().getValue(); j++) {
+//                            availableRes.remove(e.getKey());
+//                        }
+//                    }
                 }
             }
 
             // Player tokens
-            HashMap<BuyAction.BuyType, Counter> playerTok = new HashMap<>();
+            Map<BuyAction.BuyType, Counter> playerTok = new HashMap<>();
             for (Map.Entry<BuyAction.BuyType, Counter> e: playerTokens.get(i).entrySet()) {
                 playerTok.put(e.getKey(), e.getValue().copy());
             }
@@ -497,17 +497,17 @@ public class CatanGameState extends AbstractGameState {
             copy.shuffleDevelopmentCards(playerId);
 
             // Resources in hand are hidden
-            for (int i = 0; i < nPlayers; i++) {
-                if (i != playerId) {
-                    int nInHand = getNResourcesInHand(i);
-                    for (int j = 0; j < nInHand; j++) {
-                        if (availableRes.isEmpty()) break;
-                        CatanParameters.Resource r = availableRes.remove(rnd.nextInt(availableRes.size()));
-                        copy.playerResources.get(i).get(r).increment();
-                    }
-                }
-
-            }
+//            for (int i = 0; i < nPlayers; i++) {
+//                if (i != playerId) {
+//                    int nInHand = getNResourcesInHand(i);
+//                    for (int j = 0; j < nInHand; j++) {
+//                        if (availableRes.isEmpty()) break;
+//                        CatanParameters.Resource r = availableRes.remove(rnd.nextInt(availableRes.size()));
+//                        copy.playerResources.get(i).get(r).increment();
+//                    }
+//                }
+//
+//            }
         }
 
         return copy;

--- a/src/main/java/games/catan/CatanGameState.java
+++ b/src/main/java/games/catan/CatanGameState.java
@@ -527,6 +527,7 @@ public class CatanGameState extends AbstractGameState {
         return scores[playerId];
     }
 
+
     private void shuffleDevelopmentCards(int playerId) {
         // Dev cards in hand are hidden and shuffled with the main deck
         int[][] turnCardsWereBoughtIn = new int[nPlayers][];

--- a/src/main/java/games/catan/CatanGameState.java
+++ b/src/main/java/games/catan/CatanGameState.java
@@ -23,14 +23,14 @@ public class CatanGameState extends AbstractGameState {
     protected int[] scores; // score for each player
     protected int[] victoryPoints; // secret points from victory cards
     protected int[] knights, roadLengths; // knight count and road length for each player
-    protected List<Map<CatanParameters.Resource, Counter>> exchangeRates; // exchange rate with bank for each resource
+    protected List<HashMap<CatanParameters.Resource, Counter>> exchangeRates; // exchange rate with bank for each resource
     protected int largestArmyOwner; // playerID of the player currently holding the largest army
     protected int longestRoadOwner; // playerID of the player currently holding the longest road
     protected int longestRoadLength, largestArmySize;
     int rollValue;
 
-    List<Map<CatanParameters.Resource, Counter>> playerResources;
-    List<Map<BuyAction.BuyType, Counter>> playerTokens;
+    List<HashMap<CatanParameters.Resource, Counter>> playerResources;
+    List<HashMap<BuyAction.BuyType, Counter>> playerTokens;
     List<Deck<CatanCard>> playerDevCards;
     HashMap<CatanParameters.Resource, Counter> resourcePool;
     Deck<CatanCard> devCards;
@@ -48,7 +48,7 @@ public class CatanGameState extends AbstractGameState {
         this.tradeOffer = tradeOffer;
     }
 
-    public List<Map<BuyAction.BuyType, Counter>> getPlayerTokens() {
+    public List<HashMap<BuyAction.BuyType, Counter>> getPlayerTokens() {
         return playerTokens;
     }
 
@@ -192,7 +192,7 @@ public class CatanGameState extends AbstractGameState {
         return victoryPoints.clone();
     }
 
-    public Map<CatanParameters.Resource, Counter> getPlayerResources(int playerID) {
+    public HashMap<CatanParameters.Resource, Counter> getPlayerResources(int playerID) {
         return playerResources.get(playerID);
     }
 
@@ -227,11 +227,12 @@ public class CatanGameState extends AbstractGameState {
         }
     }
 
+
     public int[] getScores() {
         return scores;
     }
 
-    public Map<CatanParameters.Resource, Counter> getExchangeRates(int playerID) {
+    public HashMap<CatanParameters.Resource, Counter> getExchangeRates(int playerID) {
         return exchangeRates.get(playerID);
     }
 
@@ -416,30 +417,30 @@ public class CatanGameState extends AbstractGameState {
         copy.playerTokens = new ArrayList<>();
         copy.victoryPoints = victoryPoints.clone();
 
-//        // Resources in hand are shuffled if PO
-//        List<CatanParameters.Resource> availableRes = new ArrayList<>();
-//
-//        // PO
-//        if (playerId != -1 || !getCoreGameParameters().partialObservable) {
-//            for (CatanParameters.Resource r : resourcePool.keySet()) {
-//                int nAvailable = ((CatanParameters) gameParameters).n_resource_cards - resourcePool.get(r).getValue();
-//                if (nAvailable > 0) {
-//                    for (int j = 0; j < nAvailable; j++) {
-//                        availableRes.add(r);
-//                    }
-//                }
-//            }
-//        }
+        // Resources in hand are shuffled if PO
+        List<CatanParameters.Resource> availableRes = new ArrayList<>();
+
+        // PO
+        if (playerId != -1 || !getCoreGameParameters().partialObservable) {
+            for (CatanParameters.Resource r : resourcePool.keySet()) {
+                int nAvailable = ((CatanParameters) gameParameters).n_resource_cards - resourcePool.get(r).getValue();
+                if (nAvailable > 0) {
+                    for (int j = 0; j < nAvailable; j++) {
+                        availableRes.add(r);
+                    }
+                }
+            }
+        }
 
         for (int i = 0; i < getNPlayers(); i++) {
-            Map<CatanParameters.Resource, Counter> exchangeRate = new HashMap<>();
+            HashMap<CatanParameters.Resource, Counter> exchangeRate = new HashMap<>();
             for (Map.Entry<CatanParameters.Resource, Counter> e: exchangeRates.get(i).entrySet()) {
                 exchangeRate.put(e.getKey(), e.getValue().copy());
             }
             copy.exchangeRates.add(exchangeRate);
 
             // Resources in hand
-            Map<CatanParameters.Resource, Counter> playerRes = new HashMap<>();
+            HashMap<CatanParameters.Resource, Counter> playerRes = new HashMap<>();
             for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
                 playerRes.put(e.getKey(), e.getValue().copy());
             }
@@ -452,24 +453,24 @@ public class CatanGameState extends AbstractGameState {
             if (playerId != -1 || !getCoreGameParameters().partialObservable) {
                 if (i != playerId) {
                     // Resources in hand are hidden
-//                    for (CatanParameters.Resource r : playerResources.get(i).keySet()) {
-//                        copy.playerResources.get(i).get(r).setValue(0);
-//                    }
+                    for (CatanParameters.Resource r : playerResources.get(i).keySet()) {
+                        copy.playerResources.get(i).get(r).setValue(0);
+                    }
 
                     // VP from dev cards hidden too
                     copy.victoryPoints[i] = 0;
                 } else {
-//                    // Remove from list of resources that may be in other player's hands the ones we know are in our hand
-//                    for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
-//                        for (int j = 0; j < e.getValue().getValue(); j++) {
-//                            availableRes.remove(e.getKey());
-//                        }
-//                    }
+                    // Remove from list of resources that may be in other player's hands the ones we know are in our hand
+                    for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
+                        for (int j = 0; j < e.getValue().getValue(); j++) {
+                            availableRes.remove(e.getKey());
+                        }
+                    }
                 }
             }
 
             // Player tokens
-            Map<BuyAction.BuyType, Counter> playerTok = new HashMap<>();
+            HashMap<BuyAction.BuyType, Counter> playerTok = new HashMap<>();
             for (Map.Entry<BuyAction.BuyType, Counter> e: playerTokens.get(i).entrySet()) {
                 playerTok.put(e.getKey(), e.getValue().copy());
             }
@@ -496,17 +497,17 @@ public class CatanGameState extends AbstractGameState {
             copy.shuffleDevelopmentCards(playerId);
 
             // Resources in hand are hidden
-//            for (int i = 0; i < nPlayers; i++) {
-//                if (i != playerId) {
-//                    int nInHand = getNResourcesInHand(i);
-//                    for (int j = 0; j < nInHand; j++) {
-//                        if (availableRes.isEmpty()) break;
-//                        CatanParameters.Resource r = availableRes.remove(rnd.nextInt(availableRes.size()));
-//                        copy.playerResources.get(i).get(r).increment();
-//                    }
-//                }
-//
-//            }
+            for (int i = 0; i < nPlayers; i++) {
+                if (i != playerId) {
+                    int nInHand = getNResourcesInHand(i);
+                    for (int j = 0; j < nInHand; j++) {
+                        if (availableRes.isEmpty()) break;
+                        CatanParameters.Resource r = availableRes.remove(rnd.nextInt(availableRes.size()));
+                        copy.playerResources.get(i).get(r).increment();
+                    }
+                }
+
+            }
         }
 
         return copy;

--- a/src/main/java/games/catan/CatanGameState.java
+++ b/src/main/java/games/catan/CatanGameState.java
@@ -23,14 +23,14 @@ public class CatanGameState extends AbstractGameState {
     protected int[] scores; // score for each player
     protected int[] victoryPoints; // secret points from victory cards
     protected int[] knights, roadLengths; // knight count and road length for each player
-    protected List<HashMap<CatanParameters.Resource, Counter>> exchangeRates; // exchange rate with bank for each resource
+    protected List<Map<CatanParameters.Resource, Counter>> exchangeRates; // exchange rate with bank for each resource
     protected int largestArmyOwner; // playerID of the player currently holding the largest army
     protected int longestRoadOwner; // playerID of the player currently holding the longest road
     protected int longestRoadLength, largestArmySize;
     int rollValue;
 
-    List<HashMap<CatanParameters.Resource, Counter>> playerResources;
-    List<HashMap<BuyAction.BuyType, Counter>> playerTokens;
+    List<Map<CatanParameters.Resource, Counter>> playerResources;
+    List<Map<BuyAction.BuyType, Counter>> playerTokens;
     List<Deck<CatanCard>> playerDevCards;
     HashMap<CatanParameters.Resource, Counter> resourcePool;
     Deck<CatanCard> devCards;
@@ -48,7 +48,7 @@ public class CatanGameState extends AbstractGameState {
         this.tradeOffer = tradeOffer;
     }
 
-    public List<HashMap<BuyAction.BuyType, Counter>> getPlayerTokens() {
+    public List<Map<BuyAction.BuyType, Counter>> getPlayerTokens() {
         return playerTokens;
     }
 
@@ -192,7 +192,7 @@ public class CatanGameState extends AbstractGameState {
         return victoryPoints.clone();
     }
 
-    public HashMap<CatanParameters.Resource, Counter> getPlayerResources(int playerID) {
+    public Map<CatanParameters.Resource, Counter> getPlayerResources(int playerID) {
         return playerResources.get(playerID);
     }
 
@@ -227,12 +227,11 @@ public class CatanGameState extends AbstractGameState {
         }
     }
 
-
     public int[] getScores() {
         return scores;
     }
 
-    public HashMap<CatanParameters.Resource, Counter> getExchangeRates(int playerID) {
+    public Map<CatanParameters.Resource, Counter> getExchangeRates(int playerID) {
         return exchangeRates.get(playerID);
     }
 
@@ -417,30 +416,30 @@ public class CatanGameState extends AbstractGameState {
         copy.playerTokens = new ArrayList<>();
         copy.victoryPoints = victoryPoints.clone();
 
-        // Resources in hand are shuffled if PO
-        List<CatanParameters.Resource> availableRes = new ArrayList<>();
-
-        // PO
-        if (playerId != -1 || !getCoreGameParameters().partialObservable) {
-            for (CatanParameters.Resource r : resourcePool.keySet()) {
-                int nAvailable = ((CatanParameters) gameParameters).n_resource_cards - resourcePool.get(r).getValue();
-                if (nAvailable > 0) {
-                    for (int j = 0; j < nAvailable; j++) {
-                        availableRes.add(r);
-                    }
-                }
-            }
-        }
+//        // Resources in hand are shuffled if PO
+//        List<CatanParameters.Resource> availableRes = new ArrayList<>();
+//
+//        // PO
+//        if (playerId != -1 || !getCoreGameParameters().partialObservable) {
+//            for (CatanParameters.Resource r : resourcePool.keySet()) {
+//                int nAvailable = ((CatanParameters) gameParameters).n_resource_cards - resourcePool.get(r).getValue();
+//                if (nAvailable > 0) {
+//                    for (int j = 0; j < nAvailable; j++) {
+//                        availableRes.add(r);
+//                    }
+//                }
+//            }
+//        }
 
         for (int i = 0; i < getNPlayers(); i++) {
-            HashMap<CatanParameters.Resource, Counter> exchangeRate = new HashMap<>();
+            Map<CatanParameters.Resource, Counter> exchangeRate = new HashMap<>();
             for (Map.Entry<CatanParameters.Resource, Counter> e: exchangeRates.get(i).entrySet()) {
                 exchangeRate.put(e.getKey(), e.getValue().copy());
             }
             copy.exchangeRates.add(exchangeRate);
 
             // Resources in hand
-            HashMap<CatanParameters.Resource, Counter> playerRes = new HashMap<>();
+            Map<CatanParameters.Resource, Counter> playerRes = new HashMap<>();
             for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
                 playerRes.put(e.getKey(), e.getValue().copy());
             }
@@ -453,24 +452,24 @@ public class CatanGameState extends AbstractGameState {
             if (playerId != -1 || !getCoreGameParameters().partialObservable) {
                 if (i != playerId) {
                     // Resources in hand are hidden
-                    for (CatanParameters.Resource r : playerResources.get(i).keySet()) {
-                        copy.playerResources.get(i).get(r).setValue(0);
-                    }
+//                    for (CatanParameters.Resource r : playerResources.get(i).keySet()) {
+//                        copy.playerResources.get(i).get(r).setValue(0);
+//                    }
 
                     // VP from dev cards hidden too
                     copy.victoryPoints[i] = 0;
                 } else {
-                    // Remove from list of resources that may be in other player's hands the ones we know are in our hand
-                    for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
-                        for (int j = 0; j < e.getValue().getValue(); j++) {
-                            availableRes.remove(e.getKey());
-                        }
-                    }
+//                    // Remove from list of resources that may be in other player's hands the ones we know are in our hand
+//                    for (Map.Entry<CatanParameters.Resource, Counter> e: playerResources.get(i).entrySet()) {
+//                        for (int j = 0; j < e.getValue().getValue(); j++) {
+//                            availableRes.remove(e.getKey());
+//                        }
+//                    }
                 }
             }
 
             // Player tokens
-            HashMap<BuyAction.BuyType, Counter> playerTok = new HashMap<>();
+            Map<BuyAction.BuyType, Counter> playerTok = new HashMap<>();
             for (Map.Entry<BuyAction.BuyType, Counter> e: playerTokens.get(i).entrySet()) {
                 playerTok.put(e.getKey(), e.getValue().copy());
             }
@@ -497,17 +496,17 @@ public class CatanGameState extends AbstractGameState {
             copy.shuffleDevelopmentCards(playerId);
 
             // Resources in hand are hidden
-            for (int i = 0; i < nPlayers; i++) {
-                if (i != playerId) {
-                    int nInHand = getNResourcesInHand(i);
-                    for (int j = 0; j < nInHand; j++) {
-                        if (availableRes.isEmpty()) break;
-                        CatanParameters.Resource r = availableRes.remove(rnd.nextInt(availableRes.size()));
-                        copy.playerResources.get(i).get(r).increment();
-                    }
-                }
-
-            }
+//            for (int i = 0; i < nPlayers; i++) {
+//                if (i != playerId) {
+//                    int nInHand = getNResourcesInHand(i);
+//                    for (int j = 0; j < nInHand; j++) {
+//                        if (availableRes.isEmpty()) break;
+//                        CatanParameters.Resource r = availableRes.remove(rnd.nextInt(availableRes.size()));
+//                        copy.playerResources.get(i).get(r).increment();
+//                    }
+//                }
+//
+//            }
         }
 
         return copy;

--- a/src/main/java/games/catan/CatanHeuristic.java
+++ b/src/main/java/games/catan/CatanHeuristic.java
@@ -98,7 +98,7 @@ public class CatanHeuristic extends TunableParameters implements IStateHeuristic
 
         // value player ports
         if (playerPorts != 0.0){
-            HashMap<CatanParameters.Resource, Counter> playerExchangeRates = state.getExchangeRates(playerId);
+            Map<CatanParameters.Resource, Counter> playerExchangeRates = state.getExchangeRates(playerId);
             for(Map.Entry<CatanParameters.Resource, Counter> e: playerExchangeRates.entrySet()){
                     if(e.getValue().getValue() < ((CatanParameters)state.getGameParameters()).default_exchange_rate - 1)
                         stateValue += playerPorts * 0.2;

--- a/src/main/java/games/catan/CatanHeuristic.java
+++ b/src/main/java/games/catan/CatanHeuristic.java
@@ -98,7 +98,7 @@ public class CatanHeuristic extends TunableParameters implements IStateHeuristic
 
         // value player ports
         if (playerPorts != 0.0){
-            Map<CatanParameters.Resource, Counter> playerExchangeRates = state.getExchangeRates(playerId);
+            HashMap<CatanParameters.Resource, Counter> playerExchangeRates = state.getExchangeRates(playerId);
             for(Map.Entry<CatanParameters.Resource, Counter> e: playerExchangeRates.entrySet()){
                     if(e.getValue().getValue() < ((CatanParameters)state.getGameParameters()).default_exchange_rate - 1)
                         stateValue += playerPorts * 0.2;

--- a/src/main/java/games/catan/CatanParameters.java
+++ b/src/main/java/games/catan/CatanParameters.java
@@ -1,7 +1,10 @@
 package games.catan;
 
 import core.AbstractParameters;
+import core.Game;
 import core.components.Dice;
+import evaluation.optimisation.TunableParameters;
+import games.GameType;
 import games.catan.actions.build.BuyAction;
 import games.catan.components.Building;
 import games.catan.components.CatanCard;
@@ -12,9 +15,8 @@ import java.util.HashMap;
 import static games.catan.actions.build.BuyAction.BuyType.*;
 import static games.catan.CatanParameters.Resource.*;
 
-public class CatanParameters extends AbstractParameters {
-    private String dataPath;
-    public int maxRounds = 1000;
+public class CatanParameters extends TunableParameters {
+    private String dataPath = "data/catan/";
 
     public int n_resource_cards = 19;
     public int n_tiles_per_row = 7;
@@ -46,6 +48,8 @@ public class CatanParameters extends AbstractParameters {
     public int n_settlements_setup = 2;
     public int nResourcesYoP = 2;
     public int nRoadsRB = 2;
+
+    public boolean tradingAllowed = true;
 
     public HashMap<Building.Type, Integer> buildingValue = new HashMap<Building.Type, Integer>() {{
         put(Building.Type.Settlement, 1);
@@ -167,12 +171,25 @@ public class CatanParameters extends AbstractParameters {
     }};
 
     public CatanParameters(){
-        setMaxRounds(1000);
+        addTunableParameter("tradingAllowed", true);
+        addTunableParameter("maxRounds", 100);
+        addTunableParameter("dataPath", "data/catan/");
+        _reset();
     }
 
-    public CatanParameters(String dataPath){
-        this.dataPath = dataPath;
+
+    @Override
+    public Object instantiate() {
+        return new Game(GameType.Catan, new CatanForwardModel(), new CatanGameState(this, GameType.Catan.getMinPlayers()));
     }
+
+    @Override
+    public void _reset() {
+        tradingAllowed = (boolean) getParameterValue("tradingAllowed");
+        setMaxRounds((int) getParameterValue("maxRounds"));
+        dataPath = (String) getParameterValue("dataPath");
+    }
+
 
     public String getDataPath(){
         return dataPath;
@@ -181,8 +198,6 @@ public class CatanParameters extends AbstractParameters {
     @Override
     protected AbstractParameters _copy() {
         CatanParameters retValue =  new CatanParameters();
-        retValue.dataPath = dataPath;
-        retValue.maxRounds = maxRounds;
         retValue.n_resource_cards = n_resource_cards;
         retValue.n_tiles_per_row = n_tiles_per_row;
         retValue.dieType = dieType;

--- a/src/main/java/games/catan/actions/build/BuildSettlement.java
+++ b/src/main/java/games/catan/actions/build/BuildSettlement.java
@@ -9,7 +9,6 @@ import games.catan.components.Building;
 import games.catan.components.CatanTile;
 
 import java.util.HashMap;
-import java.util.Map;
 import java.util.Objects;
 
 import static games.catan.stats.CatanMetrics.CatanEvent.PortSettle;
@@ -53,7 +52,7 @@ public class BuildSettlement extends AbstractAction {
             if(settlement.getHarbour() != null){
                 gs.logEvent(PortSettle, String.valueOf(playerID));
 
-                Map<CatanParameters.Resource, Counter> exchangeRates = cgs.getExchangeRates(playerID);
+                HashMap<CatanParameters.Resource, Counter> exchangeRates = cgs.getExchangeRates(playerID);
                 CatanParameters.Resource harbour = settlement.getHarbour();
                 int newRate = cp.harbour_exchange_rate;
                 if (harbour == CatanParameters.Resource.WILD) newRate = cp.harbour_wild_exchange_rate;

--- a/src/main/java/games/catan/actions/build/BuildSettlement.java
+++ b/src/main/java/games/catan/actions/build/BuildSettlement.java
@@ -9,6 +9,7 @@ import games.catan.components.Building;
 import games.catan.components.CatanTile;
 
 import java.util.HashMap;
+import java.util.Map;
 import java.util.Objects;
 
 import static games.catan.stats.CatanMetrics.CatanEvent.PortSettle;
@@ -52,7 +53,7 @@ public class BuildSettlement extends AbstractAction {
             if(settlement.getHarbour() != null){
                 gs.logEvent(PortSettle, String.valueOf(playerID));
 
-                HashMap<CatanParameters.Resource, Counter> exchangeRates = cgs.getExchangeRates(playerID);
+                Map<CatanParameters.Resource, Counter> exchangeRates = cgs.getExchangeRates(playerID);
                 CatanParameters.Resource harbour = settlement.getHarbour();
                 int newRate = cp.harbour_exchange_rate;
                 if (harbour == CatanParameters.Resource.WILD) newRate = cp.harbour_wild_exchange_rate;

--- a/src/main/java/games/catan/actions/dev/PlayYearOfPlenty.java
+++ b/src/main/java/games/catan/actions/dev/PlayYearOfPlenty.java
@@ -8,10 +8,7 @@ import games.catan.CatanGameState;
 import games.catan.CatanParameters;
 import games.catan.components.CatanCard;
 
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.Objects;
-import java.util.Optional;
+import java.util.*;
 
 public class PlayYearOfPlenty extends AbstractAction {
     public final CatanParameters.Resource[] resources;
@@ -28,7 +25,7 @@ public class PlayYearOfPlenty extends AbstractAction {
     public boolean execute(AbstractGameState gs) {
         CatanGameState cgs = (CatanGameState) gs;
         Deck<CatanCard> playerDevDeck = cgs.getPlayerDevCards(player);
-        HashMap<CatanParameters.Resource, Counter> playerResources = cgs.getPlayerResources(player);
+        Map<CatanParameters.Resource, Counter> playerResources = cgs.getPlayerResources(player);
 
         Optional<CatanCard> yearOfPlenty = playerDevDeck.stream()
                 .filter(card -> card.cardType == CatanCard.CardType.YEAR_OF_PLENTY)

--- a/src/main/java/games/catan/actions/dev/PlayYearOfPlenty.java
+++ b/src/main/java/games/catan/actions/dev/PlayYearOfPlenty.java
@@ -8,7 +8,10 @@ import games.catan.CatanGameState;
 import games.catan.CatanParameters;
 import games.catan.components.CatanCard;
 
-import java.util.*;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Objects;
+import java.util.Optional;
 
 public class PlayYearOfPlenty extends AbstractAction {
     public final CatanParameters.Resource[] resources;
@@ -25,7 +28,7 @@ public class PlayYearOfPlenty extends AbstractAction {
     public boolean execute(AbstractGameState gs) {
         CatanGameState cgs = (CatanGameState) gs;
         Deck<CatanCard> playerDevDeck = cgs.getPlayerDevCards(player);
-        Map<CatanParameters.Resource, Counter> playerResources = cgs.getPlayerResources(player);
+        HashMap<CatanParameters.Resource, Counter> playerResources = cgs.getPlayerResources(player);
 
         Optional<CatanCard> yearOfPlenty = playerDevDeck.stream()
                 .filter(card -> card.cardType == CatanCard.CardType.YEAR_OF_PLENTY)

--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -12,6 +12,7 @@ import games.coltexpress.ColtExpressTypes.CharacterType;
 import games.coltexpress.ColtExpressTypes.LootType;
 import games.coltexpress.actions.*;
 import games.coltexpress.cards.ColtExpressCard;
+import games.coltexpress.cards.RoundCard;
 import games.coltexpress.components.Compartment;
 import games.coltexpress.components.Loot;
 import utilities.Group;
@@ -33,7 +34,7 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
         cegs.playerPlayingBelle = -1;
         cegs.plannedActions = null;
         cegs.trainCompartments = new LinkedList<>();
-        cegs.rounds = new PartialObservableDeck<>("Rounds", -1, cegs.getNPlayers());
+        cegs.rounds = new PartialObservableDeck<>("Rounds", -1, cegs.getNPlayers(), VisibilityMode.TOP_VISIBLE_TO_ALL);
 
         setupRounds(cegs, cep);
         setupTrain(cegs);
@@ -46,7 +47,7 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
         cegs.playerHandCards = new ArrayList<>(cegs.getNPlayers());
         cegs.playerLoot = new ArrayList<>(cegs.getNPlayers());
         cegs.bulletsLeft = new int[cegs.getNPlayers()];
-        cegs.plannedActions = new PartialObservableDeck<>("plannedActions", -1, cegs.getNPlayers());
+        cegs.plannedActions = new PartialObservableDeck<>("plannedActions", -1, cegs.getNPlayers(), VisibilityMode.MIXED_VISIBILITY);
 
         Arrays.fill(cegs.bulletsLeft, cep.nBulletsPerPlayer);
 
@@ -94,13 +95,12 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
     }
 
     private void setupRounds(ColtExpressGameState cegs, ColtExpressParameters cep) {
-        cegs.rounds = new PartialObservableDeck<>("Rounds", -1, cegs.getNPlayers());
+        cegs.rounds = new PartialObservableDeck<>("Rounds", -1, cegs.getNPlayers(), VisibilityMode.TOP_VISIBLE_TO_ALL);
 
         // Add 1 random end round card
         // A deck works on a First In Last Out basis - so we deal the last card to be drawn first (it goes to the bottom of the deck
 
         Random rndForRoundCards = cep.roundDeckShuffleSeed != -1 ? new Random(cep.roundDeckShuffleSeed) : cegs.getRnd();
-        cegs.rounds.add(cegs.getRandomEndRoundCard(cep, rndForRoundCards));
 
         // Add random round cards
         ArrayList<ColtExpressTypes.RegularRoundCard> availableRounds = new ArrayList<>(Arrays.asList(cep.roundCards));
@@ -109,10 +109,10 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
             cegs.rounds.add(cegs.getRoundCard(availableRounds.get(choice), cegs.getNPlayers()));
             availableRounds.remove(availableRounds.get(choice));
         }
-        // set first card to be visible
-        boolean[] allTrue = new boolean[cegs.getNPlayers()];
-        Arrays.fill(allTrue, true);
-        cegs.rounds.setVisibilityOfComponent(0, allTrue);
+        cegs.rounds.shuffle(rndForRoundCards);
+
+        RoundCard endCard = cegs.getRandomEndRoundCard(cep, rndForRoundCards);
+        cegs.rounds.addToBottom(endCard);
     }
 
     @Override

--- a/src/main/java/games/dominion/DominionGameState.java
+++ b/src/main/java/games/dominion/DominionGameState.java
@@ -263,7 +263,7 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
                 // need to shuffle drawpile separately
                 retValue.playerHands[p] = playerHands[p].copy();
                 retValue.playerDrawPiles[p] = playerDrawPiles[p].copy();
-                retValue.playerDrawPiles[p].shuffleVisible(redeterminisationRnd, p, false);
+                retValue.playerDrawPiles[p].redeterminiseUnknown(redeterminisationRnd, p);
             } else {
                 // need to combine and shuffle hands and drawpiles
                 retValue.playerDrawPiles[p] = playerDrawPiles[p].copy();
@@ -278,7 +278,7 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
                 // we have now moved all the non-visible Hand cards into the Draw pile to reshuffle
                 retValue.playerHands[p].clear(); // we will need to reconstruct this, including visibility status in a sec
                 // we then reshuffle all the non-visible cards
-                retValue.playerDrawPiles[p].shuffleVisible(redeterminisationRnd, playerId, false);
+                retValue.playerDrawPiles[p].redeterminiseUnknown(redeterminisationRnd, playerId);
                 // we then remove cards from the top of the shuffled draw pile (in the region we know is not visible)
                 for (int i = 0; i < playerHands[p].getSize(); i++) {
                     if (!playerHands[p].getVisibilityForPlayer(i, playerId)) {
@@ -380,10 +380,10 @@ public class DominionGameState extends AbstractGameState implements IPrintable {
         for (int i = 0; i < nPlayers; i++) {
             boolean[] handVisibility = new boolean[nPlayers];
             handVisibility[i] = true;
-            playerHands[i] = new PartialObservableDeck<>("Hand of Player " + i + 1, handVisibility);
-            playerDrawPiles[i] = new PartialObservableDeck<>("Drawpile of Player " + i + 1, new boolean[nPlayers]);
-            playerDiscards[i] = new Deck<>("Discard of Player " + i + 1, VISIBLE_TO_ALL);
-            playerTableaux[i] = new Deck<>("Tableau of Player " + i + 1, VISIBLE_TO_ALL);
+            playerHands[i] = new PartialObservableDeck<>("Hand of Player " + i + 1, i, handVisibility);
+            playerDrawPiles[i] = new PartialObservableDeck<>("Drawpile of Player " + i + 1, i, new boolean[nPlayers]);
+            playerDiscards[i] = new Deck<>("Discard of Player " + i + 1, i, VISIBLE_TO_ALL);
+            playerTableaux[i] = new Deck<>("Tableau of Player " + i + 1, i, VISIBLE_TO_ALL);
         }
         super.reset();
     }

--- a/src/main/java/games/dominion/cards/DominionCard.java
+++ b/src/main/java/games/dominion/cards/DominionCard.java
@@ -15,42 +15,13 @@ public class DominionCard extends Card {
     }
 
     public static DominionCard create(CardType type) {
-        switch (type) {
-            case GOLD:
-            case COPPER:
-            case SILVER:
-            case ESTATE:
-            case DUCHY:
-            case PROVINCE:
-            case CURSE:
-            case VILLAGE:
-            case SMITHY:
-            case LABORATORY:
-            case MARKET:
-            case FESTIVAL:
-            case CELLAR:
-            case MILITIA:
-            case MOAT:
-            case REMODEL:
-            case MERCHANT:
-            case MINE:
-            case WORKSHOP:
-            case ARTISAN:
-            case MONEYLENDER:
-            case POACHER:
-            case WITCH:
-            case CHAPEL:
-            case HARBINGER:
-            case THRONE_ROOM:
-            case BANDIT:
-            case BUREAUCRAT:
-            case SENTRY:
-                return new DominionCard(type);
-            case GARDENS:
-                return new Gardens();
-            default:
-                throw new AssertionError("Not yet implemented : " + type);
-        }
+        return switch (type) {
+            case GOLD, COPPER, SILVER, ESTATE, DUCHY, PROVINCE, CURSE, VILLAGE, SMITHY, LABORATORY, MARKET, FESTIVAL,
+                 CELLAR, MILITIA, MOAT, REMODEL, MERCHANT, MINE, WORKSHOP, ARTISAN, MONEYLENDER, POACHER, WITCH, CHAPEL,
+                 HARBINGER, THRONE_ROOM, BANDIT, BUREAUCRAT, SENTRY -> new DominionCard(type);
+            case GARDENS -> new Gardens();
+            default -> throw new AssertionError("Not yet implemented : " + type);
+        };
     }
 
     public boolean isTreasureCard() {

--- a/src/main/java/games/explodingkittens/ExplodingKittensForwardModel.java
+++ b/src/main/java/games/explodingkittens/ExplodingKittensForwardModel.java
@@ -39,7 +39,7 @@ public class ExplodingKittensForwardModel extends AbstractForwardModel implement
         ekgs.playerGettingAFavor = -1;
         ekgs.actionStack = null;
         // Set up draw pile deck
-        PartialObservableDeck<ExplodingKittensCard> drawPile = new PartialObservableDeck<>("Draw Pile", firstState.getNPlayers());
+        PartialObservableDeck<ExplodingKittensCard> drawPile = new PartialObservableDeck<>("Draw Pile", -1, firstState.getNPlayers(), VisibilityMode.HIDDEN_TO_ALL);
         ekgs.setDrawPile(drawPile);
 
         // Add all cards but defuse and exploding kittens
@@ -58,7 +58,7 @@ public class ExplodingKittensForwardModel extends AbstractForwardModel implement
         for (int i = 0; i < firstState.getNPlayers(); i++) {
             boolean[] visible = new boolean[firstState.getNPlayers()];
             visible[i] = true;
-            PartialObservableDeck<ExplodingKittensCard> playerCards = new PartialObservableDeck<>("Player Cards", visible);
+            PartialObservableDeck<ExplodingKittensCard> playerCards = new PartialObservableDeck<>("Player Cards", i, visible);
             playerHandCards.add(playerCards);
 
             // Add defuse card

--- a/src/main/java/games/explodingkittens/ExplodingKittensGameState.java
+++ b/src/main/java/games/explodingkittens/ExplodingKittensGameState.java
@@ -9,7 +9,6 @@ import core.components.Deck;
 import core.components.PartialObservableDeck;
 import core.interfaces.IGamePhase;
 import core.interfaces.IPrintable;
-import core.interfaces.IStateFeatureJSON;
 import core.turnorders.TurnOrder;
 import games.GameType;
 import games.explodingkittens.cards.ExplodingKittensCard;
@@ -92,7 +91,7 @@ public class ExplodingKittensGameState extends AbstractGameStateWithTurnOrder im
             }
 
             // Shuffles only hidden cards in draw pile, if player knows what's on top those will stay in place
-            ekgs.drawPile.shuffleVisible(redeterminisationRnd, playerId, false);
+            ekgs.drawPile.redeterminiseUnknown(redeterminisationRnd, playerId);
             Deck<ExplodingKittensCard> explosive = new Deck<>("tmp", VisibilityMode.HIDDEN_TO_ALL);
             for (int i = 0; i < getNPlayers(); i++) {
                 if (i != playerId) {

--- a/src/main/java/games/loveletter/LoveLetterForwardModel.java
+++ b/src/main/java/games/loveletter/LoveLetterForwardModel.java
@@ -29,7 +29,7 @@ public class LoveLetterForwardModel extends StandardForwardModel implements ITre
 
         llgs.effectProtection = new boolean[llgs.getNPlayers()];
         // Set up all variables
-        llgs.drawPile = new PartialObservableDeck<>("drawPile", llgs.getNPlayers());
+        llgs.drawPile = new PartialObservableDeck<>("drawPile", -1, llgs.getNPlayers(), VisibilityMode.HIDDEN_TO_ALL);
         llgs.reserveCards = new Deck<>("reserveCards", VisibilityMode.VISIBLE_TO_ALL);
         llgs.affectionTokens = new int[llgs.getNPlayers()];
         llgs.playerHandCards = new ArrayList<>(llgs.getNPlayers());

--- a/src/main/java/games/resistance/ResForwardModel.java
+++ b/src/main/java/games/resistance/ResForwardModel.java
@@ -60,7 +60,7 @@ public class ResForwardModel extends StandardForwardModel {
         for (int i = 0; i < firstState.getNPlayers(); i++) {
             boolean[] visible = new boolean[firstState.getNPlayers()];
             visible[i] = false;
-            PartialObservableDeck<ResPlayerCards> playerCards = new PartialObservableDeck<>("Player Cards", visible);
+            PartialObservableDeck<ResPlayerCards> playerCards = new PartialObservableDeck<>("Player Cards", i, visible);
             if (spies.get(i)) {
                 ResPlayerCards idCard = new ResPlayerCards(ResPlayerCards.CardType.SPY);
                 idCard.setOwnerId(i);

--- a/src/main/java/players/mcts/MCTSParams.java
+++ b/src/main/java/players/mcts/MCTSParams.java
@@ -32,7 +32,7 @@ public class MCTSParams extends PlayerParameters {
     public double MASTGamma = 0.0;
     public double MASTDefaultValue = 0.0;
     public double MASTBoltzmann = 0.1;
-    public double exp3Boltzmann = 1.0;
+    public double exp3Boltzmann = 0.1;
     public double hedgeBoltzmann = 100;
     public boolean useMASTAsActionHeuristic = false;
     public MCTSEnums.SelectionPolicy selectionPolicy = SIMPLE;  // In general better than ROBUST
@@ -75,7 +75,7 @@ public class MCTSParams extends PlayerParameters {
     public MCTSParams() {
         addTunableParameter("K", Math.sqrt(2), Arrays.asList(0.0, 0.1, 1.0, Math.sqrt(2), 3.0, 10.0));
         addTunableParameter("MASTBoltzmann", 0.1);
-        addTunableParameter("exp3Boltzmann", 1.0);
+        addTunableParameter("exp3Boltzmann", 0.1);
         addTunableParameter("hedgeBoltzmann", 100.0);
         addTunableParameter("rolloutLength", 10, Arrays.asList(0, 3, 10, 30, 100));
         addTunableParameter("rolloutLengthPerPlayer", false);

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -808,7 +808,7 @@ public class SingleTreeNode {
         double retValue = Math.exp(actionValue / params.exp3Boltzmann);
 
         if (Double.isNaN(retValue) || Double.isInfinite(retValue)) {
-            System.out.println("We have a non-number in EXP3 somewhere : " + retValue);
+            System.out.printf("We have a non-number %s in EXP3 somewhere from %s %n", retValue, action);
             retValue = 1e6;  // to avoid numeric issues later
         }
         // We add FPU after exponentiation for safety (as it likely a large number)
@@ -845,7 +845,6 @@ public class SingleTreeNode {
         int actionVisits = actionVisits(action);
         return params.progressiveBias * actionValueEstimates.getOrDefault(action, 0.0) / (actionVisits + 1);
     }
-
     /**
      * Perform a Monte Carlo rollout from this node.
      *

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -153,7 +153,7 @@ public class SingleTreeNode {
         lowReward = template.lowReward;
         inheritedVisits = nVisits;
         MASTStatistics = new ArrayList<>();
-        for (int i = 0; i < state.getNPlayers(); i++)
+        for (int i = 0; i < template.state.getNPlayers(); i++)
             MASTStatistics.add(new HashMap<>());
     }
 

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -152,6 +152,9 @@ public class SingleTreeNode {
         highReward = template.highReward;
         lowReward = template.lowReward;
         inheritedVisits = nVisits;
+        MASTStatistics = new ArrayList<>();
+        for (int i = 0; i < state.getNPlayers(); i++)
+            MASTStatistics.add(new HashMap<>());
     }
 
     protected void resetDepth(SingleTreeNode newRoot) {

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -799,10 +799,12 @@ public class SingleTreeNode {
         int actionVisits = actionVisits(action);
         // we then normalise to [0, 1], or we subtract the mean action value to get an advantage (and reduce risk of
         // NaN or Infinities when we exponentiate)
-        if (params.normaliseRewards && actionVisits > 0)
-            actionValue = normalise(actionValue, root.lowReward, root.highReward);
-        else
-            actionValue = actionValue - nodeValue(decisionPlayer);
+        if (actionVisits > 0) {
+            if (params.normaliseRewards)
+                actionValue = normalise(actionValue, root.lowReward, root.highReward);
+            else
+                actionValue = actionValue - nodeValue(decisionPlayer);
+        }
         if (params.progressiveBias > 0)
             actionValue += getBiasValue(action);
         double retValue = Math.exp(actionValue / params.exp3Boltzmann);

--- a/src/main/java/players/rhea/RHEAPlayer.java
+++ b/src/main/java/players/rhea/RHEAPlayer.java
@@ -3,6 +3,7 @@ package players.rhea;
 import core.AbstractGameState;
 import core.AbstractPlayer;
 import core.actions.AbstractAction;
+import players.IAnyTimePlayer;
 import players.PlayerConstants;
 import players.mcts.MASTPlayer;
 import players.simple.RandomPlayer;
@@ -13,7 +14,7 @@ import utilities.Utils;
 import java.util.*;
 import java.util.stream.Collectors;
 
-public class RHEAPlayer extends AbstractPlayer {
+public class RHEAPlayer extends AbstractPlayer implements IAnyTimePlayer {
     private static final AbstractPlayer randomPlayer = new RandomPlayer();
     List<Map<Object, Pair<Integer, Double>>> MASTStatistics; // a list of one Map per player. Action -> (visits, totValue)
     protected List<RHEAIndividual> population = new ArrayList<>();
@@ -286,4 +287,14 @@ public class RHEAPlayer extends AbstractPlayer {
     }
 
 
+    @Override
+    public void setBudget(int budget) {
+        parameters.budget = budget;
+        parameters.setParameterValue("budget", budget);
+    }
+
+    @Override
+    public int getBudget() {
+        return parameters.budget;
+    }
 }

--- a/src/main/java/players/simple/RandomPlayer.java
+++ b/src/main/java/players/simple/RandomPlayer.java
@@ -37,4 +37,9 @@ public class RandomPlayer extends AbstractPlayer {
     public RandomPlayer copy() {
         return new RandomPlayer(new Random(rnd.nextInt()));
     }
+
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof RandomPlayer;
+    }
 }

--- a/src/main/java/utilities/DeterminisationUtilities.java
+++ b/src/main/java/utilities/DeterminisationUtilities.java
@@ -31,9 +31,9 @@ public class DeterminisationUtilities {
 
         // The fully observable decks care now filtered to remove any that are visible to us
         for (Deck<C> d : decks) {
-            if (d instanceof PartialObservableDeck) {
-                PartialObservableDeck<C> pod = (PartialObservableDeck<C>) d;
-                for (int i = 0; i < pod.getSize(); i++) {
+            int length = d.getSize();
+            if (d instanceof PartialObservableDeck<C> pod) {
+                for (int i = 0; i < length; i++) {
                     if (!pod.getVisibilityForPlayer(i, player) && lambda.test(pod.get(i)))
                         allCards.add(pod.get(i));
                 }
@@ -46,15 +46,20 @@ public class DeterminisationUtilities {
                         if (d.getOwnerId() == player)
                             break;
                     case HIDDEN_TO_ALL:
-                        allCards.add(d.stream().filter(lambda).collect(toList()));
+                        for (int i = 0; i < length; i++)
+                            if (lambda.test(d.get(i)))
+                                allCards.add(d.get(i));
                         break;
-                    case FIRST_VISIBLE_TO_ALL:
-                        Deck<C> temp = d.copy();
-                        temp.draw();
-                        allCards.add(temp.stream().filter(lambda).collect(toList()));
+                    case TOP_VISIBLE_TO_ALL:
+                        for (int i = 1; i < length; i++)
+                            if (lambda.test(d.get(i)))
+                                allCards.add(d.get(i));
                         break;
-                    case LAST_VISIBLE_TO_ALL:
-                        throw new AssertionError("Not supported : LAST_VISIBLE_TO_ALL");
+                    case BOTTOM_VISIBLE_TO_ALL:
+                        for (int i = 0; i < length - 1;  i++)
+                            if (lambda.test(d.get(i)))
+                                allCards.add(d.get(i));
+                        break;
                     case MIXED_VISIBILITY:
                         throw new AssertionError("Not supported : MIXED_VISIBILITTY");
                 }
@@ -64,9 +69,9 @@ public class DeterminisationUtilities {
 
         // and put the shuffled cards in place
         for (Deck<C> d : decks) {
-            if (d instanceof PartialObservableDeck) {
-                PartialObservableDeck<C> pod = (PartialObservableDeck<C>) d;
-                for (int i = 0; i < pod.getSize(); i++) {
+            int length = d.getSize();
+            if (d instanceof PartialObservableDeck<C> pod) {
+                for (int i = 0; i < length; i++) {
                     if (!pod.getVisibilityForPlayer(i, player) && lambda.test(pod.get(i)))
                         pod.setComponent(i, allCards.draw());
                 }
@@ -78,17 +83,20 @@ public class DeterminisationUtilities {
                         if (d.getOwnerId() == player)
                             break;
                     case HIDDEN_TO_ALL:
-                        for (int i = 0; i < d.getSize(); i++)
+                        for (int i = 0; i < length; i++)
                             if (lambda.test(d.get(i)))
                                 d.setComponent(i, allCards.draw());
                         break;
-                    case FIRST_VISIBLE_TO_ALL:
-                        for (int i = 1; i < d.getSize(); i++)
+                    case TOP_VISIBLE_TO_ALL:
+                        for (int i = 1; i < length; i++)
                             if (lambda.test(d.get(i)))
                                 d.setComponent(i, allCards.draw());
                         break;
-                    case LAST_VISIBLE_TO_ALL:
-                        throw new AssertionError("Not supported : LAST_VISIBLE_TO_ALL");
+                    case BOTTOM_VISIBLE_TO_ALL:
+                        for (int i = 0; i < length - 1;  i++)
+                            if (lambda.test(d.get(i)))
+                                d.setComponent(i, allCards.draw());
+                        break;
                     case MIXED_VISIBILITY:
                         throw new AssertionError("Not supported : MIXED_VISIBILITTY");
                 }

--- a/src/main/java/utilities/JSONUtils.java
+++ b/src/main/java/utilities/JSONUtils.java
@@ -1,5 +1,6 @@
 package utilities;
 
+import evaluation.optimisation.TunableParameters;
 import org.apache.commons.lang3.reflect.ConstructorUtils;
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
@@ -59,6 +60,13 @@ public class JSONUtils {
                 return (T) Enum.valueOf(enumClass, val);
             }
             Class<T> outputClass = (Class<T>) Class.forName(cl);
+            if (TunableParameters.class.isAssignableFrom(outputClass)) {
+                // in this case we do not look for the Constructor arguments, as
+                // the parameters are defined directly as name-value pairs in JSON
+                T t = outputClass.getConstructor().newInstance();
+                TunableParameters.loadFromJSON((TunableParameters) t, json);
+                return t;
+            }
             JSONArray argArray = (JSONArray) json.getOrDefault("args", new JSONArray());
             Class<?>[] argClasses = new Class[argArray.size()];
             Object[] args = new Object[argArray.size()];

--- a/src/main/java/utilities/JSONUtils.java
+++ b/src/main/java/utilities/JSONUtils.java
@@ -6,6 +6,7 @@ import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
 import org.json.simple.parser.ParseException;
+import scala.util.parsing.json.JSON;
 
 import java.io.*;
 import java.lang.reflect.Array;
@@ -335,6 +336,49 @@ public class JSONUtils {
             e.printStackTrace();
             throw new AssertionError("Problem reading from file " + filename);
         }
+    }
+
+    public static String prettyPrint(JSONObject json, int tabDepth) {
+        StringBuilder sb = new StringBuilder("{\n");
+        Object[] keys = json.keySet().toArray();
+        for (int keyIndex = 0; keyIndex < keys.length; keyIndex++) {
+            String keyName = keys[keyIndex].toString();
+            Object value = json.get(keyName);
+            sb.append("\t".repeat(Math.max(0, tabDepth)));
+            sb.append("\"").append(keyName).append("\"").append(" : ");
+            if (value instanceof JSONObject subJSON) {
+                sb.append(prettyPrint(subJSON, tabDepth + 1));
+            } else if (value instanceof JSONArray array) {
+                sb.append("[\n");
+                tabDepth++;
+                for (int index = 0; index < array.size(); index++) {
+                    Object v = array.get(index);
+                    sb.append("\t".repeat(Math.max(0, tabDepth)));
+                    if (v instanceof JSONObject subJSON) {
+                        sb.append(prettyPrint(subJSON, tabDepth + 1));
+                    } else {
+                        sb.append(v);
+                    }
+                    if (index < array.size() - 1)
+                        sb.append(",");
+                    sb.append("\n");
+                }
+                tabDepth--;
+            } else if (value instanceof String){
+                sb.append("\"").append(value).append("\"");
+            } else if (value instanceof Long || value instanceof Integer ||
+                    value instanceof Double || value instanceof Boolean) {
+                sb.append(value);
+            } else {
+                throw new AssertionError("Unexpected value type in prettyPrint : " + value);
+            }
+            if (keyIndex < keys.length - 1)
+                sb.append(",");
+            sb.append("\n");
+        }
+        sb.append("\t".repeat(Math.max(0, tabDepth-1)));
+        sb.append("}");
+        return sb.toString();
     }
 
     @SuppressWarnings("unchecked")

--- a/src/test/java/core/PartialObervableDecks.java
+++ b/src/test/java/core/PartialObervableDecks.java
@@ -1,0 +1,409 @@
+package core;
+
+import core.components.Deck;
+import core.components.PartialObservableDeck;
+import games.dominion.cards.CardType;
+import games.dominion.cards.DominionCard;
+import org.junit.Test;
+import utilities.DeterminisationUtilities;
+
+import java.util.*;
+
+import static core.CoreConstants.VisibilityMode.HIDDEN_TO_ALL;
+import static core.CoreConstants.VisibilityMode.TOP_VISIBLE_TO_ALL;
+import static org.junit.Assert.*;
+
+public class PartialObervableDecks {
+
+
+    Random rnd = new Random(393);
+
+    @Test
+    public void addingElementToDeckPicksUpDefaultVisibility() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 1, new boolean[]{true, false, false});
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        for (int i = 0; i < 2; i++) {
+            assertTrue(deck.isComponentVisible(i, 0));
+            assertFalse(deck.isComponentVisible(i, 1));
+            assertFalse(deck.isComponentVisible(i, 2));
+        }
+        deck.setVisibilityOfComponent(1, new boolean[]{true, true, true});
+        deck.add(DominionCard.create(CardType.SMITHY), 1); // Add to the middle of the deck
+        // this moves the specifically modified card to position 2.
+        for (int i = 0; i < 3; i++) {
+            if (i != 2) {
+                assertTrue(deck.isComponentVisible(i, 0));
+                assertFalse(deck.isComponentVisible(i, 1));
+                assertFalse(deck.isComponentVisible(i, 2));
+            } else {
+                assertTrue(deck.isComponentVisible(i, 0));
+                assertTrue(deck.isComponentVisible(i, 1));
+                assertTrue(deck.isComponentVisible(i, 2));
+            }
+        }
+    }
+
+    @Test
+    public void initialisingWithVisibleToAllDoes() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 1, 4, CoreConstants.VisibilityMode.VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        for (int i = 0; i < 2; i++) {
+            assertTrue(deck.isComponentVisible(i, 0));
+            assertTrue(deck.isComponentVisible(i, 1));
+            assertTrue(deck.isComponentVisible(i, 2));
+        }
+    }
+
+    @Test
+    public void initialisingWithHiddenToAllDoes() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 1, 4, HIDDEN_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        for (int i = 0; i < 3; i++) {
+            assertFalse(deck.isComponentVisible(i, 0));
+            assertFalse(deck.isComponentVisible(i, 1));
+            assertFalse(deck.isComponentVisible(i, 2));
+            assertFalse(deck.isComponentVisible(i, 3));
+        }
+        deck.setVisibilityOfComponent(0, new boolean[]{false, true, false, true});
+        for (int i = 0; i < 3; i++) {
+            if (i == 0) {
+                assertFalse(deck.isComponentVisible(i, 0));
+                assertTrue(deck.isComponentVisible(i, 1));
+                assertFalse(deck.isComponentVisible(i, 2));
+                assertTrue(deck.isComponentVisible(i, 3));
+            } else {
+                assertFalse(deck.isComponentVisible(i, 0));
+                assertFalse(deck.isComponentVisible(i, 1));
+                assertFalse(deck.isComponentVisible(i, 2));
+                assertFalse(deck.isComponentVisible(i, 3));
+            }
+        }
+    }
+
+    @Test
+    public void initialisingWithVisibleToOwnerDoes() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.VISIBLE_TO_OWNER);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        for (int i = 0; i < 2; i++) {
+            assertFalse(deck.isComponentVisible(i, 0));
+            assertFalse(deck.isComponentVisible(i, 1));
+            assertTrue(deck.isComponentVisible(i, 2));
+            assertFalse(deck.isComponentVisible(i, 3));
+        }
+    }
+
+    @Test
+    public void allVisibleIfDealtOneAtATimeAndTopMostIsVisible() {
+        // A deck works on a First In Last Out basis - so we deal the last card to be drawn first (it goes to the bottom of the deck)
+        // As we put the cards on one at a time, they are all visible
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.TOP_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));  // this is the top of the deck and the 'FIRST' card
+        for (int i = 0; i < 3; i++) {
+            for (int p = 0; p < 4; p++) {
+                System.out.println(i + " " + p + " " + deck.isComponentVisible(i, p));
+                assertTrue(deck.isComponentVisible(i, p));
+            }
+        }
+    }
+
+    @Test
+    public void shufflingResetsVisibility() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.TOP_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));  // this is the top of the deck and the 'FIRST' card
+        deck.shuffle(rnd);
+        for (int i = 0; i < 3; i++) {
+            for (int p = 0; p < 4; p++) {
+                System.out.println(i + " " + p + " " + deck.isComponentVisible(i, p));
+                if (i == 0) {
+                    assertTrue(deck.isComponentVisible(i, p));
+                } else {
+                    assertFalse(deck.isComponentVisible(i, p));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void initialisingWithBottomVisibleToAllDoes() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.BOTTOM_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));  // this is the top of the deck and the 'FIRST' card
+        for (int i = 0; i < 3; i++) {
+            for (int p = 0; p < 4; p++) {
+                System.out.println(i + " " + p + " " + deck.isComponentVisible(i, p));
+                if (i == deck.getSize() - 1) {
+                    assertTrue(deck.isComponentVisible(i, p));
+                } else {
+                    assertFalse(deck.isComponentVisible(i, p));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void testAddToBottom() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.BOTTOM_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        assertEquals(CardType.COPPER, deck.get(2).cardType());
+        deck.addToBottom(DominionCard.create(CardType.MINE));
+        assertEquals(CardType.MINE, deck.get(3).cardType());
+        assertEquals(CardType.COPPER, deck.get(2).cardType());
+        for (int i = 0; i < 4; i++) {
+            for (int p = 0; p < 4; p++) {
+                System.out.println(i + " " + p + " " + deck.isComponentVisible(i, p));
+                if (i > 1) {  // the last two cards are visible
+                    assertTrue(deck.isComponentVisible(i, p));
+                } else {
+                    assertFalse(deck.isComponentVisible(i, p));
+                }
+            }
+        }
+    }
+
+    @Test
+    public void addingWholeDeckDoesNotIncreaseTopVisibility() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, HIDDEN_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        PartialObservableDeck<DominionCard> deck2 = new PartialObservableDeck<>("Test", 2, 4, TOP_VISIBLE_TO_ALL);
+        deck2.add(DominionCard.create(CardType.COPPER));
+        deck2.add(deck);
+        for (int p = 0; p < 4; p++) {
+            assertTrue(deck2.isComponentVisible(0, p));
+            assertFalse(deck2.isComponentVisible(1, p));
+            assertFalse(deck2.isComponentVisible(2, p));
+            assertTrue(deck2.isComponentVisible(3, p));
+        }
+
+        deck2.shuffle(rnd);
+        for (int p = 0; p < 4; p++) {
+            assertTrue(deck2.isComponentVisible(0, p));
+            assertFalse(deck2.isComponentVisible(1, p));
+            assertFalse(deck2.isComponentVisible(2, p));
+            assertFalse(deck2.isComponentVisible(3, p));
+        }
+    }
+
+
+    @Test
+    public void setVisibilityModeToTopAfterCreatingDeck() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, HIDDEN_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.setVisibility(CoreConstants.VisibilityMode.TOP_VISIBLE_TO_ALL);
+        for (int p = 0; p < 4; p++) {
+            assertTrue(deck.isComponentVisible(0, p));
+            assertFalse(deck.isComponentVisible(1, p));
+            assertFalse(deck.isComponentVisible(2, p));
+            assertFalse(deck.isComponentVisible(3, p));
+        }
+    }
+
+
+    @Test
+    public void reshuffleTopDeckWithBottomDeck() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.BOTTOM_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+
+        PartialObservableDeck<DominionCard> deck2 = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
+        deck2.add(DominionCard.create(CardType.MERCHANT));
+        deck2.add(DominionCard.create(CardType.GOLD));
+        deck2.add(DominionCard.create(CardType.SILVER));
+        deck2.setVisibility(CoreConstants.VisibilityMode.TOP_VISIBLE_TO_ALL);  // SILVER
+
+        deck.add(deck2);  // should put deck2 on top of deck
+        assertEquals(CardType.SILVER, deck.get(0).cardType());  // top
+        assertEquals(CardType.COPPER, deck.get(5).cardType());  // bottom
+        for (int p = 0; p < 4; p++) {
+            assertTrue(deck.isComponentVisible(0, p));
+            assertFalse(deck.isComponentVisible(1, p));
+            assertFalse(deck.isComponentVisible(2, p));
+            assertFalse(deck.isComponentVisible(3, p));
+            assertFalse(deck.isComponentVisible(4, p));
+            assertTrue(deck.isComponentVisible(5, p));
+        }
+
+        deck.redeterminiseUnknown(rnd, 1);
+        assertEquals(CardType.SILVER, deck.get(0).cardType());
+        assertFalse(deck.get(1).cardType() == CardType.GOLD &&
+                deck.get(2).cardType() == CardType.MERCHANT &&
+                deck.get(3).cardType() == CardType.SMITHY &&
+                deck.get(4).cardType() == CardType.MILITIA);
+        assertEquals(CardType.COPPER, deck.get(5).cardType());
+        for (int p = 0; p < 4; p++) {
+            assertTrue(deck.isComponentVisible(0, p));
+            assertFalse(deck.isComponentVisible(1, p));
+            assertFalse(deck.isComponentVisible(2, p));
+            assertFalse(deck.isComponentVisible(3, p));
+            assertFalse(deck.isComponentVisible(4, p));
+            assertTrue(deck.isComponentVisible(5, p));
+        }
+    }
+
+
+    @Test
+    public void reshuffleSingleDeckWithPerspective() {
+        PartialObservableDeck<DominionCard> deck2 = new PartialObservableDeck<>("Test", 2, 4, CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
+        deck2.add(DominionCard.create(CardType.MERCHANT));
+        deck2.setVisibilityOfComponent(0, new boolean[]{true, false, true, false});
+        deck2.add(DominionCard.create(CardType.GOLD));
+        deck2.setVisibilityOfComponent(0, new boolean[]{true, false, false, false});
+        deck2.add(DominionCard.create(CardType.SILVER));
+        deck2.add(DominionCard.create(CardType.COPPER));
+        deck2.setVisibilityOfComponent(0, new boolean[]{false, true, false, false});
+        deck2.add(DominionCard.create(CardType.MILITIA));
+        deck2.add(DominionCard.create(CardType.SMITHY));
+
+        deck2.redeterminiseUnknown(rnd, 0);
+        assertEquals(CardType.MERCHANT, deck2.get(5).cardType());
+        assertArrayEquals(new boolean[]{true, false, true, false}, deck2.getVisibilityOfComponent(5));
+        assertEquals(CardType.GOLD, deck2.get(4).cardType());
+        assertArrayEquals(new boolean[]{true, false, false, false}, deck2.getVisibilityOfComponent(4));
+        assertArrayEquals(new boolean[]{false, false, false, false}, deck2.getVisibilityOfComponent(3));
+        assertArrayEquals(new boolean[]{false, true, false, false}, deck2.getVisibilityOfComponent(2));
+
+        deck2.redeterminiseUnknown(rnd, 2);
+        assertEquals(CardType.MERCHANT, deck2.get(5).cardType());
+        assertArrayEquals(new boolean[]{true, false, true, false}, deck2.getVisibilityOfComponent(5));
+        assertArrayEquals(new boolean[]{true, false, false, false}, deck2.getVisibilityOfComponent(4));
+        assertNotEquals(CardType.GOLD, deck2.get(4).cardType());
+        assertNotEquals(CardType.SILVER, deck2.get(3).cardType());
+        CardType card2 = deck2.get(2).cardType(); // the one that player 1 knows
+        CardType card3 = deck2.get(3).cardType(); // the one that player 1 does not know
+
+        deck2.redeterminiseUnknown(rnd, 1);
+        assertEquals(card2, deck2.get(2).cardType());
+        assertNotEquals(card3, deck2.get(3).cardType());
+        // visibility is tracked, even if the actual cards aren't
+        assertArrayEquals(new boolean[]{false, true, false, false}, deck2.getVisibilityOfComponent(2));
+        assertArrayEquals(new boolean[]{true, false, true, false}, deck2.getVisibilityOfComponent(5));
+
+    }
+
+    @Test
+    public void reshuffleTwoDecks() {
+        Deck<DominionCard> deck = new Deck<>("Test", 2, TOP_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.shuffle(rnd);  // so that only the top card is visible
+        CardType top1 = deck.get(0).cardType();
+        CardType next1 = deck.get(1).cardType();
+
+        Deck<DominionCard> deck2 = new Deck<>("Test", 2, TOP_VISIBLE_TO_ALL);
+        deck2.add(DominionCard.create(CardType.GOLD));
+        deck2.add(DominionCard.create(CardType.MERCHANT));
+        deck2.add(DominionCard.create(CardType.SILVER));
+        deck2.add(DominionCard.create(CardType.WORKSHOP));
+        deck2.shuffle(rnd);  // so that only the top card is visible
+        CardType top2 = deck2.get(0).cardType();
+        CardType next2 = deck2.get(1).cardType();
+
+        // reshuffle everything (all players are the same here)
+        DeterminisationUtilities.reshuffle(2, List.of(deck, deck2), c -> true, rnd);
+        assertEquals(top1, deck.get(0).cardType());
+        assertEquals(top2, deck2.get(0).cardType());
+        assertNotEquals(next1, deck.get(1).cardType());
+        assertNotEquals(next2, deck2.get(1).cardType());
+    }
+
+    @Test
+    public void shuffleDeckAndPartialObservableDeck() {
+        PartialObservableDeck<DominionCard> deck = new PartialObservableDeck<>("Test", 2, 4, TOP_VISIBLE_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.shuffle(rnd);  // so that only the top card is visible
+        deck.setVisibilityOfComponent(1, 2, true);
+        CardType card0 = deck.get(0).cardType();
+        CardType card1 = deck.get(1).cardType();
+        CardType card2 = deck.get(2).cardType();
+
+        Deck<DominionCard> deck2 = new Deck<>("Test", 2, TOP_VISIBLE_TO_ALL);
+        deck2.add(DominionCard.create(CardType.GOLD));
+        deck2.add(DominionCard.create(CardType.MERCHANT));
+        deck2.add(DominionCard.create(CardType.SILVER));
+        deck2.add(DominionCard.create(CardType.WORKSHOP));
+        deck2.shuffle(rnd);  // so that only the top card is visible
+        CardType card0_2 = deck2.get(0).cardType();
+        CardType card1_2 = deck2.get(1).cardType();
+
+        assertEquals(card0, deck.get(0).cardType());
+        assertEquals(card0_2, deck2.get(0).cardType());
+        List<CardType> deckCard2 = new ArrayList<>();
+        List<CardType> deck2Card1 = new ArrayList<>();
+        for (int i = 0; i < 10; i++) {
+            DeterminisationUtilities.reshuffle(2, List.of(deck, deck2), c -> true, rnd);
+            assertEquals(card0, deck.get(0).cardType());
+            assertEquals(card0_2, deck2.get(0).cardType());
+            assertEquals(card1, deck.get(1).cardType());
+            assertArrayEquals(new boolean[]{false, false, true, false}, deck.getVisibilityOfComponent(1));
+            assertArrayEquals(new boolean[]{true, true, true, true}, deck.getVisibilityOfComponent(0));
+            assertArrayEquals(new boolean[]{false, false, false, false}, deck.getVisibilityOfComponent(2));
+            deckCard2.add(deck.get(2).cardType());
+            deck2Card1.add(deck2.get(1).cardType());
+        }
+        // some shuffles will have the same card in the same position; but should be 3 or less in each case of the 10 shuffles
+        assertEquals(1, deckCard2.stream().filter(c -> c == card2).count(), 2);
+        assertEquals(1, deck2Card1.stream().filter(c -> c == card1_2).count(), 2);
+    }
+
+    @Test
+    public void shuffleTwoDecksWithPredicate() {
+        Deck<DominionCard> deck = new Deck<>("Test", 2, HIDDEN_TO_ALL);
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.add(DominionCard.create(CardType.MILITIA));
+        deck.add(DominionCard.create(CardType.SMITHY));
+        deck.add(DominionCard.create(CardType.COPPER));
+        deck.shuffle(rnd);  // so that only the top card is visible
+        Deck<DominionCard> deckCopy = deck.copy();
+
+        Deck<DominionCard> deck2 = new Deck<>("Test", 2, HIDDEN_TO_ALL);
+        deck2.add(DominionCard.create(CardType.GOLD));
+        deck2.add(DominionCard.create(CardType.MERCHANT));
+        deck2.add(DominionCard.create(CardType.SILVER));
+        deck2.add(DominionCard.create(CardType.WORKSHOP));
+        deck2.shuffle(rnd);  // so that only the top card is visible
+        Deck<DominionCard> deck2Copy = deck2.copy();
+
+        int[] nonShuffledCount = new int[2];
+
+        // reshuffle everything (all players are the same here)
+        for (int i = 0; i < 10; i++) {
+            DeterminisationUtilities.reshuffle(2, List.of(deck, deck2), c -> c.cardType() != CardType.COPPER, rnd);
+            // now go through both decks, and check COPPER in same position as in copy
+            // and track the count of other cards in the same position
+            for (int j = 0; j < 4; j++) {
+                if (deck.get(j).cardType() == CardType.COPPER) {
+                    assertEquals(deckCopy.get(j).cardType(), deck.get(j).cardType());
+                } else {
+                    nonShuffledCount[0] += (deckCopy.get(j).cardType() == deck.get(j).cardType()) ? 1 : 0;
+                }
+                // No COPPER in deck2
+                nonShuffledCount[1] += (deck2Copy.get(j).cardType() == deck2.get(j).cardType()) ? 1 : 0;
+            }
+        }
+        // 6 non-COPPER, so 1 in 6 shuffles will leave any given card unchanged
+        assertEquals(3, nonShuffledCount[0], 3); // 2 cards, so expect 20/6 = 3
+        assertEquals(7, nonShuffledCount[1], 3); // 4 cards, so expect 40/6 = 7
+    }
+}

--- a/src/test/java/evaluation/MCTSSearch_MASTRollout.json
+++ b/src/test/java/evaluation/MCTSSearch_MASTRollout.json
@@ -11,7 +11,6 @@
         "opponentTreePolicy" : ["OneTree", "MultiTree", "SelfOnly"],
         "rolloutType" : "MAST",
         "oppModelType" : ["RANDOM", "MAST"],
-        "expansionPolicy" : "RANDOM",
         "MAST" : ["Tree", "Rollout", "Both"],
         "MASTGamma" : [0.0, 0.5, 0.9, 1.0],
         "MASTDefaultValue" : [-100.0, -10.0, 0.0, 10.0, 100.0],

--- a/src/test/java/evaluation/MCTSSearch_PR_RolloutPolicy.json
+++ b/src/test/java/evaluation/MCTSSearch_PR_RolloutPolicy.json
@@ -11,7 +11,6 @@
     1000
   ],
   "maxTreeDepth": 100,
-  "expansionPolicy": "RANDOM",
   "rolloutType": "PARAMS",
   "rolloutPolicyParams": {
     "class": "players.simple.BoltzmannActionParams",

--- a/src/test/java/evaluation/TunableParametersTest.java
+++ b/src/test/java/evaluation/TunableParametersTest.java
@@ -166,11 +166,21 @@ public class TunableParametersTest {
         params.setParameterValue("maxTreeDepth", 67);
 
         JSONObject json = params.instanceToJSON(false);
+        assertEquals(0.56, params.getParameterValue("rolloutPolicyParams.temperature"));
+
+        MCTSParams noChange = (MCTSParams) params.instanceFromJSON(json);
+        assertTrue(params.allParametersAndValuesEqual(noChange));
+
         assertEquals(67, json.get("maxTreeDepth"));
+        assertEquals(0.56, params.getParameterValue("rolloutPolicyParams.temperature"));
         assertEquals(0.56, ((JSONObject) json.get("rolloutPolicyParams")).get("temperature"));
         assertEquals(Math.sqrt(2), (Double) json.get("K"), 0.002);
         assertEquals(false, json.get("useMASTAsActionHeuristic"));
         assertEquals("BUDGET_FM_CALLS", json.get("budgetType"));
+
+        assertEquals(MCTSParams.class, params.instanceFromJSON(json).getClass());
+        MCTSParams fromJSON = (MCTSParams) params.instanceFromJSON(json);
+        assertTrue(fromJSON.allParametersAndValuesEqual(noChange));
     }
 
     @Test
@@ -180,11 +190,18 @@ public class TunableParametersTest {
         params.setParameterValue("budgetType", BUDGET_TIME);
 
         JSONObject json = params.instanceToJSON(true);
+
+        MCTSParams noChange = (MCTSParams) params.instanceFromJSON(json);
+        assertTrue(params.allParametersAndValuesEqual(noChange));
+
         assertEquals(67, json.get("maxTreeDepth"));
         assertEquals(0.56, ((JSONObject) json.get("rolloutPolicyParams")).get("temperature"));
         assertFalse(json.containsKey("K"));
         assertFalse(json.containsKey("useMASTAsActionHeuristic"));
         assertFalse(json.containsKey("selectionPolicy"));
         assertEquals("BUDGET_TIME", json.get("budgetType"));
+
+        MCTSParams fromJSON = (MCTSParams) params.instanceFromJSON(json);
+        assertTrue(fromJSON.allParametersAndValuesEqual(noChange));
     }
 }

--- a/src/test/java/evaluation/TunableParametersTest.java
+++ b/src/test/java/evaluation/TunableParametersTest.java
@@ -2,6 +2,7 @@ package evaluation;
 
 import evaluation.optimisation.ITPSearchSpace;
 import games.puertorico.PuertoRicoActionHeuristic001;
+import org.json.simple.JSONObject;
 import org.junit.Before;
 import org.junit.Test;
 import players.heuristics.CoarseTunableHeuristic;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static org.junit.Assert.*;
+import static players.PlayerConstants.BUDGET_TIME;
 import static players.heuristics.CoarseTunableHeuristic.HeuristicType.*;
 
 public class TunableParametersTest {
@@ -156,5 +158,33 @@ public class TunableParametersTest {
         MCTSParams copy = (MCTSParams) params.copy();
         assertNotEquals(startingSeed, copy.getRandomSeed());
         assertEquals(startingSeed, params.getRandomSeed());
+    }
+
+    @Test
+    public void toJSONWithDefaults() {
+        params.setParameterValue("rolloutPolicyParams", bap);
+        params.setParameterValue("maxTreeDepth", 67);
+
+        JSONObject json = params.instanceToJSON(false);
+        assertEquals(67, json.get("maxTreeDepth"));
+        assertEquals(0.56, ((JSONObject) json.get("rolloutPolicyParams")).get("temperature"));
+        assertEquals(Math.sqrt(2), (Double) json.get("K"), 0.002);
+        assertEquals(false, json.get("useMASTAsActionHeuristic"));
+        assertEquals("BUDGET_FM_CALLS", json.get("budgetType"));
+    }
+
+    @Test
+    public void toJSONWithoutDefaults() {
+        params.setParameterValue("rolloutPolicyParams", bap);
+        params.setParameterValue("maxTreeDepth", 67);
+        params.setParameterValue("budgetType", BUDGET_TIME);
+
+        JSONObject json = params.instanceToJSON(true);
+        assertEquals(67, json.get("maxTreeDepth"));
+        assertEquals(0.56, ((JSONObject) json.get("rolloutPolicyParams")).get("temperature"));
+        assertFalse(json.containsKey("K"));
+        assertFalse(json.containsKey("useMASTAsActionHeuristic"));
+        assertFalse(json.containsKey("selectionPolicy"));
+        assertEquals("BUDGET_TIME", json.get("budgetType"));
     }
 }

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -8,83 +8,83 @@ public class ForwardModelTestsWithMCTS {
 
     @Test
     public void testBattleLore() {
-        new ForwardModelTester("game=Battlelore", "nGames=1", "nPlayers=2", "agentToPlay=json\\players\\gameSpecific\\Battlelore.json");
+        new ForwardModelTester("game=Battlelore", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Battlelore.json");
     }
     @Test
     public void testCantStop() {
-         new ForwardModelTester("game=CantStop", "nGames=1", "nPlayers=3", "agentToPlay=json\\players\\gameSpecific\\CantStop.json");
+         new ForwardModelTester("game=CantStop", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\CantStop.json");
     }
     @Test
     public void testCatan() {
-        new ForwardModelTester("game=Catan", "nGames=1", "nPlayers=3", "agentToPlay=json\\players\\gameSpecific\\Catan.json");
+        new ForwardModelTester("game=Catan", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\Catan.json");
     }
     @Test
     public void testColtExpress() {
-         new ForwardModelTester("game=ColtExpress", "nGames=1", "nPlayers=3", "agentToPlay=json\\players\\gameSpecific\\ColtExpress_3P.json");
+         new ForwardModelTester("game=ColtExpress", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\ColtExpress_3P.json");
     }
     @Test
     public void testConnect4() {
-         new ForwardModelTester("game=Connect4", "nGames=1", "nPlayers=2", "agentToPlay=json\\players\\gameSpecific\\Connect4.json");
+         new ForwardModelTester("game=Connect4", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Connect4.json");
     }
     @Test
     public void testDiamant() {
-        new ForwardModelTester("game=Diamant", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\Diamant.json");
+        new ForwardModelTester("game=Diamant", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Diamant.json");
     }
     @Test
     public void testDominion() {
-       new ForwardModelTester("game=Dominion", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\Dominion.json");
+       new ForwardModelTester("game=Dominion", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Dominion.json");
     }
 
     @Test
     public void testDotsAndBoxes() {
-         new ForwardModelTester("game=DotsAndBoxes", "nGames=1", "nPlayers=2", "agentToPlay=json\\players\\gameSpecific\\DotsAndBoxes.json");
+         new ForwardModelTester("game=DotsAndBoxes", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\DotsAndBoxes.json");
     }
     @Test
     public void testExplodingKittens() {
-         new ForwardModelTester("game=ExplodingKittens", "nGames=1", "nPlayers=3", "agentToPlay=json\\players\\gameSpecific\\ExplodingKittens.json");
+         new ForwardModelTester("game=ExplodingKittens", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\ExplodingKittens.json");
     }
     @Test
     public void testLoveLetter() {
-        new ForwardModelTester("game=LoveLetter", "nGames=1", "nPlayers=3", "agentToPlay=json\\players\\gameSpecific\\LoveLetter.json");
+        new ForwardModelTester("game=LoveLetter", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\LoveLetter.json");
     }
 
     @Test
     public void testPoker() {
-        new ForwardModelTester("game=Poker", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\Poker.json");
+        new ForwardModelTester("game=Poker", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Poker_3+P.json");
     }
     @Test
     public void testStratego() {
-       new ForwardModelTester("game=Stratego", "nGames=1", "nPlayers=2", "agentToPlay=json\\players\\gameSpecific\\Stratego.json");
+       new ForwardModelTester("game=Stratego", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Stratego.json");
     }
     @Test
     public void testSushiGo() {
-        new ForwardModelTester("game=SushiGo", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=SushiGo", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
     }
 
     @Test
     public void testTicTacToe() {
-        new ForwardModelTester("game=TicTacToe", "nGames=1", "nPlayers=2", "agentToPlay=json\\players\\gameSpecific\\TicTacToe.json");
+        new ForwardModelTester("game=TicTacToe", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\TicTacToe.json");
     }
     @Test
     public void testUno() {
-       new ForwardModelTester("game=Uno", "nGames=1", "nPlayers=5", "agentToPlay=json\\players\\gameSpecific\\Virus.json");
+       new ForwardModelTester("game=Uno", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Virus.json");
     }
     @Test
     public void testResistance() {
-      new ForwardModelTester("game=Resistance", "nGames=1", "nPlayers=5", "agentToPlay=json\\players\\gameSpecific\\Dominion.json");
+      new ForwardModelTester("game=Resistance", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Dominion.json");
     }
     @Test
     public void testVirus() {
-       new ForwardModelTester("game=Virus", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\Virus.json");
+       new ForwardModelTester("game=Virus", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Virus.json");
     }
 
     @Test
     public void testSevenWonders() {
-       new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\SushiGo.json");
+       new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
     }
 
     @Test
     public void testHearts() {
-        new ForwardModelTester("game=Hearts", "nGames=1", "nPlayers=4", "agentToPlay=json\\players\\gameSpecific\\Poker.json");
+        new ForwardModelTester("game=Hearts", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Poker.json");
     }
 }

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -1,6 +1,7 @@
 package games.fmtester;
 
 import evaluation.ForwardModelTester;
+import games.catan.CatanParameters;
 import org.junit.Test;
 
 public class ForwardModelTestsWithMCTS {
@@ -17,6 +18,13 @@ public class ForwardModelTestsWithMCTS {
     @Test
     public void testCatan() {
         new ForwardModelTester("game=Catan", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\Catan.json");
+    }
+
+    @Test
+    public void testCatanNoTrading() {
+        CatanParameters cp = new CatanParameters();
+        cp.setParameterValue("tradingAllowed", false);
+        new ForwardModelTester(cp, "game=Catan", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\Catan.json");
     }
     @Test
     public void testColtExpress() {

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -85,6 +85,6 @@ public class ForwardModelTestsWithMCTS {
 
     @Test
     public void testHearts() {
-        new ForwardModelTester("game=Hearts", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Poker.json");
+        new ForwardModelTester("game=Hearts", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Poker_3+P.json");
     }
 }


### PR DESCRIPTION
Other than the Alpha-rank calculations, this is a general 'quality of life' PR to automate a few things that I have been doing manuaally rather too often.

**1) Alpha-Rank calculation**
Running a Tournament will now calculate the alpha-rank of the participating agents (with alpha of 30, which seems to be fair for most cases). Alpha-rank assigns a single value to each agent as an indicator of its quality (and they will always sum to 1, as they are the probability that that a specific strategy will be used based on a constructed markov chain). 
The advantage of the alpha-rank over sinple 'win rate' is that it takes account of intransitivities and the quality of the other agents. For example, an agent that is very good at beating weak agents can have an over-inflated win rate, which alpha-rank will allow for.

The alpha-rank results will be printed to System.out if verbose=true, and will be written to fiile along with the win rate summary if output is set.

For more details see Omidshafiei et al. "α-rank: Multi-agent evaluation by evolution", 2019 in Nature Communications. [Deepmind]

**2) Pretty printing of JSON agent files**
Parameter Search (and Skill Ladder) now generates a JSON file with the agent at each iteration as well as logging the settings. This saves vast amounts of time if you want to then use those directly in a tournament for example. 
A JSONUtils.prettyPrint() method has been added for general use.

**3) Skill Ladder converted to RunArgs** 

**4) budget added as a parameter for Tournament and ParameterSearch**
If provided this will will override the budget value set in the Agent JSON files. This avoids the need to edit/copy JSON files to run comparison tournaments at different budget levels. (if unset, then the default behaviour is unchanged)
[This does require the agent to implement the IAnyTiime interface, which both MCTS and RHEA do.]

**5) Error bounds logged by Tournament corrected** (I missed a rather critical square root).

**6) Catan changes.**
- Major bug fixed that means trading was not working (no Trading proposal would be accepted from certain players)
- CatanParameters converted to Tunable. 
- Parameter added to allow trading between players to be switched off (games then take a third of the time)
- Commented out most of the redeterminisation of Resource cards. This is because it did not take account of the information in open trading offers, and led to crashes when a player made an Offer that the recipient (after redeterminisatiion) thought was invalid. Given that Resource cards are mostly trackable (with a few exceptions), this seemed the safer approach than adding extra complexity to take Open Offers into account.

**7) EXP3 bug fix** (only affected the first visit to an EXP3 node)

**8) Mild refactor of PartialObservableDeck**, including the fix to a bug that meant shuffling a deck did not correctly update the visibility. Uniit tests added! [This was done for War of the Toads, but is of more general use]