### PR TITLE
Remove usage of CombinatoricsUtils.factorial, which only works up to 20

### DIFF
--- a/src/main/java/utilities/Utils.java
+++ b/src/main/java/utilities/Utils.java
@@ -101,7 +101,12 @@ public abstract class Utils {
         if (selfPlay) {
             return (int) Math.pow(nAgents, nPlayers);
         } else {
-            return (int) (CombinatoricsUtils.factorial(nAgents) / CombinatoricsUtils.factorial(nAgents - nPlayers));
+            // nAgents! / (nAgents - nPlayers)!, without having to compute large factorials which may overflow an integer.
+            int ret = 1;
+            for (int i=0;i<nPlayers;i++) {
+                ret *= nAgents - i;
+            }
+            return ret;
         }
     }
 


### PR DESCRIPTION
Any tournament of more than 20 players will automatically give an error in non-self-play exhaustive mode, because 21! does not fit into a `long`. By not using factorials but just multiplying the numbers manually this allows MUCH bigger tournaments to still work properly.

For example, a 2-player tournament with 30 configurations each will have 30! / 28! = 30*29 permutations, which is easily calculable, but the intermediate step of calculating either of those two factorials will give an error. I am not aware of a function that cleanly calculates this, so I've just written a very simple forloop to do this, but please let me know if this can be done with some other preferred method.