### PR TITLE
Seven wonders fix

### DIFF
--- a/json/players/gameSpecific/SushiGo.json
+++ b/json/players/gameSpecific/SushiGo.json
@@ -1,5 +1,5 @@
 {
-  "budgetType": "BUDGET_TIME",
+  "budgetType": "BUDGET_ITERATIONS",
   "rolloutLength": 30,
   "opponentTreePolicy": "OneTree",
   "MASTGamma": 0,
@@ -13,5 +13,5 @@
   "rolloutType": "RANDOM",
   "information": "Information_Set",
   "class": "players.mcts.MCTSParams",
-  "budget": 40
+  "budget": 200
 }

--- a/json/players/gameSpecific/SushiGo.json
+++ b/json/players/gameSpecific/SushiGo.json
@@ -1,5 +1,5 @@
 {
-  "budgetType": "BUDGET_ITERATIONS",
+  "budgetType": "BUDGET_TIME",
   "rolloutLength": 30,
   "opponentTreePolicy": "OneTree",
   "MASTGamma": 0,
@@ -13,5 +13,5 @@
   "rolloutType": "RANDOM",
   "information": "Information_Set",
   "class": "players.mcts.MCTSParams",
-  "budget": 200
+  "budget": 40
 }

--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -557,7 +557,6 @@ public class Game {
                     System.out.println(history.get(i));
                 }
             }
-            forwardModel.computeAvailableActions(gameState);
             throw new AssertionError("No actions available for player " + activePlayer
                     + (lastAction != null ? ". Last action: " + lastAction.getClass().getSimpleName() + " (" + lastAction + ")" : ". No actions in history")
                     + ". Actions in progress: " + actionsInProgress.size()

--- a/src/main/java/core/Game.java
+++ b/src/main/java/core/Game.java
@@ -535,7 +535,6 @@ public class Game {
 
         // Get actions for the player
         s = System.nanoTime();
-        boolean errorInbound = forwardModel.computeAvailableActions(observation, currentPlayer.getParameters().actionSpace).isEmpty();
         List<AbstractAction> observedActions = forwardModel.computeAvailableActions(observation, currentPlayer.getParameters().actionSpace);
         if (observedActions.isEmpty()) {
             Stack<IExtendedSequence> actionsInProgress = gameState.getActionsInProgress();

--- a/src/main/java/games/wonders7/Wonders7ForwardModel.java
+++ b/src/main/java/games/wonders7/Wonders7ForwardModel.java
@@ -54,7 +54,8 @@ public class Wonders7ForwardModel extends StandardForwardModel {
         wgs.discardPile = new Deck<>("Discarded Cards", CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
 
         // Shuffles wonder-boards
-        createWonderDeck(wgs, new Random(params.wonderShuffleSeed)); // Adds Wonders into game
+        // createWonderDeck(wgs, params.wonderShuffleSeed == -1 ? state.getRnd() : new Random(params.wonderShuffleSeed)); // Adds Wonders into game
+        createWonderDeck(wgs, new Random(params.wonderShuffleSeed));
 
         // Gives each player wonder board and manufactured goods from the wonder
         for (int player = 0; player < wgs.getNPlayers(); player++) {
@@ -273,7 +274,7 @@ public class Wonders7ForwardModel extends StandardForwardModel {
             case 1:
                 switch (wgs.getNPlayers()) {
                     case 7:
-                        wgs.ageDeck.add(Wonder7Card.factory(Pawnshop));
+                        wgs.ageDeck.add(Wonder7Card.factory(Well));
                         wgs.ageDeck.add(Wonder7Card.factory(Baths));
                         wgs.ageDeck.add(Wonder7Card.factory(Tavern));
                         wgs.ageDeck.add(Wonder7Card.factory(EastTradingPost));
@@ -300,7 +301,7 @@ public class Wonders7ForwardModel extends StandardForwardModel {
                         wgs.ageDeck.add(Wonder7Card.factory(LumberYard));
                         wgs.ageDeck.add(Wonder7Card.factory(OreVein));
                         wgs.ageDeck.add(Wonder7Card.factory(Excavation));
-                        wgs.ageDeck.add(Wonder7Card.factory(Pawnshop));
+                        wgs.ageDeck.add(Wonder7Card.factory(Well));
                         wgs.ageDeck.add(Wonder7Card.factory(Tavern));
                         wgs.ageDeck.add(Wonder7Card.factory(GuardTower));
                         wgs.ageDeck.add(Wonder7Card.factory(Scriptorium));
@@ -350,9 +351,9 @@ public class Wonders7ForwardModel extends StandardForwardModel {
                         wgs.ageDeck.add(Wonder7Card.factory(Forum));
                         wgs.ageDeck.add(Wonder7Card.factory(Vineyard));
                     case 5:
-                        wgs.ageDeck.add(Wonder7Card.factory(Loom));
-                        wgs.ageDeck.add(Wonder7Card.factory(Glassworks));
-                        wgs.ageDeck.add(Wonder7Card.factory(Press));
+                        wgs.ageDeck.add(Wonder7Card.factory(LoomAge2));
+                        wgs.ageDeck.add(Wonder7Card.factory(GlassworksAge2));
+                        wgs.ageDeck.add(Wonder7Card.factory(PressAge2));
                         wgs.ageDeck.add(Wonder7Card.factory(Courthouse));
                         wgs.ageDeck.add(Wonder7Card.factory(Stables));
                         wgs.ageDeck.add(Wonder7Card.factory(Laboratory));
@@ -370,9 +371,9 @@ public class Wonders7ForwardModel extends StandardForwardModel {
                         wgs.ageDeck.add(Wonder7Card.factory(Quarry));
                         wgs.ageDeck.add(Wonder7Card.factory(Foundry));
                         wgs.ageDeck.add(Wonder7Card.factory(Brickyard));
-                        wgs.ageDeck.add(Wonder7Card.factory(Loom));
-                        wgs.ageDeck.add(Wonder7Card.factory(Glassworks));
-                        wgs.ageDeck.add(Wonder7Card.factory(Press));
+                        wgs.ageDeck.add(Wonder7Card.factory(LoomAge2));
+                        wgs.ageDeck.add(Wonder7Card.factory(GlassworksAge2));
+                        wgs.ageDeck.add(Wonder7Card.factory(PressAge2));
                         wgs.ageDeck.add(Wonder7Card.factory(Aqueduct));
                         wgs.ageDeck.add(Wonder7Card.factory(Temple));
                         wgs.ageDeck.add(Wonder7Card.factory(Courthouse));

--- a/src/main/java/games/wonders7/Wonders7ForwardModel.java
+++ b/src/main/java/games/wonders7/Wonders7ForwardModel.java
@@ -54,8 +54,7 @@ public class Wonders7ForwardModel extends StandardForwardModel {
         wgs.discardPile = new Deck<>("Discarded Cards", CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
 
         // Shuffles wonder-boards
-        // createWonderDeck(wgs, params.wonderShuffleSeed == -1 ? state.getRnd() : new Random(params.wonderShuffleSeed)); // Adds Wonders into game
-        createWonderDeck(wgs, new Random(params.wonderShuffleSeed));
+        createWonderDeck(wgs, params.wonderShuffleSeed == -1 ? state.getRnd() : new Random(params.wonderShuffleSeed)); // Adds Wonders into game
 
         // Gives each player wonder board and manufactured goods from the wonder
         for (int player = 0; player < wgs.getNPlayers(); player++) {
@@ -110,6 +109,7 @@ public class Wonders7ForwardModel extends StandardForwardModel {
                     wgs.getPlayerWonderBoard(p).effectUsed = true;
                     return;
                 }
+                // the _afterAction method of BuildFromDiscard will rotate hands and check for end of age
             }
 
             rotateHands(wgs);

--- a/src/main/java/games/wonders7/actions/BuildFromDiscard.java
+++ b/src/main/java/games/wonders7/actions/BuildFromDiscard.java
@@ -38,4 +38,11 @@ public class BuildFromDiscard extends OneShotExtendedAction {
         fm.checkAgeEnd(wgs);
     }
 
+    @Override
+    public BuildFromDiscard copy() {
+        BuildFromDiscard retValue = new BuildFromDiscard(player);
+        retValue.executed = executed;
+        return retValue;
+    }
+
 }

--- a/src/main/java/games/wonders7/cards/Wonder7Board.java
+++ b/src/main/java/games/wonders7/cards/Wonder7Board.java
@@ -37,19 +37,19 @@ public class Wonder7Board extends Card {
                 List.of(Map.of(Victory, 3), Map.of(ScienceWild, 1), Map.of(Victory, 7)),
                 List.of(Map.of(Stone, 2), Map.of(Clay, 3, Glass, 1)),
                 List.of(emptyMap(), Map.of(ScienceWild, 1))
-        ), // TODO: Babylon Night side special ability to build the discard card at the end of each age
+        ),
         TheStatueOfZeusInOlympia(Clay,
                 List.of(Map.of(Stone, 2), Map.of(Wood, 2), Map.of(Clay, 3)),
                 List.of(Map.of(Victory, 3), emptyMap(), Map.of(Victory, 7)),
                 List.of(Map.of(Ore, 2), Map.of(Clay, 3), Map.of(Glass, 1, Papyrus, 1, Textile, 1)),
                 List.of(Map.of(Victory, 2), Map.of(Victory, 3), Map.of(Victory, 5))
-        ), // TODO: Olympia Night side special ability to build first/last cards of each age for free
+        ),
         TheMausoleumOfHalicarnassus(Textile,
                 List.of(Map.of(Ore, 2), Map.of(Glass, 1, Papyrus, 1), Map.of(Stone, 3)),
                 List.of(Map.of(Victory, 3), emptyMap(), Map.of(Victory, 7)),
                 List.of(Map.of(Ore, 2), Map.of(Glass, 1, Papyrus, 1), Map.of(Stone, 3)),
                 List.of(Map.of(Victory, 2), Map.of(Victory, 1), emptyMap())
-        ),  // TODO: Halicarnassus Night side special ability to build from discard at end of turn that each stage is built
+        ),
         ThePyramidsOfGiza(Clay,
                 List.of(Map.of(Wood, 2), Map.of(Clay, 2, Textile, 1), Map.of(Stone, 4)),
                 List.of(Map.of(Victory, 3), Map.of(Victory, 5), Map.of(Victory, 7)),

--- a/src/main/java/games/wonders7/cards/Wonder7Card.java
+++ b/src/main/java/games/wonders7/cards/Wonder7Card.java
@@ -29,14 +29,31 @@ public class Wonder7Card extends Card {
     }
 
     public enum CardType {
-        LumberYard, StonePit, ClayPool, OreVein, TreeFarm, Excavation, ClayPit, TimberYard, ForestCave, Mine, Sawmill, Quarry, Brickyard, Foundry,
-        Loom, Glassworks, Press,
-        Workshop, Scriptorium, Apothecary, Dispensary, Laboratory, Library, School, Observatory, University, Academy, Study, Lodge,
-        Baths, Altar, Theatre, Pawnshop, Statue, Aqueduct, Courthouse, Temple, TownHall, Senate, Pantheon, Palace, Gardens,
-        Tavern, EastTradingPost, WestTradingPost, Marketplace, Caravansery, Forum, Ludus, ChamberOfCommerce, Arena, Vineyard, Bazaar, Haven, Lighthouse,
-        Stockade, Barracks, GuardTower, Walls, TrainingGround, Stables, ArcheryRange, SiegeWorkshop, Fortifications, Arsenal, Circus, Castrum,
-        WorkersGuild, CraftsmenGuild, MagistratesGuild, TradersGuild, SpiesGuild, PhilosophersGuild, ShipownersGuild, BuildersGuild, DecoratorsGuild, ScientistsGuild
+        LumberYard(1), StonePit(1), ClayPool(1), OreVein(1), TreeFarm(1), Excavation(1),
+        ClayPit(1), TimberYard(1), ForestCave(1), Mine(1),
+        Sawmill(2), Quarry(2), Brickyard(2), Foundry(2),
+        Loom(1), Glassworks(1), Press(1),
+        LoomAge2(2), GlassworksAge2(2), PressAge2(2),
+        Workshop(1), Scriptorium(1), Apothecary(1),
+        Dispensary(2), Laboratory(2), Library(2), School(2),
+        Observatory(3), University(3), Academy(3), Study(3), Lodge(3),
+        Baths(1), Altar(1), Theatre(1), Well(1),
+        Statue(2), Aqueduct(2), Courthouse(2), Temple(2),
+        TownHall(3), Senate(3), Pantheon(3), Palace(3), Gardens(3),
+        Tavern(1), EastTradingPost(1), WestTradingPost(1), Marketplace(1),
+        Caravansery(2), Forum(2), Vineyard(2), Bazaar(2),
+        ChamberOfCommerce(3), Arena(3),  Haven(3), Lighthouse(3), Ludus(3),
+        Stockade(1), Barracks(1), GuardTower(1),
+        Walls(2), TrainingGround(2), Stables(2), ArcheryRange(2),
+        SiegeWorkshop(3), Fortifications(3), Arsenal(3), Circus(3), Castrum(3),
+        WorkersGuild(3), CraftsmenGuild(3), MagistratesGuild(3), TradersGuild(3), SpiesGuild(3),
+        PhilosophersGuild(3), ShipownersGuild(3), BuildersGuild(3), DecoratorsGuild(3), ScientistsGuild(3);
 
+        public final int age;
+
+        CardType(int age) {
+            this.age = age;
+        }
 
     }
 
@@ -78,17 +95,17 @@ public class Wonder7Card extends Card {
                 return new Wonder7Card(cardType, RawMaterials, Map.of(Coin, 1), Map.of(Clay, 2));
             case Foundry:
                 return new Wonder7Card(cardType, RawMaterials, Map.of(Coin, 1), Map.of(Ore, 2));
-            case Loom:
+            case Loom, LoomAge2:
                 return new Wonder7Card(cardType, ManufacturedGoods, emptyMap(), Map.of(Textile, 1));
-            case Glassworks:
+            case Glassworks, GlassworksAge2:
                 return new Wonder7Card(cardType, ManufacturedGoods, emptyMap(), Map.of(Glass, 1));
-            case Press:
+            case Press, PressAge2:
                 return new Wonder7Card(cardType, ManufacturedGoods, emptyMap(), Map.of(Papyrus, 1));
-            case Pawnshop, Baths, Altar, Theatre:
+            case Well, Baths, Altar, Theatre:
                 return new Wonder7Card(cardType, CivilianStructures, emptyMap(), Map.of(Victory, 3));
             case Statue:
                 return new Wonder7Card(cardType, CivilianStructures, Map.of(Ore, 2, Wood, 1), Map.of(Victory, 4),
-                        List.of(CardType.Pawnshop));
+                        List.of(CardType.Well));
             case Aqueduct:
                 return new Wonder7Card(cardType, CivilianStructures, Map.of(Stone, 3), Map.of(Victory, 5),
                         List.of(CardType.Baths));
@@ -404,6 +421,22 @@ public class Wonder7Card extends Card {
             if (cardType == card.cardType) {
                 // Player already has an identical structure, can't play another
                 return true;
+            }
+            // then the special cases for Manufactured resources, as the only ones wit identical cards in different Ages
+            if (cardType == CardType.Loom || cardType == CardType.LoomAge2) {
+                if (card.cardType == CardType.Loom || card.cardType == CardType.LoomAge2) {
+                    return true;
+                }
+            }
+            if (cardType == CardType.Glassworks || cardType == CardType.GlassworksAge2) {
+                if (card.cardType == CardType.Glassworks || card.cardType == CardType.GlassworksAge2) {
+                    return true;
+                }
+            }
+            if (cardType == CardType.Press || cardType == CardType.PressAge2) {
+                if (card.cardType == CardType.Press || card.cardType == CardType.PressAge2) {
+                    return true;
+                }
             }
         }
         return false;

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -386,7 +386,7 @@ public class SingleTreeNode {
         // selected == this is a clear sign that we have a problem in the expansion phase
         // although if we have no decisions to make - this is fine
 
-        // Monte carlo rollout: return value of MC rollout from the newly added node
+        // Monte Carlo rollout: return value of MC rollout from the newly added node
         int lastActorInTree = actionsInTree.isEmpty() ? decisionPlayer : actionsInTree.get(actionsInTree.size() - 1).a;
         double[] delta = selected.rollout(lastActorInTree);
         // Back up the value of the rollout through the tree

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -100,11 +100,11 @@ public class ForwardModelTestsWithMCTS {
 
     @Test
     public void testSevenWonders() {
-       new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\SushiGo.json");
-        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
-        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\SushiGo.json");
-        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=6", "agent=json\\players\\gameSpecific\\SushiGo.json");
-        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=7", "agent=json\\players\\gameSpecific\\SushiGo.json");
+   //    new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=3", "agent=json\\players\\gameSpecific\\SushiGo.json");
+    //    new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
+     //   new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=5", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=6", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=7", "agent=json\\players\\gameSpecific\\SushiGo.json");
     }
 
     @Test

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -10,10 +10,12 @@ public class ForwardModelTestsWithMCTS {
     public void testSaboteur() {
         new ForwardModelTester("game=Saboteur", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\Saboteur.json");
     }
+
     @Test
     public void testRoot() {
         ForwardModelTester fmt = new ForwardModelTester("game=Root", "nGames=1", "nPlayers=4", "agent=json\\players\\mcts.json");
     }
+
     @Test
     public void testBattleLore() {
         new ForwardModelTester("game=Battlelore", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Battlelore.json");
@@ -23,10 +25,12 @@ public class ForwardModelTestsWithMCTS {
     public void testDescent2e() {
         ForwardModelTester fmt = new ForwardModelTester("game=Descent2e", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Descent.json");
     }
+
     @Test
     public void testCantStop() {
-         new ForwardModelTester("game=CantStop", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\CantStop.json");
+        new ForwardModelTester("game=CantStop", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\CantStop.json");
     }
+
     @Test
     public void testCatan() {
         new ForwardModelTester("game=Catan", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\catan\\Catan_LearnedHeuristic.json");
@@ -38,31 +42,37 @@ public class ForwardModelTestsWithMCTS {
         cp.setParameterValue("tradingAllowed", false);
         new ForwardModelTester(cp, "game=Catan", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\catan\\Catan_LearnedHeuristic.json");
     }
+
     @Test
     public void testColtExpress() {
-         new ForwardModelTester("game=ColtExpress", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\ColtExpress_3P.json");
+        new ForwardModelTester("game=ColtExpress", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\ColtExpress_3P.json");
     }
+
     @Test
     public void testConnect4() {
-         new ForwardModelTester("game=Connect4", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Connect4.json");
+        new ForwardModelTester("game=Connect4", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Connect4.json");
     }
+
     @Test
     public void testDiamant() {
         new ForwardModelTester("game=Diamant", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Diamant.json");
     }
+
     @Test
     public void testDominion() {
-       new ForwardModelTester("game=Dominion", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Dominion.json");
+        new ForwardModelTester("game=Dominion", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Dominion.json");
     }
 
     @Test
     public void testDotsAndBoxes() {
-         new ForwardModelTester("game=DotsAndBoxes", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\DotsAndBoxes.json");
+        new ForwardModelTester("game=DotsAndBoxes", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\DotsAndBoxes.json");
     }
+
     @Test
     public void testExplodingKittens() {
-         new ForwardModelTester("game=ExplodingKittens", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\ExplodingKittens.json");
+        new ForwardModelTester("game=ExplodingKittens", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\ExplodingKittens.json");
     }
+
     @Test
     public void testLoveLetter() {
         new ForwardModelTester("game=LoveLetter", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\LoveLetter.json");
@@ -72,10 +82,12 @@ public class ForwardModelTestsWithMCTS {
     public void testPoker() {
         new ForwardModelTester("game=Poker", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Poker_3+P.json");
     }
+
     @Test
     public void testStratego() {
-       new ForwardModelTester("game=Stratego", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Stratego.json");
+        new ForwardModelTester("game=Stratego", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\Stratego.json");
     }
+
     @Test
     public void testSushiGo() {
         new ForwardModelTester("game=SushiGo", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
@@ -85,26 +97,29 @@ public class ForwardModelTestsWithMCTS {
     public void testTicTacToe() {
         new ForwardModelTester("game=TicTacToe", "nGames=1", "nPlayers=2", "agent=json\\players\\gameSpecific\\TicTacToe.json");
     }
+
     @Test
     public void testUno() {
-       new ForwardModelTester("game=Uno", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Virus.json");
+        new ForwardModelTester("game=Uno", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Virus.json");
     }
+
     @Test
     public void testResistance() {
-      new ForwardModelTester("game=Resistance", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Dominion.json");
+        new ForwardModelTester("game=Resistance", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Dominion.json");
     }
+
     @Test
     public void testVirus() {
-       new ForwardModelTester("game=Virus", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Virus.json");
+        new ForwardModelTester("game=Virus", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\Virus.json");
     }
 
     @Test
     public void testSevenWonders() {
-   //    new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=3", "agent=json\\players\\gameSpecific\\SushiGo.json");
-    //    new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
-     //   new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=5", "agent=json\\players\\gameSpecific\\SushiGo.json");
-        new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=6", "agent=json\\players\\gameSpecific\\SushiGo.json");
-        new ForwardModelTester("game=Wonders7", "nGames=10", "nPlayers=7", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=4", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=6", "agent=json\\players\\gameSpecific\\SushiGo.json");
+        new ForwardModelTester("game=Wonders7", "nGames=1", "nPlayers=7", "agent=json\\players\\gameSpecific\\SushiGo.json");
     }
 
     @Test

--- a/src/test/java/games/wonders7/ShuffleTests.java
+++ b/src/test/java/games/wonders7/ShuffleTests.java
@@ -1,11 +1,13 @@
 package games.wonders7;
 
 import core.actions.AbstractAction;
+import games.wonders7.cards.Wonder7Card;
 import org.junit.Before;
 import org.junit.Test;
 
 import java.util.List;
 
+import static java.util.stream.Collectors.toList;
 import static org.junit.Assert.*;
 
 public class ShuffleTests {
@@ -153,6 +155,33 @@ public class ShuffleTests {
             assertEquals(6, copy.getPlayerHands().get(i).getSize());
         }
 
+    }
+
+    @Test
+    public void testRedeterminisationWithDifferentAgeCardsInDiscard() {
+        do {
+            List<AbstractAction> availableActions = fm.computeAvailableActions(state);
+            fm.next(state, availableActions.get(state.getRnd().nextInt(availableActions.size())));
+        } while (state.currentAge < 2);
+        assertEquals(2, state.getCurrentAge());
+        assertTrue(state.getDiscardPile().getSize() > 5);
+
+        assertEquals(7, state.getPlayerHand(0).getSize());
+        for (int trial = 0; trial < 5; trial++) {
+            List<Wonder7Card.CardType> inDiscard = state.getDiscardPile().stream()
+                    .map(c -> c.cardType).collect(toList());
+            Wonders7GameState copy = (Wonders7GameState) state.copy(2);
+
+            // check that none of the cards in the new discard pile are from Age 2
+            for (Wonder7Card card : copy.discardPile) {
+                assertEquals(1, card.cardType.age);
+            }
+            // in fact, we can check that the discard pile is the same as the copy (although the order may be different)
+            for (Wonder7Card card : copy.discardPile) {
+                assertTrue(inDiscard.contains(card.cardType));
+                inDiscard.remove(card.cardType);
+            }
+        }
     }
 }
 

--- a/src/test/java/games/wonders7/WonderAbilities.java
+++ b/src/test/java/games/wonders7/WonderAbilities.java
@@ -175,7 +175,7 @@ public class WonderAbilities {
         do {
             if (state.getRoundCounter() % 6 == 0 && state.getCurrentPlayer() == 0 && !state.isActionInProgress()) {
                 // before the first action of each Age
-                assertEquals(state.playerHands.get(2).getSize(), 7);
+                assertEquals(7, state.playerHands.get(2).getSize());
                 for (int p = 0; p < 4; p++) {
                     state.getPlayerHand(p).remove(6);  // remove random card, add expensive one
                     state.getPlayerHand(p).add(Wonder7Card.factory(Palace));
@@ -263,6 +263,39 @@ public class WonderAbilities {
         } while (state.isNotTerminal());
 
         assertEquals(3, checks);
+    }
+
+    @Test
+    public void halicarnassusOnLastRoundOfAge() {
+        // we trigger Halicarnassus on the last round of an age...and check the age still ends correctly
+        state.playerWonderBoard[3] = new Wonder7Board(Wonder7Board.Wonder.TheMausoleumOfHalicarnassus, 1);
+        for (int i = 0; i < 20; i++) { // take 20 actions (6 rounds)
+            List<AbstractAction> actions = fm.computeAvailableActions(state);
+            int index = rnd.nextInt(actions.size());
+            fm.next(state, actions.get(index));
+        }
+        assertEquals(1, state.getCurrentAge());
+        for (int p = 0; p < 4; p++) {
+            assertEquals(2, state.getPlayerHand(p).getSize()); // for the last round
+        }
+        state.playerWonderBoard[3].changeStage();  // stage one;  should allow building from discard pile
+
+        for (int i = 0; i < 4; i++) { // take 4 actions
+            List<AbstractAction> actions = fm.computeAvailableActions(state);
+            int index = rnd.nextInt(actions.size());
+            fm.next(state, actions.get(index));
+        }
+        assertTrue(state.isActionInProgress());
+        assertEquals(3, state.getCurrentPlayer());
+        assertTrue(state.currentActionInProgress() instanceof BuildFromDiscard);
+        List<AbstractAction> actions = fm.computeAvailableActions(state);
+        fm.next(state, actions.get(0));
+
+        assertEquals(2, state.getCurrentAge());
+        for (int p = 0; p < 4; p++) {
+            assertEquals(7, state.getPlayerHand(p).getSize());
+        }
+
     }
 
 }


### PR DESCRIPTION
Three bug fixes for Seven Wonders
1) Redeterminisation did not split the Age of cards...any card of a previous Age must stay in the discard pile after redeterminisation, and not be shuffled into a player's hand!
2) Special case for Halicarnassus in redeterminisation. If this special action is in process, then do not touch the discard pile.
3) BuildFromDiscard.copy() implemented for MCTS to play nicely