### PR TITLE
Fix GridBoard GUI (TTT, C4, MM)

### DIFF
--- a/src/main/java/core/components/GridBoard.java
+++ b/src/main/java/core/components/GridBoard.java
@@ -304,15 +304,15 @@ public class GridBoard extends Component implements IComponentContainer<BoardNod
 
     @Override
     public String toString() {
-        String s = "";
+        StringBuilder s = new StringBuilder();
         for (int y = 0; y < getHeight(); y++) {
             for (int x = 0; x < getWidth(); x++) {
                 BoardNode t = getElement(x, y);
-                if (t != null) s += t + " ";
+                if (t != null) s.append(t.getComponentName()).append(" ");
             }
-            s += "\n";
+            s.append("\n");
         }
-        return s;
+        return s.toString();
     }
 
     /**
@@ -408,9 +408,9 @@ public class GridBoard extends Component implements IComponentContainer<BoardNod
         // Add all cells as board nodes connected to each other
         for (int i = 0; i < height; i++) {
             for (int j = 0; j < width; j++) {
-                BoardNode bn = new BoardNode(-1, getElement(j, i).toString());
+                BoardNode bn = new BoardNode(-1, getElement(j, i).getComponentName());
                 bn.setProperty(new PropertyVector2D("coordinates", new Vector2D(j, i)));
-                bn.setProperty(new PropertyString("terrain", getElement(j, i).toString()));
+                bn.setProperty(new PropertyString("terrain", getElement(j, i).getComponentName()));
                 gb.addBoardNode(bn);
                 bnMapping.put(new Vector2D(j, i), bn);
             }
@@ -446,9 +446,9 @@ public class GridBoard extends Component implements IComponentContainer<BoardNod
         for (int i = 0; i < height; i++) {
             for (int j = 0; j < width; j++) {
                 if (getElement(j, i) != null) {
-                    BoardNode bn = new BoardNode(-1, getElement(j, i).toString());
+                    BoardNode bn = new BoardNode(-1, getElement(j, i).getComponentName());
                     bn.setProperty(new PropertyVector2D("coordinates", new Vector2D(j, i)));
-                    bn.setProperty(new PropertyString("terrain", getElement(j, i).toString()));
+                    bn.setProperty(new PropertyString("terrain", getElement(j, i).getComponentName()));
                     gb.addBoardNode(bn);
                     bnMapping.put(new Vector2D(j, i), bn);
                 }

--- a/src/main/java/games/connect4/Connect4GameState.java
+++ b/src/main/java/games/connect4/Connect4GameState.java
@@ -92,7 +92,7 @@ public class Connect4GameState extends AbstractGameState implements IPrintable, 
                     sb.append(",");
                 }
                 BoardNode t = gridBoard.getElement(x, y);
-                sb.append("\"").append("Grid_").append(x).append('_').append(y).append("\":\"").append(t.toString()).append("\"");
+                sb.append("\"").append("Grid_").append(x).append('_').append(y).append("\":\"").append(t.getComponentName()).append("\"");
             }
         }
 

--- a/src/main/java/games/connect4/gui/Connect4BoardView.java
+++ b/src/main/java/games/connect4/gui/Connect4BoardView.java
@@ -111,8 +111,8 @@ public class Connect4BoardView extends ComponentView implements IScreenHighlight
 
             Font f = g.getFont();
             g.setFont(new Font(f.getName(), Font.BOLD, defaultItemSize * 3 / 2));
-            if(!element.toString().equals(Connect4Constants.emptyCell))
-                g.drawString(element.toString(), x + defaultItemSize / 16, y + defaultItemSize - defaultItemSize / 16);
+            if(!element.getComponentName().equals(Connect4Constants.emptyCell))
+                g.drawString(element.getComponentName(), x + defaultItemSize / 16, y + defaultItemSize - defaultItemSize / 16);
             g.setFont(f);
         }else
         {

--- a/src/main/java/games/connect4/gui/Connect4GUIManager.java
+++ b/src/main/java/games/connect4/gui/Connect4GUIManager.java
@@ -71,7 +71,8 @@ public class Connect4GUIManager extends AbstractGUIManager {
                     SetGridValueAction action = (SetGridValueAction) abstractAction;
                     if (action.getX() == r.x/defaultItemSize) { // && action.getY() == r.y/defaultItemSize) {
                         actionButtons[0].setVisible(true);
-                        actionButtons[0].setButtonAction(action, "Play " + Connect4Constants.playerMapping.get(player.getPlayerID())
+                        actionButtons[0].setButtonAction(action, "Play " +
+                                Connect4Constants.playerMapping.get(player.getPlayerID()).getComponentName()
                           + " in column " + (action.getX() + 1));
                         break;
                     }

--- a/src/main/java/games/mastermind/gui/MMBoardView.java
+++ b/src/main/java/games/mastermind/gui/MMBoardView.java
@@ -87,7 +87,7 @@ public class MMBoardView extends ComponentView implements IScreenHighlight {
         if (element != null) {
             Font f = g.getFont();
             g.setFont(new Font(f.getName(), Font.BOLD, scaledDefaultItemSize));
-            g.drawString(element.toString(), x + scaledDefaultItemSize / 16, y + scaledDefaultItemSize - scaledDefaultItemSize / 16);
+            g.drawString(element.getComponentName(), x + scaledDefaultItemSize / 16, y + scaledDefaultItemSize - scaledDefaultItemSize / 16);
             g.setFont(f);
         }
     }

--- a/src/main/java/games/tictactoe/TTTFeatures.java
+++ b/src/main/java/games/tictactoe/TTTFeatures.java
@@ -26,7 +26,7 @@ public class TTTFeatures implements IStateFeatureVector, IStateFeatureJSON {
         String playerSymbol = (playerId == 0) ? "x" : "o";
         for (int x = 0; x < tttgs.gridBoard.getWidth(); x++) {
             for (int y = 0; y < tttgs.gridBoard.getHeight(); y++) {
-                String cellSymbol = tttgs.gridBoard.getElement(x, y).toString();
+                String cellSymbol = tttgs.gridBoard.getElement(x, y).getComponentName();
                 if (cellSymbol.equals(playerSymbol)) {
                     json.put(x + "," + y, 1);
                 } else if (cellSymbol.equals(".")) {
@@ -46,7 +46,7 @@ public class TTTFeatures implements IStateFeatureVector, IStateFeatureJSON {
         String playerSymbol = (playerID == 0) ? "x" : "o";
         for (int x = 0; x < tttgs.gridBoard.getWidth(); x++) {
             for (int y = 0; y < tttgs.gridBoard.getHeight(); y++) {
-                String cellSymbol = tttgs.gridBoard.getElement(x, y).toString();
+                String cellSymbol = tttgs.gridBoard.getElement(x, y).getComponentName();
                 if (cellSymbol.equals(playerSymbol)) {
                     listVec.add(1.0);
                 } else if (cellSymbol.equals(".")) {

--- a/src/main/java/games/tictactoe/gui/TTTBoardView.java
+++ b/src/main/java/games/tictactoe/gui/TTTBoardView.java
@@ -93,7 +93,7 @@ public class TTTBoardView extends ComponentView implements IScreenHighlight {
         if (element != null) {
             Font f = g.getFont();
             g.setFont(new Font(f.getName(), Font.BOLD, defaultItemSize * 3 / 2));
-            g.drawString(element.toString(), x + defaultItemSize / 16, y + defaultItemSize - defaultItemSize / 16);
+            g.drawString(element.getComponentName(), x + defaultItemSize / 16, y + defaultItemSize - defaultItemSize / 16);
             g.setFont(f);
         }
     }

--- a/src/main/java/games/tictactoe/gui/TicTacToeGUIManager.java
+++ b/src/main/java/games/tictactoe/gui/TicTacToeGUIManager.java
@@ -70,7 +70,8 @@ public class TicTacToeGUIManager extends AbstractGUIManager {
                     SetGridValueAction action = (SetGridValueAction) abstractAction;
                     if (action.getX() == r.x/defaultItemSize && action.getY() == r.y/defaultItemSize) {
                         actionButtons[0].setVisible(true);
-                        actionButtons[0].setButtonAction(action, "Play " + TicTacToeConstants.playerMapping.get(player.getPlayerID()));
+                        actionButtons[0].setButtonAction(action, "Play " +
+                                TicTacToeConstants.playerMapping.get(player.getPlayerID()).getComponentName());
                         break;
                     }
                 }


### PR DESCRIPTION
Refactor to Gridboard a while ago accidentally broke the TTT, Connect4 and Mastermind GUIs.

These have now been fixed to use BoardNode.getComponentName() instead of toString()