### PR TITLE
AlphaBeta Search

### DIFF
--- a/src/main/java/core/actions/SetGridValueAction.java
+++ b/src/main/java/core/actions/SetGridValueAction.java
@@ -39,8 +39,7 @@ public class SetGridValueAction<T extends Component> extends AbstractAction impl
     @Override
     public boolean equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof SetGridValueAction)) return false;
-        SetGridValueAction<?> that = (SetGridValueAction<?>) o;
+        if (!(o instanceof SetGridValueAction<?> that)) return false;
         return gridBoard == that.gridBoard &&
                 x == that.x &&
                 y == that.y &&

--- a/src/main/java/players/mcts/ActionStats.java
+++ b/src/main/java/players/mcts/ActionStats.java
@@ -2,6 +2,7 @@ package players.mcts;
 
 import core.actions.AbstractAction;
 
+import javax.swing.*;
 import java.util.*;
 
 public class ActionStats {
@@ -24,6 +25,15 @@ public class ActionStats {
             squaredTotValue[i] += results[i] * results[i];
         }
         nVisits++;
+    }
+
+    public ActionStats copy() {
+        ActionStats newStats = new ActionStats(totValue.length);
+        newStats.nVisits = nVisits;
+        newStats.validVisits = validVisits;
+        System.arraycopy(totValue, 0, newStats.totValue, 0, totValue.length);
+        System.arraycopy(squaredTotValue, 0, newStats.squaredTotValue, 0, squaredTotValue.length);
+        return newStats;
     }
 
 }

--- a/src/main/java/players/search/MaxNSearchParameters.java
+++ b/src/main/java/players/search/MaxNSearchParameters.java
@@ -13,8 +13,9 @@ public class MaxNSearchParameters extends PlayerParameters {
 
     protected int searchDepth = 1;
     protected SearchUnit searchUnit = SearchUnit.ACTION;
-    protected IStateHeuristic heuristic;
+    protected IStateHeuristic heuristic = new GameDefaultHeuristic();
     protected boolean paranoid = false;
+    protected boolean alphaBetaPruning = true;
     protected boolean iterativeDeepening = false;
 
     public MaxNSearchParameters() {
@@ -23,6 +24,7 @@ public class MaxNSearchParameters extends PlayerParameters {
         this.addTunableParameter("heuristic", IStateHeuristic.class);
         this.addTunableParameter("paranoid", false);
         this.addTunableParameter("iterativeDeepening", false);
+        this.addTunableParameter("alphaBetaPruning", true);
     }
 
     @Override
@@ -33,6 +35,7 @@ public class MaxNSearchParameters extends PlayerParameters {
         heuristic = (IStateHeuristic) getParameterValue("heuristic");
         paranoid = (boolean) getParameterValue("paranoid");
         iterativeDeepening = (boolean) getParameterValue("iterativeDeepening");
+        alphaBetaPruning = (boolean) getParameterValue("alphaBetaPruning");
         if (heuristic == null) {
             heuristic = new GameDefaultHeuristic();
         }

--- a/src/main/java/players/search/MaxNSearchParameters.java
+++ b/src/main/java/players/search/MaxNSearchParameters.java
@@ -17,6 +17,7 @@ public class MaxNSearchParameters extends PlayerParameters {
     protected boolean paranoid = false;
     protected boolean alphaBetaPruning = true;
     protected boolean iterativeDeepening = false;
+    protected boolean expandByEstimatedValue = false;
 
     public MaxNSearchParameters() {
         this.addTunableParameter("searchDepth", 1);
@@ -25,6 +26,7 @@ public class MaxNSearchParameters extends PlayerParameters {
         this.addTunableParameter("paranoid", false);
         this.addTunableParameter("iterativeDeepening", false);
         this.addTunableParameter("alphaBetaPruning", true);
+        this.addTunableParameter("expandByEstimatedValue", false);
     }
 
     @Override
@@ -36,12 +38,17 @@ public class MaxNSearchParameters extends PlayerParameters {
         paranoid = (boolean) getParameterValue("paranoid");
         iterativeDeepening = (boolean) getParameterValue("iterativeDeepening");
         alphaBetaPruning = (boolean) getParameterValue("alphaBetaPruning");
+        expandByEstimatedValue = (boolean) getParameterValue("expandByEstimatedValue");
         if (heuristic == null) {
             heuristic = new GameDefaultHeuristic();
         }
         if (budgetType != PlayerConstants.BUDGET_TIME) {
             System.out.println("Warning: SearchPlayer only supports time-based budget limits. Setting to BUDGET_TIME.");
             budgetType = PlayerConstants.BUDGET_TIME;
+        }
+        if (expandByEstimatedValue && !alphaBetaPruning) {
+            System.out.println("Warning: expandByEstimatedValue only makes sense with alphaBetaPruning. Disabling expandByEstimatedValue.");
+            expandByEstimatedValue = false;
         }
     }
 

--- a/src/main/java/players/search/MaxNSearchParameters.java
+++ b/src/main/java/players/search/MaxNSearchParameters.java
@@ -7,7 +7,7 @@ import players.heuristics.GameDefaultHeuristic;
 
 public class MaxNSearchParameters extends PlayerParameters {
 
-    enum SearchUnit {
+    public enum SearchUnit {
         ACTION, MACRO_ACTION, TURN
     }
 
@@ -15,12 +15,14 @@ public class MaxNSearchParameters extends PlayerParameters {
     protected SearchUnit searchUnit = SearchUnit.ACTION;
     protected IStateHeuristic heuristic;
     protected boolean paranoid = false;
+    protected boolean iterativeDeepening = false;
 
     public MaxNSearchParameters() {
         this.addTunableParameter("searchDepth", 1);
         this.addTunableParameter("searchUnit", SearchUnit.ACTION);
         this.addTunableParameter("heuristic", IStateHeuristic.class);
         this.addTunableParameter("paranoid", false);
+        this.addTunableParameter("iterativeDeepening", false);
     }
 
     @Override
@@ -30,6 +32,7 @@ public class MaxNSearchParameters extends PlayerParameters {
         searchUnit = (SearchUnit) getParameterValue("searchUnit");
         heuristic = (IStateHeuristic) getParameterValue("heuristic");
         paranoid = (boolean) getParameterValue("paranoid");
+        iterativeDeepening = (boolean) getParameterValue("iterativeDeepening");
         if (heuristic == null) {
             heuristic = new GameDefaultHeuristic();
         }

--- a/src/main/java/players/search/MaxNSearchPlayer.java
+++ b/src/main/java/players/search/MaxNSearchPlayer.java
@@ -50,7 +50,16 @@ public class MaxNSearchPlayer extends AbstractPlayer {
         // - MACRO_ACTION: only when the currentPlayer() has changed as a result of applying the action
         // - TURN: only when turn number has changed as a result of applying the action
         startTime = System.currentTimeMillis();
-        return expand(gs, actions, getParameters().searchDepth).action;
+        if (getParameters().iterativeDeepening) {
+            // we do a depth D = 1 search, then D = 2 and so on until we reach maxDepth or exhaust budget
+            SearchResult bestResult = null;
+            for (int depth = 1; depth <= getParameters().searchDepth; depth++) {
+                bestResult = expand(gs, actions, depth);
+            }
+            return bestResult == null ? null : bestResult.action;
+        } else {
+            return expand(gs, actions, getParameters().searchDepth).action;
+        }
     }
 
     /**
@@ -107,7 +116,7 @@ public class MaxNSearchPlayer extends AbstractPlayer {
             SearchResult result = expand(stateCopy, nextActions, newDepth);
 
             // we make the decision based on the actor at state, not the actor at stateCopy
-            if (result.value[state.getCurrentPlayer()]  > bestValue) {
+            if (result.value[state.getCurrentPlayer()] > bestValue) {
                 bestAction = action;
                 bestValues = result.value;
                 bestValue = bestValues[state.getCurrentPlayer()];

--- a/src/main/java/players/search/MaxNSearchPlayer.java
+++ b/src/main/java/players/search/MaxNSearchPlayer.java
@@ -3,7 +3,6 @@ package players.search;
 import core.*;
 import core.actions.AbstractAction;
 
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -34,6 +33,7 @@ public class MaxNSearchPlayer extends AbstractPlayer {
 
 
     private long startTime;
+    private SearchResult rootResult;
 
     public MaxNSearchPlayer(MaxNSearchParameters parameters) {
         super(parameters, "MinMaxSearch");
@@ -44,7 +44,6 @@ public class MaxNSearchPlayer extends AbstractPlayer {
         return (MaxNSearchParameters) this.parameters;
     }
 
-    // TODO: alpha-beta pruning if paranoid
     // TODO: Use information from iterative deepening to improve the expansion order
 
     @Override
@@ -55,17 +54,21 @@ public class MaxNSearchPlayer extends AbstractPlayer {
         // - MACRO_ACTION: only when the currentPlayer() has changed as a result of applying the action
         // - TURN: only when turn number has changed as a result of applying the action
         startTime = System.currentTimeMillis();
+        rootResult = null;
         if (getParameters().iterativeDeepening) {
             // we do a depth D = 1 search, then D = 2 and so on until we reach maxDepth or exhaust budget
-            SearchResult bestResult = null;
             for (int depth = 1; depth <= getParameters().searchDepth; depth++) {
-                bestResult = expand(gs, actions, depth, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
+                rootResult = expand(gs, actions, depth, Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
             }
-            return bestResult == null ? null : bestResult.action;
         } else {
-            return expand(gs, actions, getParameters().searchDepth,
-                    Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY).action;
+            rootResult = expand(gs, actions, getParameters().searchDepth,
+                    Double.NEGATIVE_INFINITY, Double.POSITIVE_INFINITY);
         }
+        return rootResult == null ? null : rootResult.action;
+    }
+
+    public SearchResult getRootResult() {
+        return rootResult;
     }
 
     /**

--- a/src/main/java/players/search/MaxNSearchPlayer.java
+++ b/src/main/java/players/search/MaxNSearchPlayer.java
@@ -42,6 +42,10 @@ public class MaxNSearchPlayer extends AbstractPlayer {
         return (MaxNSearchParameters) this.parameters;
     }
 
+    // TODO: alpha-beta pruning if paranoid
+    // TODO: Use information from iterative deepening to improve the expansion order
+    // TODO: Store the best action so far, in case we run out of budget
+
     @Override
     public AbstractAction _getAction(AbstractGameState gs, List<AbstractAction> actions) {
         // For each action we copy the state and recursively call the expand method
@@ -69,10 +73,6 @@ public class MaxNSearchPlayer extends AbstractPlayer {
      */
     protected SearchResult expand(AbstractGameState state, List<AbstractAction> actions, int searchDepth) {
         MaxNSearchParameters params = getParameters();
-        if (System.currentTimeMillis() - startTime > params.budget) {
-            // out of time - return null action and a vector of zeros
-            return new SearchResult(null, new double[state.getNPlayers()]);
-        }
         // if we have reached the end of the search, or the state is terminal, we evaluate the state
         if (searchDepth == 0 || !state.isNotTerminal()) {
             // when valuing a state, we need to record the full vector of values for each player
@@ -120,6 +120,11 @@ public class MaxNSearchPlayer extends AbstractPlayer {
                 bestAction = action;
                 bestValues = result.value;
                 bestValue = bestValues[state.getCurrentPlayer()];
+            }
+
+            if (System.currentTimeMillis() - startTime > params.budget) {
+                // out of time - return best action so far
+                return new SearchResult(bestAction, bestValues);
             }
         }
         if (bestAction == null) {

--- a/src/main/java/players/search/MaxNSearchPlayer.java
+++ b/src/main/java/players/search/MaxNSearchPlayer.java
@@ -3,6 +3,7 @@ package players.search;
 import core.*;
 import core.actions.AbstractAction;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -94,8 +95,8 @@ public class MaxNSearchPlayer extends AbstractPlayer {
         }
 
         // otherwise we recurse to find the best action and value
-        double bestValue = Double.NEGATIVE_INFINITY;
         double[] bestValues = new double[state.getNPlayers()];
+        Arrays.fill(bestValues, Double.NEGATIVE_INFINITY);
         AbstractAction bestAction = null;
         // we shuffle the actions so that ties are broken at random
         Collections.shuffle(actions, getRnd());
@@ -117,24 +118,23 @@ public class MaxNSearchPlayer extends AbstractPlayer {
             SearchResult result = expand(stateCopy, nextActions, newDepth, alpha, beta);
 
             // we make the decision based on the actor at state, not the actor at stateCopy
-            if (result.value[state.getCurrentPlayer()] > bestValue) {
+            if (result.value[state.getCurrentPlayer()] > bestValues[state.getCurrentPlayer()]) {
                 bestAction = action;
                 bestValues = result.value;
-                bestValue = bestValues[state.getCurrentPlayer()];
             }
-            if (params.paranoid) {
+            if (params.paranoid && params.alphaBetaPruning) {
                 // alpha-beta pruning
                 // bestValue is already from the perspective of the current player (i.e. negated for opponents)
                 if (getPlayerID() == state.getCurrentPlayer()) {
-                    if (bestValue >= beta) {
+                    if (bestValues[state.getCurrentPlayer()] > beta) {
                         return new SearchResult(bestAction, bestValues, alpha, beta);
                     }
-                    alpha = Math.max(alpha, bestValue);
+                    alpha = Math.max(alpha, bestValues[state.getCurrentPlayer()]);
                 } else {
-                    if (bestValue <= alpha) {
+                    if (-bestValues[state.getCurrentPlayer()] < alpha) {
                         return new SearchResult(bestAction, bestValues, alpha, beta);
                     }
-                    beta = Math.min(beta, bestValue);
+                    beta = Math.min(beta, -bestValues[state.getCurrentPlayer()]);
                 }
             }
 

--- a/src/test/java/players/search/AlphaBetaPruningTests.java
+++ b/src/test/java/players/search/AlphaBetaPruningTests.java
@@ -29,6 +29,7 @@ public class AlphaBetaPruningTests {
         paramsOne.alphaBetaPruning = false;
         paramsOne.paranoid = true;
         paramsOne.searchDepth = 4;
+        paramsOne.setRandomSeed(89);
         AbstractPlayer player1 = new MaxNSearchPlayer(paramsOne);
         player1.setForwardModel(forwardModel);
 
@@ -37,6 +38,7 @@ public class AlphaBetaPruningTests {
         paramsTwo.alphaBetaPruning = true;
         paramsTwo.paranoid = true;
         paramsTwo.searchDepth = 4;
+        paramsTwo.setRandomSeed(89);
         AbstractPlayer player2 = new MaxNSearchPlayer(paramsTwo);
         player2.setForwardModel(forwardModel);
 

--- a/src/test/java/players/search/AlphaBetaPruningTests.java
+++ b/src/test/java/players/search/AlphaBetaPruningTests.java
@@ -11,9 +11,10 @@ import static org.junit.Assert.*;
 
 public class AlphaBetaPruningTests {
 
-    @Test
-    public void connect4SameMoveAndTimings() {
+    Connect4ForwardModel forwardModel = new Connect4ForwardModel();
 
+    @Test
+    public void connect4AlphaBeta() {
         // the intention here is to run a game of Connect4 from start to finish and confirm that
         // two MaxNSearchPlayer with alphaBetaPruning set to true and false respectively will make the same moves
         // (or moves which have identical values with fixed depth search)
@@ -21,26 +22,126 @@ public class AlphaBetaPruningTests {
 
         // create a game of Connect4
         Connect4GameState gameState = new Connect4GameState(new Connect4GameParameters(), 2);
-        Connect4ForwardModel forwardModel = new Connect4ForwardModel();
         forwardModel.setup(gameState);
 
         // create a MaxNSearchPlayer with alphaBetaPruning set to false
         MaxNSearchParameters paramsOne = new MaxNSearchParameters();
         paramsOne.alphaBetaPruning = false;
+        paramsOne.budget = 1000;
         paramsOne.paranoid = true;
         paramsOne.searchDepth = 4;
-        paramsOne.setRandomSeed(89);
         MaxNSearchPlayer player1 = new MaxNSearchPlayer(paramsOne);
         player1.setForwardModel(forwardModel);
 
         // create a MaxNSearchPlayer with alphaBetaPruning set to true
         MaxNSearchParameters paramsTwo = new MaxNSearchParameters();
         paramsTwo.alphaBetaPruning = true;
+        paramsTwo.budget = 1000;
         paramsTwo.paranoid = true;
         paramsTwo.searchDepth = 4;
-        paramsTwo.setRandomSeed(89);
         MaxNSearchPlayer player2 = new MaxNSearchPlayer(paramsTwo);
         player2.setForwardModel(forwardModel);
+
+        runGame(gameState, player1, player2);
+    }
+
+
+    @Test
+    public void connect4IterativeDeepening() {
+        // and with the base agent against iterative deepening
+
+        // create a game of Connect4
+        Connect4GameState gameState = new Connect4GameState(new Connect4GameParameters(), 2);
+        forwardModel.setup(gameState);
+
+        // create a MaxNSearchPlayer with iterativeDeepening set to true
+        MaxNSearchParameters paramsOne = new MaxNSearchParameters();
+        paramsOne.iterativeDeepening = true;
+        paramsOne.budget = 1000;
+        paramsOne.paranoid = false;
+        paramsOne.searchDepth = 4;
+        MaxNSearchPlayer player1 = new MaxNSearchPlayer(paramsOne);
+        player1.setForwardModel(forwardModel);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to true
+        MaxNSearchParameters paramsTwo = new MaxNSearchParameters();
+        paramsOne.iterativeDeepening = false;
+        paramsTwo.budget = 1000;
+        paramsTwo.paranoid = false;
+        paramsTwo.searchDepth = 4;
+        MaxNSearchPlayer player2 = new MaxNSearchPlayer(paramsTwo);
+        player2.setForwardModel(forwardModel);
+
+        runGame(gameState, player1, player2);
+    }
+
+    @Test
+    public void connect4NonRandomExpansionOrder() {
+        // and now with move expansion broken by value function (with alphaBetaPruning)
+
+        // create a game of Connect4
+        Connect4GameState gameState = new Connect4GameState(new Connect4GameParameters(), 2);
+        forwardModel.setup(gameState);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to false
+        MaxNSearchParameters paramsOne = new MaxNSearchParameters();
+        paramsOne.alphaBetaPruning = true;
+        paramsOne.expandByEstimatedValue = false;
+        paramsOne.budget = 1000;
+        paramsOne.paranoid = true;
+        paramsOne.searchDepth = 4;
+        MaxNSearchPlayer player1 = new MaxNSearchPlayer(paramsOne);
+        player1.setForwardModel(forwardModel);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to true
+        MaxNSearchParameters paramsTwo = new MaxNSearchParameters();
+        paramsTwo.alphaBetaPruning = true;
+        paramsTwo.budget = 1000;
+        paramsTwo.expandByEstimatedValue = true;
+        paramsTwo.paranoid = true;
+        paramsTwo.searchDepth = 4;
+        MaxNSearchPlayer player2 = new MaxNSearchPlayer(paramsTwo);
+        player2.setForwardModel(forwardModel);
+
+        runGame(gameState, player1, player2);
+    }
+
+    @Test
+    public void connect4IterativeNonRandomExpansionOrder() {
+        // iterative deepening with non-random expansion order
+
+        // create a game of Connect4
+        Connect4GameState gameState = new Connect4GameState(new Connect4GameParameters(), 2);
+        forwardModel.setup(gameState);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to false
+        MaxNSearchParameters paramsOne = new MaxNSearchParameters();
+        paramsOne.iterativeDeepening = true;
+        paramsOne.alphaBetaPruning = true;
+        paramsOne.budget = 1000;
+        paramsOne.expandByEstimatedValue = false;
+        paramsOne.paranoid = true;
+        paramsOne.searchDepth = 4;
+        MaxNSearchPlayer player1 = new MaxNSearchPlayer(paramsOne);
+        player1.setForwardModel(forwardModel);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to true
+        MaxNSearchParameters paramsTwo = new MaxNSearchParameters();
+        paramsTwo.iterativeDeepening = true;
+        paramsTwo.alphaBetaPruning = true;
+        paramsTwo.budget = 1000;
+        paramsTwo.expandByEstimatedValue = true;
+        paramsTwo.paranoid = true;
+        paramsTwo.searchDepth = 4;
+        MaxNSearchPlayer player2 = new MaxNSearchPlayer(paramsTwo);
+        player2.setForwardModel(forwardModel);
+
+        runGame(gameState, player1, player2);
+    }
+
+
+    // should be called so that the expected faster agent is player2
+    private void runGame(Connect4GameState gameState, MaxNSearchPlayer player1, MaxNSearchPlayer player2) {
 
         long playerOneTime = 0;
         long playerTwoTime = 0;
@@ -54,8 +155,8 @@ public class AlphaBetaPruningTests {
             AbstractAction actionTwo = player2.getAction(gameState, forwardModel.computeAvailableActions(gameState));
             long timeTwo = System.currentTimeMillis() - start - timeOne;
 
-            System.out.println("Player 1 : " + actionOne.toString() + "\tPlayer 2 : " + actionTwo.toString());
-            System.out.println("Player 1 took " + timeOne + "ms, Player 2 took " + timeTwo + "ms");
+     //       System.out.println("Player 1 : " + actionOne.toString() + "\tPlayer 2 : " + actionTwo.toString());
+     //       System.out.println("Player 1 took " + timeOne + "ms, Player 2 took " + timeTwo + "ms");
             //    assertTrue(timeOne > timeTwo);
             totalActions++;
             if (actionOne.equals(actionTwo))

--- a/src/test/java/players/search/AlphaBetaPruningTests.java
+++ b/src/test/java/players/search/AlphaBetaPruningTests.java
@@ -6,6 +6,8 @@ import games.connect4.Connect4ForwardModel;
 import games.connect4.Connect4GameParameters;
 import games.connect4.Connect4GameState;
 import org.junit.Test;
+import players.PlayerConstants;
+import players.search.MaxNSearchPlayer.SearchResult;
 
 import static org.junit.Assert.*;
 
@@ -27,7 +29,8 @@ public class AlphaBetaPruningTests {
         // create a MaxNSearchPlayer with alphaBetaPruning set to false
         MaxNSearchParameters paramsOne = new MaxNSearchParameters();
         paramsOne.alphaBetaPruning = false;
-        paramsOne.budget = 1000;
+        paramsOne.budget = Integer.MAX_VALUE;
+        paramsOne.budgetType = PlayerConstants.BUDGET_TIME;
         paramsOne.paranoid = true;
         paramsOne.searchDepth = 4;
         MaxNSearchPlayer player1 = new MaxNSearchPlayer(paramsOne);
@@ -36,7 +39,8 @@ public class AlphaBetaPruningTests {
         // create a MaxNSearchPlayer with alphaBetaPruning set to true
         MaxNSearchParameters paramsTwo = new MaxNSearchParameters();
         paramsTwo.alphaBetaPruning = true;
-        paramsTwo.budget = 1000;
+        paramsTwo.budget = Integer.MAX_VALUE;
+        paramsTwo.budgetType = PlayerConstants.BUDGET_TIME;
         paramsTwo.paranoid = true;
         paramsTwo.searchDepth = 4;
         MaxNSearchPlayer player2 = new MaxNSearchPlayer(paramsTwo);
@@ -155,14 +159,20 @@ public class AlphaBetaPruningTests {
             AbstractAction actionTwo = player2.getAction(gameState, forwardModel.computeAvailableActions(gameState));
             long timeTwo = System.currentTimeMillis() - start - timeOne;
 
-     //       System.out.println("Player 1 : " + actionOne.toString() + "\tPlayer 2 : " + actionTwo.toString());
-     //       System.out.println("Player 1 took " + timeOne + "ms, Player 2 took " + timeTwo + "ms");
+            //       System.out.println("Player 1 : " + actionOne.toString() + "\tPlayer 2 : " + actionTwo.toString());
+            //       System.out.println("Player 1 took " + timeOne + "ms, Player 2 took " + timeTwo + "ms");
             //    assertTrue(timeOne > timeTwo);
             totalActions++;
             if (actionOne.equals(actionTwo))
                 identicalActions++;
-            else
+            else {
                 assertArrayEquals(player1.getRootResult().value(), player2.getRootResult().value(), 0.000001);
+                // we also check that the action chosen by Player2 (the faster one) has the same value for Player 1 (even if not chosen)
+                SearchResult player1Result = player1.getRootResult();
+                SearchResult player2Result = player2.getRootResult();
+                double[] p1ValueForP2Action = player1Result.allActionValues().get(actionTwo);
+                assertArrayEquals(p1ValueForP2Action, player2Result.value(), 0.000001);
+            }
 
             forwardModel.next(gameState, actionOne);
 

--- a/src/test/java/players/search/AlphaBetaPruningTests.java
+++ b/src/test/java/players/search/AlphaBetaPruningTests.java
@@ -1,0 +1,70 @@
+package players.search;
+
+import core.AbstractPlayer;
+import core.actions.AbstractAction;
+import games.connect4.Connect4ForwardModel;
+import games.connect4.Connect4GameParameters;
+import games.connect4.Connect4GameState;
+import org.junit.Test;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class AlphaBetaPruningTests {
+
+    @Test
+    public void connect4SameMoveAndTimings() {
+
+        // the intention here is to run a game of Connect4 from start to finish and confirm that
+        // a MaxNSearchPlayer with alphaBetaPruning set to true and false will make the same moves
+        // except that the player with pruning should take less time
+
+        // create a game of Connect4
+        Connect4GameState gameState = new Connect4GameState(new Connect4GameParameters(), 2);
+        Connect4ForwardModel forwardModel = new Connect4ForwardModel();
+        forwardModel.setup(gameState);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to false
+        MaxNSearchParameters paramsOne = new MaxNSearchParameters();
+        paramsOne.alphaBetaPruning = false;
+        paramsOne.paranoid = true;
+        paramsOne.searchDepth = 4;
+        AbstractPlayer player1 = new MaxNSearchPlayer(paramsOne);
+        player1.setForwardModel(forwardModel);
+
+        // create a MaxNSearchPlayer with alphaBetaPruning set to true
+        MaxNSearchParameters paramsTwo = new MaxNSearchParameters();
+        paramsTwo.alphaBetaPruning = true;
+        paramsTwo.paranoid = true;
+        paramsTwo.searchDepth = 4;
+        AbstractPlayer player2 = new MaxNSearchPlayer(paramsTwo);
+        player2.setForwardModel(forwardModel);
+
+        long playerOneTime = 0;
+        long playerTwoTime = 0;
+        do {
+            // player 1's turn
+            long start = System.currentTimeMillis();
+            AbstractAction actionOne = player1.getAction(gameState, forwardModel.computeAvailableActions(gameState));
+            long timeOne = System.currentTimeMillis() - start;
+            AbstractAction actionTwo = player2.getAction(gameState, forwardModel.computeAvailableActions(gameState));
+            long timeTwo = System.currentTimeMillis() - start - timeOne;
+
+            System.out.println("Player 1 : " + actionOne.toString() + "\tPlayer 2 : " + actionTwo.toString());
+            System.out.println("Player 1 took " + timeOne + "ms, Player 2 took " + timeTwo + "ms");
+        //    assertTrue(timeOne > timeTwo);
+            assertEquals(actionOne, actionTwo);
+            forwardModel.next(gameState, actionOne);
+
+            if (gameState.getGameTick() > 4) {
+                // skip the first few moves for JVM warmup
+                playerOneTime += timeOne;
+                playerTwoTime += timeTwo;
+            }
+        } while (gameState.isNotTerminal());
+
+        System.out.println("Player 1 took " + playerOneTime + "ms, Player 2 took " + playerTwoTime + "ms");
+        assertTrue(playerOneTime > playerTwoTime);
+    }
+
+}

--- a/src/test/java/players/search/AlphaBetaPruningTests.java
+++ b/src/test/java/players/search/AlphaBetaPruningTests.java
@@ -7,8 +7,7 @@ import games.connect4.Connect4GameParameters;
 import games.connect4.Connect4GameState;
 import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 
 public class AlphaBetaPruningTests {
 
@@ -16,7 +15,8 @@ public class AlphaBetaPruningTests {
     public void connect4SameMoveAndTimings() {
 
         // the intention here is to run a game of Connect4 from start to finish and confirm that
-        // a MaxNSearchPlayer with alphaBetaPruning set to true and false will make the same moves
+        // two MaxNSearchPlayer with alphaBetaPruning set to true and false respectively will make the same moves
+        // (or moves which have identical values with fixed depth search)
         // except that the player with pruning should take less time
 
         // create a game of Connect4
@@ -30,7 +30,7 @@ public class AlphaBetaPruningTests {
         paramsOne.paranoid = true;
         paramsOne.searchDepth = 4;
         paramsOne.setRandomSeed(89);
-        AbstractPlayer player1 = new MaxNSearchPlayer(paramsOne);
+        MaxNSearchPlayer player1 = new MaxNSearchPlayer(paramsOne);
         player1.setForwardModel(forwardModel);
 
         // create a MaxNSearchPlayer with alphaBetaPruning set to true
@@ -39,11 +39,13 @@ public class AlphaBetaPruningTests {
         paramsTwo.paranoid = true;
         paramsTwo.searchDepth = 4;
         paramsTwo.setRandomSeed(89);
-        AbstractPlayer player2 = new MaxNSearchPlayer(paramsTwo);
+        MaxNSearchPlayer player2 = new MaxNSearchPlayer(paramsTwo);
         player2.setForwardModel(forwardModel);
 
         long playerOneTime = 0;
         long playerTwoTime = 0;
+        int identicalActions = 0;
+        int totalActions = 0;
         do {
             // player 1's turn
             long start = System.currentTimeMillis();
@@ -54,8 +56,13 @@ public class AlphaBetaPruningTests {
 
             System.out.println("Player 1 : " + actionOne.toString() + "\tPlayer 2 : " + actionTwo.toString());
             System.out.println("Player 1 took " + timeOne + "ms, Player 2 took " + timeTwo + "ms");
-        //    assertTrue(timeOne > timeTwo);
-            assertEquals(actionOne, actionTwo);
+            //    assertTrue(timeOne > timeTwo);
+            totalActions++;
+            if (actionOne.equals(actionTwo))
+                identicalActions++;
+            else
+                assertArrayEquals(player1.getRootResult().value(), player2.getRootResult().value(), 0.000001);
+
             forwardModel.next(gameState, actionOne);
 
             if (gameState.getGameTick() > 4) {
@@ -66,6 +73,7 @@ public class AlphaBetaPruningTests {
         } while (gameState.isNotTerminal());
 
         System.out.println("Player 1 took " + playerOneTime + "ms, Player 2 took " + playerTwoTime + "ms");
+        System.out.println("Identical actions : " + identicalActions + " / " + totalActions);
         assertTrue(playerOneTime > playerTwoTime);
     }
 


### PR DESCRIPTION
Improvements to MaxNSearch Player:
- AlphaBeta search now available (only for paranoid agents, for which an N-person game is effectively 2-player and hence minimax)
- Iterative Deepening search added as an option. This enables MaxNSearch to be pseudo-Anytime. It will return the best action found at a depth d-1 search if it runs out of time while searching at depth d.
- Use the data gathered from search so far to order the node expansion during later search. This adds an overhead of tracking estimated action values, but can improve the rate of pruning (so only relevant when AlphaBeta is on) significantly.

All three of these are new boolean parameters in MaxNSearchParameters. They are all off by default.