### PR TITLE
Rollout termination fix

### DIFF
--- a/src/main/java/games/poker/PokerForwardModel.java
+++ b/src/main/java/games/poker/PokerForwardModel.java
@@ -97,7 +97,7 @@ public class PokerForwardModel extends StandardForwardModel {
         } else {
             new Bet(pgs.bigId, params.bigBlind).execute(pgs);
         }
-        // It is then possible that the round (and game) ends immediately
+        // It is then possible that the round ends immediately
         // if there are 2 players left, and one went AllIn on the blind
         if (pgs.isRoundOver()) {
             roundEnd(pgs);

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -44,7 +44,7 @@ public class SingleTreeNode {
     // variables to track rollout - these were originally local in rollout(); but
     // having them on the node reduces verbiage in passing to advance() to check rollout termination in some edge cases
     // (specifically when using SelfOnly trees, with START/END_TURN/ROUND rollout termination conditions
-    protected int roundAtStartOfRollout, turnAtStartOfRollout, lastActorInRollout, lastTurnInRollout, lastRoundInRollout;
+    protected int lastActorInRollout, lastTurnInRollout, lastRoundInRollout;
     List<AbstractAction> actionsFromOpenLoopState = new ArrayList<>();
     Map<AbstractAction, Double> actionValueEstimates = new HashMap<>();
     Map<AbstractAction, Double> actionPDFEstimates = new HashMap<>();
@@ -889,10 +889,8 @@ public class SingleTreeNode {
         lastActorInRollout = lastActor;
         lastRoundInRollout = openLoopState.getRoundCounter();
         lastTurnInRollout = openLoopState.getTurnCounter();
-        roundAtStartOfRollout = openLoopState.getRoundCounter();
-        turnAtStartOfRollout = openLoopState.getTurnCounter();
 
-                // If rollouts are enabled, select actions for the rollout in line with the rollout policy
+        // If rollouts are enabled, select actions for the rollout in line with the rollout policy
         AbstractGameState rolloutState = openLoopState;
         if (params.rolloutLength > 0 || params.rolloutTermination != DEFAULT) {
             // even if rollout length is zero, we may rollout a few actions to reach the end of our turn, or the start of our next turn

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -555,6 +555,8 @@ public class SingleTreeNode {
     protected void advanceState(AbstractGameState gs, AbstractAction act, boolean inRollout) {
         // we execute a copy(), because this can change the action, so we then don't find the node later!
         if (inRollout) {
+            lastTurnInRollout = gs.getTurnCounter();
+            lastRoundInRollout = gs.getRoundCounter();
             lastActorInRollout = gs.getCurrentPlayer();
             root.actionsInRollout.add(new Pair<>(lastActorInRollout, act));
         } else {
@@ -587,6 +589,8 @@ public class SingleTreeNode {
             if (inRollout) {
                 root.actionsInRollout.add(new Pair<>(gs.getCurrentPlayer(), action));
                 lastActorInRollout = gs.getCurrentPlayer();
+                lastRoundInRollout = gs.getRoundCounter();
+                lastTurnInRollout = gs.getTurnCounter();
             }
             forwardModel.next(gs, action);
             root.fmCallsCount++;
@@ -883,6 +887,8 @@ public class SingleTreeNode {
      */
     protected double[] rollout(int lastActor) {
         lastActorInRollout = lastActor;
+        lastRoundInRollout = openLoopState.getRoundCounter();
+        lastTurnInRollout = openLoopState.getTurnCounter();
         roundAtStartOfRollout = openLoopState.getRoundCounter();
         turnAtStartOfRollout = openLoopState.getTurnCounter();
 
@@ -906,9 +912,6 @@ public class SingleTreeNode {
                 }
                 AbstractPlayer agent = rolloutState.getCurrentPlayer() == root.decisionPlayer ? params.getRolloutStrategy() : params.getOpponentModel();
                 next = agent.getAction(rolloutState, availableActions);
-                lastActorInRollout = rolloutState.getCurrentPlayer();
-                lastTurnInRollout = rolloutState.getTurnCounter();
-                lastRoundInRollout = rolloutState.getRoundCounter();
                 advanceState(rolloutState, next, true);
             }
         }

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -44,7 +44,7 @@ public class SingleTreeNode {
     // variables to track rollout - these were originally local in rollout(); but
     // having them on the node reduces verbiage in passing to advance() to check rollout termination in some edge cases
     // (specifically when using SelfOnly trees, with START/END_TURN/ROUND rollout termination conditions
-    protected int roundAtStartOfRollout, turnAtStartOfRollout, lastActorInRollout;
+    protected int roundAtStartOfRollout, turnAtStartOfRollout, lastActorInRollout, lastTurnInRollout, lastRoundInRollout;
     List<AbstractAction> actionsFromOpenLoopState = new ArrayList<>();
     Map<AbstractAction, Double> actionValueEstimates = new HashMap<>();
     Map<AbstractAction, Double> actionPDFEstimates = new HashMap<>();
@@ -886,7 +886,7 @@ public class SingleTreeNode {
         roundAtStartOfRollout = openLoopState.getRoundCounter();
         turnAtStartOfRollout = openLoopState.getTurnCounter();
 
-        // If rollouts are enabled, select actions for the rollout in line with the rollout policy
+                // If rollouts are enabled, select actions for the rollout in line with the rollout policy
         AbstractGameState rolloutState = openLoopState;
         if (params.rolloutLength > 0 || params.rolloutTermination != DEFAULT) {
             // even if rollout length is zero, we may rollout a few actions to reach the end of our turn, or the start of our next turn
@@ -907,6 +907,8 @@ public class SingleTreeNode {
                 AbstractPlayer agent = rolloutState.getCurrentPlayer() == root.decisionPlayer ? params.getRolloutStrategy() : params.getOpponentModel();
                 next = agent.getAction(rolloutState, availableActions);
                 lastActorInRollout = rolloutState.getCurrentPlayer();
+                lastTurnInRollout = rolloutState.getTurnCounter();
+                lastRoundInRollout = rolloutState.getRoundCounter();
                 advanceState(rolloutState, next, true);
             }
         }

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -939,8 +939,8 @@ public class SingleTreeNode {
                 case DEFAULT -> true;
                 case END_ACTION -> lastActorInRollout == root.decisionPlayer && currentActor != root.decisionPlayer;
                 case START_ACTION -> lastActorInRollout != root.decisionPlayer && currentActor == root.decisionPlayer;
-                case END_TURN -> rollerState.getTurnCounter() != turnAtStartOfRollout;
-                case END_ROUND -> rollerState.getRoundCounter() != roundAtStartOfRollout;
+                case END_TURN -> rollerState.getTurnCounter() != lastTurnInRollout;
+                case END_ROUND -> rollerState.getRoundCounter() != lastRoundInRollout;
             };
         }
         return false;

--- a/src/test/java/players/mcts/MTNRollout.java
+++ b/src/test/java/players/mcts/MTNRollout.java
@@ -45,9 +45,8 @@ public class MTNRollout extends MultiTreeNode {
                 break;
             case END_TURN:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
-                assertNotEquals(openLoopState.getTurnCounter(), turnAtStartOfRollout);
                 assertNotEquals(openLoopState.getTurnCounter(), lastTurnInRollout);
-                assertTrue(openLoopState.getTurnCounter() == lastTurnInRollout + 1 || openLoopState.getTurnCounter() == 1);
+                assertTrue(openLoopState.getTurnCounter() == lastTurnInRollout + 1 || openLoopState.getTurnCounter() == 0);
                 break;
             case END_ROUND:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);

--- a/src/test/java/players/mcts/MTNRollout.java
+++ b/src/test/java/players/mcts/MTNRollout.java
@@ -46,12 +46,14 @@ public class MTNRollout extends MultiTreeNode {
             case END_TURN:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
                 assertNotEquals(openLoopState.getTurnCounter(), turnAtStartOfRollout);
-                assertEquals(openLoopState.getTurnCounter(), turnAtStartOfRollout + 1);
+                assertNotEquals(openLoopState.getTurnCounter(), lastTurnInRollout);
+                assertTrue(openLoopState.getTurnCounter() == lastTurnInRollout + 1 || openLoopState.getTurnCounter() == 1);
                 break;
             case END_ROUND:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), roundAtStartOfRollout);
-                assertEquals(openLoopState.getRoundCounter(), roundAtStartOfRollout + 1);
+                assertNotEquals(openLoopState.getRoundCounter(), lastRoundInRollout);
+                assertEquals(openLoopState.getRoundCounter(), lastRoundInRollout + 1);
                 break;
         }
     }

--- a/src/test/java/players/mcts/MTNRollout.java
+++ b/src/test/java/players/mcts/MTNRollout.java
@@ -46,10 +46,12 @@ public class MTNRollout extends MultiTreeNode {
             case END_TURN:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
                 assertNotEquals(openLoopState.getTurnCounter(), turnAtStartOfRollout);
+                assertEquals(openLoopState.getTurnCounter(), turnAtStartOfRollout + 1);
                 break;
             case END_ROUND:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), roundAtStartOfRollout);
+                assertEquals(openLoopState.getRoundCounter(), roundAtStartOfRollout + 1);
                 break;
         }
     }

--- a/src/test/java/players/mcts/MTNRollout.java
+++ b/src/test/java/players/mcts/MTNRollout.java
@@ -2,6 +2,7 @@ package players.mcts;
 
 import core.AbstractGameState;
 import core.CoreConstants;
+import games.GameType;
 
 import java.util.Random;
 
@@ -52,7 +53,10 @@ public class MTNRollout extends MultiTreeNode {
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), roundAtStartOfRollout);
                 assertNotEquals(openLoopState.getRoundCounter(), lastRoundInRollout);
-                assertEquals(openLoopState.getRoundCounter(), lastRoundInRollout + 1);
+                if (openLoopState.getGameType() == GameType.Poker)
+                    assertTrue(openLoopState.getRoundCounter() == lastRoundInRollout + 1 || openLoopState.getRoundCounter() == lastRoundInRollout + 2);
+                else
+                    assertEquals(openLoopState.getRoundCounter(), lastRoundInRollout + 1);
                 break;
         }
     }

--- a/src/test/java/players/mcts/MTNRollout.java
+++ b/src/test/java/players/mcts/MTNRollout.java
@@ -51,7 +51,6 @@ public class MTNRollout extends MultiTreeNode {
                 break;
             case END_ROUND:
                 assertTrue(actionsInRollout.size() >= params.rolloutLength);
-                assertNotEquals(openLoopState.getRoundCounter(), roundAtStartOfRollout);
                 assertNotEquals(openLoopState.getRoundCounter(), lastRoundInRollout);
                 if (openLoopState.getGameType() == GameType.Poker)
                     assertTrue(openLoopState.getRoundCounter() == lastRoundInRollout + 1 || openLoopState.getRoundCounter() == lastRoundInRollout + 2);

--- a/src/test/java/players/mcts/RolloutTerminationTests.java
+++ b/src/test/java/players/mcts/RolloutTerminationTests.java
@@ -19,7 +19,7 @@ public class RolloutTerminationTests {
             GameType.LoveLetter,
             GameType.Dominion,
             GameType.Virus,
-    //        GameType.Poker,
+            GameType.Poker,
     //        GameType.Catan,
             GameType.ColtExpress,
             GameType.CantStop,

--- a/src/test/java/players/mcts/RolloutTerminationTests.java
+++ b/src/test/java/players/mcts/RolloutTerminationTests.java
@@ -18,12 +18,12 @@ public class RolloutTerminationTests {
     GameType[] gamesToTest = {
             GameType.LoveLetter,
             GameType.Dominion,
-    //        GameType.Virus,
-            GameType.Poker,
+            GameType.Virus,
+    //        GameType.Poker,
     //        GameType.Catan,
             GameType.ColtExpress,
             GameType.CantStop,
-     //       GameType.Diamant,
+            GameType.Diamant,
             GameType.SushiGo
     };
 

--- a/src/test/java/players/mcts/RolloutTerminationTests.java
+++ b/src/test/java/players/mcts/RolloutTerminationTests.java
@@ -18,12 +18,12 @@ public class RolloutTerminationTests {
     GameType[] gamesToTest = {
             GameType.LoveLetter,
             GameType.Dominion,
-            GameType.Virus,
+    //        GameType.Virus,
             GameType.Poker,
     //        GameType.Catan,
             GameType.ColtExpress,
             GameType.CantStop,
-            GameType.Diamant,
+     //       GameType.Diamant,
             GameType.SushiGo
     };
 

--- a/src/test/java/players/mcts/STNRollout.java
+++ b/src/test/java/players/mcts/STNRollout.java
@@ -52,15 +52,14 @@ public class STNRollout extends SingleTreeNode {
                 // which means that the turn has *just* changed, so the current turn is one more than the penultimate turn
                 // (i.e. the turn just before the last action in the rollout)
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
-                assertNotEquals(openLoopState.getTurnCounter(), staticStartTurn);
                 assertNotEquals(openLoopState.getTurnCounter(), staticPenultimateTurn);
-                assertTrue(openLoopState.getTurnCounter() == staticPenultimateTurn + 1 || openLoopState.getTurnCounter() == 1);
+                assertTrue(openLoopState.getTurnCounter() == staticPenultimateTurn + 1 || openLoopState.getTurnCounter() == 0);
                 break;
             case END_ROUND:
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), staticStartRound);
                 assertNotEquals(openLoopState.getRoundCounter(), staticPenultimateRound );
-                assertTrue(openLoopState.getRoundCounter() == staticPenultimateRound + 1 || openLoopState.getRoundCounter() == 1);
+                assertTrue(openLoopState.getRoundCounter() == staticPenultimateRound + 1);
                 break;
         }
     }

--- a/src/test/java/players/mcts/STNRollout.java
+++ b/src/test/java/players/mcts/STNRollout.java
@@ -10,7 +10,7 @@ import static org.junit.Assert.*;
 
 public class STNRollout extends SingleTreeNode {
 
-    static int lastActorInTree, staticRolloutDepth, staticStartTurn, staticStartRound, staticPenultimateTurn, staticPenultimateRound;
+    static int lastActorInTree, staticRolloutDepth, staticPenultimateTurn, staticPenultimateRound;
     List<Pair<Integer, AbstractAction>> rolloutActions;
 
     @Override
@@ -58,7 +58,6 @@ public class STNRollout extends SingleTreeNode {
                 break;
             case END_ROUND:
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
-                assertNotEquals(openLoopState.getRoundCounter(), staticStartRound);
                 assertNotEquals(openLoopState.getRoundCounter(), staticPenultimateRound);
                 if (openLoopState.getGameType() == GameType.Poker)
                     assertTrue(openLoopState.getRoundCounter() == staticPenultimateRound + 1 || openLoopState.getRoundCounter() == staticPenultimateRound + 2);
@@ -78,8 +77,6 @@ public class STNRollout extends SingleTreeNode {
         lastActorInTree = lastActor;  // a bit of a hack to track the last Actor in tree search
         double[] retValue = super.rollout(lastActor);
         staticRolloutDepth = root.actionsInRollout.size();
-        staticStartRound = roundAtStartOfRollout;
-        staticStartTurn = turnAtStartOfRollout;
         staticPenultimateTurn = lastTurnInRollout;
         staticPenultimateRound = lastRoundInRollout;
         return retValue;

--- a/src/test/java/players/mcts/STNRollout.java
+++ b/src/test/java/players/mcts/STNRollout.java
@@ -60,7 +60,7 @@ public class STNRollout extends SingleTreeNode {
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), staticStartRound);
                 assertNotEquals(openLoopState.getRoundCounter(), staticPenultimateRound );
-                assertEquals(openLoopState.getRoundCounter(), staticPenultimateRound + 1);
+                assertTrue(openLoopState.getRoundCounter() == staticPenultimateRound + 1 || openLoopState.getRoundCounter() == 1);
                 break;
         }
     }

--- a/src/test/java/players/mcts/STNRollout.java
+++ b/src/test/java/players/mcts/STNRollout.java
@@ -1,6 +1,7 @@
 package players.mcts;
 
 import core.actions.AbstractAction;
+import games.GameType;
 import utilities.Pair;
 
 import java.util.List;
@@ -58,8 +59,11 @@ public class STNRollout extends SingleTreeNode {
             case END_ROUND:
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), staticStartRound);
-                assertNotEquals(openLoopState.getRoundCounter(), staticPenultimateRound );
-                assertTrue(openLoopState.getRoundCounter() == staticPenultimateRound + 1);
+                assertNotEquals(openLoopState.getRoundCounter(), staticPenultimateRound);
+                if (openLoopState.getGameType() == GameType.Poker)
+                    assertTrue(openLoopState.getRoundCounter() == staticPenultimateRound + 1 || openLoopState.getRoundCounter() == staticPenultimateRound + 2);
+                else
+                    assertEquals(openLoopState.getRoundCounter(), staticPenultimateRound + 1);
                 break;
         }
     }

--- a/src/test/java/players/mcts/STNRollout.java
+++ b/src/test/java/players/mcts/STNRollout.java
@@ -53,11 +53,13 @@ public class STNRollout extends SingleTreeNode {
                 // (i.e. the turn just before the last action in the rollout)
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getTurnCounter(), staticStartTurn);
-                assertEquals(openLoopState.getTurnCounter(), staticPenultimateTurn + 1);
+                assertNotEquals(openLoopState.getTurnCounter(), staticPenultimateTurn);
+                assertTrue(openLoopState.getTurnCounter() == staticPenultimateTurn + 1 || openLoopState.getTurnCounter() == 1);
                 break;
             case END_ROUND:
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), staticStartRound);
+                assertNotEquals(openLoopState.getRoundCounter(), staticPenultimateRound );
                 assertEquals(openLoopState.getRoundCounter(), staticPenultimateRound + 1);
                 break;
         }

--- a/src/test/java/players/mcts/STNRollout.java
+++ b/src/test/java/players/mcts/STNRollout.java
@@ -9,7 +9,7 @@ import static org.junit.Assert.*;
 
 public class STNRollout extends SingleTreeNode {
 
-    static int lastActorInTree, staticRolloutDepth, staticStartTurn, staticStartRound;
+    static int lastActorInTree, staticRolloutDepth, staticStartTurn, staticStartRound, staticPenultimateTurn, staticPenultimateRound;
     List<Pair<Integer, AbstractAction>> rolloutActions;
 
     @Override
@@ -28,11 +28,11 @@ public class STNRollout extends SingleTreeNode {
         assertEquals(staticRolloutDepth, rolloutActions.size());
         switch (params.rolloutTermination) {
             case DEFAULT:
-                // in this case we just check that we have 10 actions in the rollout
+                // in this case we just check that we have expected actions in the rollout
                 assertEquals(expectedRolloutLength, staticRolloutDepth);
                 break;
             case START_ACTION:
-                // in this case we have at least 10 actions, and finish at the end of a player's Turn
+                // in this case we have at least the expected actions, and finish at the end of a player's Turn
                 // which means that the current player should be the MCTS player, and
                 // the last player should be someone else
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
@@ -40,7 +40,7 @@ public class STNRollout extends SingleTreeNode {
                 assertNotEquals(0, rolloutActions.get(rolloutActions.size() - 1).a.intValue());
                 break;
             case END_ACTION:
-                // in this case we have at least 10 actions, and finish at the end of a player's Turn
+                // in this case we have at least expected actions, and finish at the end of a player's Turn
                 // which means that the current player is not the same as the player who acted last
                 // and the last player who acted should be the decision player
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
@@ -48,12 +48,17 @@ public class STNRollout extends SingleTreeNode {
                 assertEquals(0, rolloutActions.get(rolloutActions.size() - 1).a.intValue());
                 break;
             case END_TURN:
+                // in this case we have at least expected actions, and finish at the end of a player's Turn
+                // which means that the turn has *just* changed, so the current turn is one more than the penultimate turn
+                // (i.e. the turn just before the last action in the rollout)
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getTurnCounter(), staticStartTurn);
+                assertEquals(openLoopState.getTurnCounter(), staticPenultimateTurn + 1);
                 break;
             case END_ROUND:
                 assertTrue(staticRolloutDepth >= expectedRolloutLength);
                 assertNotEquals(openLoopState.getRoundCounter(), staticStartRound);
+                assertEquals(openLoopState.getRoundCounter(), staticPenultimateRound + 1);
                 break;
         }
     }
@@ -70,6 +75,8 @@ public class STNRollout extends SingleTreeNode {
         staticRolloutDepth = root.actionsInRollout.size();
         staticStartRound = roundAtStartOfRollout;
         staticStartTurn = turnAtStartOfRollout;
+        staticPenultimateTurn = lastTurnInRollout;
+        staticPenultimateRound = lastRoundInRollout;
         return retValue;
 
     }


### PR DESCRIPTION
This fixes a bug in the END_TURN and END_ROUND rollout termination functionality in MCTS.

Previously these only checked that the rollout finished after the end of the TURN/ROUND the game state was in when rollout started. This is now - correctly - the end of the TURN/ROUND the game state is in when the rollout length is reached. In other words we rollout X steps, and then keep going until the end of the current TURN/ROUND.

Unit tests also fixed.