### PR TITLE
Sushi Go fixes

### DIFF
--- a/src/main/java/games/coltexpress/ColtExpressForwardModel.java
+++ b/src/main/java/games/coltexpress/ColtExpressForwardModel.java
@@ -29,6 +29,7 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
         ColtExpressGameState cegs = (ColtExpressGameState) firstState;
         ColtExpressParameters cep = (ColtExpressParameters) firstState.getGameParameters();
         //       System.out.println("Game " + cegs.getGameID() + ", seed: " + cep.getRandomSeed() + ", rnd: " + cegs.getRnd().nextInt(10000));
+
         cegs.bulletsLeft = new int[cegs.getNPlayers()];
         cegs.playerCharacters = new HashMap<>();
         cegs.playerPlayingBelle = -1;
@@ -65,7 +66,7 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
                 }
             }
             cegs.playerDecks.add(playerCards);
-            playerCards.shuffle(cegs.getRnd());
+            playerCards.shuffle(cegs.playerHandRnd);
 
             Deck<ColtExpressCard> playerHand = new Deck<>("playerHand" + playerIndex, playerIndex, VisibilityMode.VISIBLE_TO_OWNER);
 
@@ -397,7 +398,7 @@ public class ColtExpressForwardModel extends StandardForwardModelWithTurnOrder {
             }
         }
 
-        if (actions.size() == 0)
+        if (actions.isEmpty())
             actions.add(new PunchAction(deckFromID, deckToID, cardIdx, -1, -1, -1,
                     null, -1, playerIsCheyenne));
     }

--- a/src/main/java/games/coltexpress/ColtExpressParameters.java
+++ b/src/main/java/games/coltexpress/ColtExpressParameters.java
@@ -33,6 +33,7 @@ public class ColtExpressParameters extends TunableParameters {
     public int initialCharacterShuffleSeed = -1;
     public int roundDeckShuffleSeed = -1;
     public int trainShuffleSeed = -1;
+    public int playerHandShuffleSeed = -1;
 
     // How many cards of each type are in a player's deck, total minimum nCardsInHand + nCardsInHandExtraDoc
     public HashMap<ColtExpressCard.CardType, Integer> cardCounts = new HashMap<ColtExpressCard.CardType, Integer>() {{
@@ -143,6 +144,7 @@ public class ColtExpressParameters extends TunableParameters {
         addTunableParameter("initialCharacterShuffleSeed", -1);
         addTunableParameter("roundDeckShuffleSeed", -1);
         addTunableParameter("trainShuffleSeed", -1);
+        addTunableParameter("playerHandShuffleSeed", -1);
     }
 
     @Override
@@ -160,6 +162,7 @@ public class ColtExpressParameters extends TunableParameters {
         initialCharacterShuffleSeed = (int) getParameterValue("initialCharacterShuffleSeed");
         roundDeckShuffleSeed = (int) getParameterValue("roundDeckShuffleSeed");
         trainShuffleSeed = (int) getParameterValue("trainShuffleSeed");
+        playerHandShuffleSeed = (int) getParameterValue("playerHandShuffleSeed");
     }
 
     @Override

--- a/src/main/java/games/sushigo/SGGameState.java
+++ b/src/main/java/games/sushigo/SGGameState.java
@@ -7,6 +7,7 @@ import core.interfaces.IStateFeatureJSON;
 import games.GameType;
 import games.sushigo.actions.ChooseCard;
 import games.sushigo.cards.SGCard;
+import games.wonders7.Wonders7GameParameters;
 import org.json.simple.JSONObject;
 import utilities.Pair;
 
@@ -109,7 +110,7 @@ public class SGGameState extends AbstractGameState {
 
             // Add player hands unseen back to the draw pile
             for (int p = 0; p < copy.playerHands.size(); p++) {
-                if (hasNotSeenHand(playerId, p)) {
+                if (!hasSeenHand(playerId, p)) {
                     copy.drawPile.add(playerHands.get(p));
                 }
             }
@@ -117,7 +118,7 @@ public class SGGameState extends AbstractGameState {
 
             // Now we draw into the unknown player hands
             for (int p = 0; p < copy.playerHands.size(); p++) {
-                if (hasNotSeenHand(playerId, p)) {
+                if (!hasSeenHand(playerId, p)) {
                     Deck<SGCard> hand = copy.playerHands.get(p);
                     int handSize = hand.getSize();
                     hand.clear();
@@ -150,12 +151,10 @@ public class SGGameState extends AbstractGameState {
      * @param opponentId - id of opponent owning the hand of cards we're checking vision of
      * @return - true if player has not seen the opponent's hand of cards, false otherwise
      */
-    public boolean hasNotSeenHand(int playerId, int opponentId) {
-        if (playerId == opponentId) return false;
-        int opponentSpacesToLeft = opponentId - playerId;
-        if (opponentSpacesToLeft < 0)
-            opponentSpacesToLeft = getNPlayers() + opponentSpacesToLeft;
-        return deckRotations < opponentSpacesToLeft;
+    public boolean hasSeenHand(int playerId, int opponentId) {
+        // Player 0 is one space to the 'Left' of player 1
+        int opponentSpacesToLeft = (playerId - opponentId + getNPlayers()) % getNPlayers();
+        return opponentSpacesToLeft <= deckRotations;
     }
 
     public Counter[] getPlayerScore() {

--- a/src/test/java/games/sushigo/shuffleTests.java
+++ b/src/test/java/games/sushigo/shuffleTests.java
@@ -1,0 +1,117 @@
+package games.sushigo;
+
+import core.actions.AbstractAction;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+
+public class shuffleTests {
+
+    SGForwardModel fm = new SGForwardModel();
+    SGParameters params;
+    SGGameState state;
+
+
+    @Before
+    public void setup() {
+        params = new SGParameters();
+        params.setRandomSeed(4902);
+        state = new SGGameState(params, 4);
+        fm.setup(state);
+    }
+
+
+    @Test
+    public void testRedeterminisationWithNoCardsKnown() {
+        // we copy the state of the game, and check that all the other players have shuffled hands
+        // and that we have the same one
+        SGGameState copy = (SGGameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(8, hand.getSize());
+            if (i == 2) {
+                // iterate over all cards
+                for (int j = 0; j < hand.getSize(); j++) {
+                    assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+                }
+            } else {
+                int identicalCount = 0;
+                for (int j = 0; j < hand.getSize(); j++) {
+                    if (copy.getPlayerHands().get(i).get(j).equals(state.getPlayerHands().get(i).get(j))) {
+                        identicalCount++;
+                    }
+                }
+                assertEquals(1, identicalCount, 1); // we'll allow up to 2 cards to be the same per hand; as long as most change
+            }
+        }
+
+    }
+
+    @Test
+    public void testRedeterminisationWithOneCardKnown() {
+        // we take one turn for each player, so that hands are passed on, and all players know all the cards in the hand of the player to their left
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.getTurnCounter() < 4);
+        SGGameState copy = (SGGameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(7, hand.getSize());
+            if (i == 2 || i == 1) {
+                // iterate over all cards
+                for (int j = 0; j < hand.getSize(); j++) {
+                    assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+                }
+            } else {
+                int identicalCount = 0;
+                for (int j = 0; j < hand.getSize(); j++) {
+                    if (copy.getPlayerHands().get(i).get(j).equals(state.getPlayerHands().get(i).get(j))) {
+                        identicalCount++;
+                    }
+                }
+                assertEquals(1, identicalCount, 1); // we'll allow up to 2 cards to be the same per hand; as long as most change
+            }
+        }
+    }
+
+    @Test
+    public void testRedeterminisationWithThreeCardsKnown() {
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.getTurnCounter() < 12);
+        SGGameState copy = (SGGameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(5, hand.getSize());
+            // iterate over all cards - we now know everything about the hands of all players (the unseen hand is known by elimination)
+            for (int j = 0; j < hand.getSize(); j++) {
+                assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+            }
+        }
+    }
+
+    @Test
+    public void cardsPassedClockwise() {
+        SGGameState copy = (SGGameState) state.copy(-1);
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.getTurnCounter() < 4);
+
+        // now check that player 0 has the old hand of player 1;
+        // and that player 3 has the old hand of player 0
+
+        int commonCount = copy.getPlayerHands().get(1).stream().filter(state.getPlayerHands().get(0)::contains).toArray().length;
+        assertEquals(7, commonCount);
+        commonCount = copy.getPlayerHands().get(0).stream().filter(state.getPlayerHands().get(3)::contains).toArray().length;
+        assertEquals(7, commonCount);
+
+    }
+
+}
+

--- a/src/test/java/games/wonders7/shuffleTests.java
+++ b/src/test/java/games/wonders7/shuffleTests.java
@@ -1,0 +1,156 @@
+package games.wonders7;
+
+import core.actions.AbstractAction;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.List;
+
+import static org.junit.Assert.*;
+
+public class shuffleTests {
+
+    Wonders7ForwardModel fm = new Wonders7ForwardModel();
+    Wonders7GameParameters params;
+    Wonders7GameState state;
+
+
+    @Before
+    public void setup() {
+        params = new Wonders7GameParameters();
+        params.setRandomSeed(4902);
+        state = new Wonders7GameState(params, 4);
+        fm.setup(state);
+    }
+
+
+    @Test
+    public void testRedeterminisationWithNoCardsKnown() {
+        // we copy the state of the game, and check that all the other players have shuffled hands
+        // and that we have the same one
+        Wonders7GameState copy = (Wonders7GameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(7, hand.getSize());
+            if (i == 2) {
+                // iterate over all cards
+                for (int j = 0; j < hand.getSize(); j++) {
+                    assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+                }
+            } else {
+                int identicalCount = 0;
+                for (int j = 0; j < hand.getSize(); j++) {
+                    if (copy.getPlayerHands().get(i).get(j).equals(state.getPlayerHands().get(i).get(j))) {
+                        identicalCount++;
+                    }
+                }
+                assertEquals(1, identicalCount, 1); // we'll allow up to 2 cards to be the same per hand; as long as most change
+            }
+        }
+
+    }
+
+    @Test
+    public void testRedeterminisationWithOneCardKnown() {
+        // we take one turn for each player, so that hands are passed on, and all players know all the cards in the hand of the player to their left
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.getTurnCounter() < 4);
+        Wonders7GameState copy = (Wonders7GameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(6, hand.getSize());
+            if (i == 2 || i == 1) {
+                // iterate over all cards
+                for (int j = 0; j < hand.getSize(); j++) {
+                    assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+                }
+            } else {
+                int identicalCount = 0;
+                for (int j = 0; j < hand.getSize(); j++) {
+                    if (copy.getPlayerHands().get(i).get(j).equals(state.getPlayerHands().get(i).get(j))) {
+                        identicalCount++;
+                    }
+                }
+                assertEquals(1, identicalCount, 1); // we'll allow up to 2 cards to be the same per hand; as long as most change
+            }
+        }
+    }
+
+
+    @Test
+    public void testRedeterminisationWithOneCardKnownReverseDirection() {
+        // we take one turn for each player, so that hands are passed on, and all players know all the cards in the hand of the player to their left
+        // first we move to the second age
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.getRoundCounter() == 0 || state.getPlayerHand(0).getSize() == 7);
+        assertEquals(-1, state.getDirection());
+        Wonders7GameState copy = (Wonders7GameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(6, hand.getSize());
+            if (i == 2 || i == 3) {
+                // iterate over all cards
+                for (int j = 0; j < hand.getSize(); j++) {
+                    assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+                }
+            } else {
+                int identicalCount = 0;
+                for (int j = 0; j < hand.getSize(); j++) {
+                    if (copy.getPlayerHands().get(i).get(j).equals(state.getPlayerHands().get(i).get(j))) {
+                        identicalCount++;
+                    }
+                }
+                assertEquals(1, identicalCount, 1); // we'll allow up to 2 cards to be the same per hand; as long as most change
+            }
+        }
+    }
+
+    @Test
+    public void testRedeterminisationWithAllCardsKnown() {
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.getTurnCounter() < 12);
+        Wonders7GameState copy = (Wonders7GameState) state.copy(2);
+        for (int i = 0; i < 4; i++) {
+            var hand = state.getPlayerHands().get(i);
+            assertEquals(4, hand.getSize());
+            for (int j = 0; j < hand.getSize(); j++) {
+                assertEquals(copy.getPlayerHands().get(i).get(j), state.getPlayerHands().get(i).get(j));
+            }
+        }
+    }
+
+    @Test
+    public void testPreviousActionsAreRemovedOnRedeterminisation() {
+        fm.next(state, fm.computeAvailableActions(state).get(0));
+        fm.next(state, fm.computeAvailableActions(state).get(0));
+        Wonders7GameState copy = (Wonders7GameState) state.copy(2);
+        // the copy should have no actions...
+        for (int i = 0; i < 4; i++) {
+            assertNull(copy.turnActions[i]);
+            if (i < 2) {
+                assertNotNull(state.turnActions[i]);
+            } else {
+                assertNull(state.turnActions[i]);
+            }
+        }
+        do {
+            // we then process the game on the copy, and check that each player plays one card
+            List<AbstractAction> availableActionsCopy = fm.computeAvailableActions(copy);
+            fm.next(copy, availableActionsCopy.get(copy.getRnd().nextInt(availableActionsCopy.size())));
+        } while (copy.playerHands.get(2).getSize() == 7);
+        // The turn counter is not reset (as it really should be on the copy...but this doesn't leak any information)
+        assertEquals(6, copy.getTurnCounter());
+        for (int i = 0; i < 4; i++) {
+            assertNull(copy.turnActions[i]);
+            assertEquals(6, copy.getPlayerHands().get(i).getSize());
+        }
+
+    }
+}
+


### PR DESCRIPTION
SushiGo Redeterminisation corrected
- Previously this kept hands 'known' in the wrong direction in SGGameState.copy(player) method.

This also fixes a Colt Express bug that never reshuffled players' hands between rounds.