### PR TITLE
Basic mcts copy fix

### DIFF
--- a/src/main/java/evaluation/tournaments/AbstractTournament.java
+++ b/src/main/java/evaluation/tournaments/AbstractTournament.java
@@ -54,4 +54,8 @@ public abstract class AbstractTournament implements IGameRunner {
 
         this.nPlayers = nPlayerPerGame;
     }
+
+    public Game getGame() {
+        return game;
+    }
 }

--- a/src/main/java/evaluation/tournaments/RoundRobinTournament.java
+++ b/src/main/java/evaluation/tournaments/RoundRobinTournament.java
@@ -240,6 +240,9 @@ public class RoundRobinTournament extends AbstractTournament {
     public void createAndRunMatchUp(List<Integer> matchUp) {
 
         int nTeams = byTeam ? game.getGameState().getNTeams() : nPlayers;
+        if (gameSeeds == null || gameSeeds.isEmpty()) {
+            gameSeeds = IntStream.range(0, gamesPerMatchup).mapToObj(i -> seedRnd.nextInt()).collect(toList());
+        }
         switch (tournamentMode) {
             case FIXED:
                 // we add the agents to the matchUp in the order they are in the list

--- a/src/main/java/players/basicMCTS/BasicMCTSPlayer.java
+++ b/src/main/java/players/basicMCTS/BasicMCTSPlayer.java
@@ -69,6 +69,6 @@ public class BasicMCTSPlayer extends AbstractPlayer {
 
     @Override
     public BasicMCTSPlayer copy() {
-        return this;
+        return new BasicMCTSPlayer((BasicMCTSParams) parameters.copy());
     }
 }

--- a/src/test/java/evaluation/RunGamesTest.java
+++ b/src/test/java/evaluation/RunGamesTest.java
@@ -6,6 +6,7 @@ import evaluation.tournaments.AbstractTournament;
 import evaluation.tournaments.RoundRobinTournament;
 import games.GameType;
 import org.junit.*;
+import players.basicMCTS.BasicMCTSPlayer;
 import players.mcts.MCTSPlayer;
 import players.simple.RandomPlayer;
 
@@ -142,6 +143,28 @@ public class RunGamesTest {
         List<AbstractPlayer> singleAgent = Collections.singletonList(new MCTSPlayer());
         singleAgent.get(0).getParameters().setParameterValue("budgetType", BUDGET_TIME);
         singleAgent.get(0).getParameters().setParameterValue("reuseTree", true);
+        singleAgent.get(0).getParameters().setParameterValue("budget", 20);
+        tournament = new RoundRobinTournament(singleAgent, GameType.Poker, 3, null, config);
+        tournament.createAndRunMatchUp(List.of(0, 0, 0));
+
+        Game game = tournament.getGame();
+        assertEquals(3, game.getPlayers().size());
+        assertEquals(0, game.getPlayers().get(0).getPlayerID());
+        assertEquals(1, game.getPlayers().get(1).getPlayerID());
+        assertEquals(2, game.getPlayers().get(2).getPlayerID());
+        assertNotSame(singleAgent, game.getPlayers().get(0)); // should be a copy);
+        assertNotSame(game.getPlayers().get(0), game.getPlayers().get(1)); // should be a copy
+        assertNotSame(game.getPlayers().get(0), game.getPlayers().get(2)); // should be a copy
+        assertNotSame(game.getPlayers().get(1), game.getPlayers().get(2)); // should be a copy
+    }
+
+
+    @Test
+    public void basicMCTSPlayersCopiedCorrectly() {
+        config.put(RunArg.mode, "random");
+        config.put(RunArg.matchups, 1);
+        List<AbstractPlayer> singleAgent = Collections.singletonList(new BasicMCTSPlayer());
+        singleAgent.get(0).getParameters().setParameterValue("budgetType", BUDGET_TIME);
         singleAgent.get(0).getParameters().setParameterValue("budget", 20);
         tournament = new RoundRobinTournament(singleAgent, GameType.Poker, 3, null, config);
         tournament.createAndRunMatchUp(List.of(0, 0, 0));

--- a/src/test/java/evaluation/RunGamesTest.java
+++ b/src/test/java/evaluation/RunGamesTest.java
@@ -1,16 +1,19 @@
 package evaluation;
 
 import core.AbstractPlayer;
+import core.Game;
 import evaluation.tournaments.AbstractTournament;
 import evaluation.tournaments.RoundRobinTournament;
 import games.GameType;
 import org.junit.*;
+import players.mcts.MCTSPlayer;
 import players.simple.RandomPlayer;
 
 import java.io.File;
 import java.util.*;
 
 import static org.junit.Assert.*;
+import static players.PlayerConstants.BUDGET_TIME;
 
 public class RunGamesTest {
 
@@ -131,5 +134,28 @@ public class RunGamesTest {
         assertEquals(66, tournament.getNGamesPlayed()[2], 15);
         assertEquals(66, tournament.getNGamesPlayed()[3], 15);
     }
+
+    @Test
+    public void playersCopiedCorrectly() {
+        config.put(RunArg.mode, "random");
+        config.put(RunArg.matchups, 1);
+        List<AbstractPlayer> singleAgent = Collections.singletonList(new MCTSPlayer());
+        singleAgent.get(0).getParameters().setParameterValue("budgetType", BUDGET_TIME);
+        singleAgent.get(0).getParameters().setParameterValue("reuseTree", true);
+        singleAgent.get(0).getParameters().setParameterValue("budget", 20);
+        tournament = new RoundRobinTournament(singleAgent, GameType.Poker, 3, null, config);
+        tournament.createAndRunMatchUp(List.of(0, 0, 0));
+
+        Game game = tournament.getGame();
+        assertEquals(3, game.getPlayers().size());
+        assertEquals(0, game.getPlayers().get(0).getPlayerID());
+        assertEquals(1, game.getPlayers().get(1).getPlayerID());
+        assertEquals(2, game.getPlayers().get(2).getPlayerID());
+        assertNotSame(singleAgent, game.getPlayers().get(0)); // should be a copy);
+        assertNotSame(game.getPlayers().get(0), game.getPlayers().get(1)); // should be a copy
+        assertNotSame(game.getPlayers().get(0), game.getPlayers().get(2)); // should be a copy
+        assertNotSame(game.getPlayers().get(1), game.getPlayers().get(2)); // should be a copy
+    }
+
 
 }


### PR DESCRIPTION
BasicMCTS did not copy itself nicely.

This meant that in RunGames the same agent was being used for all player positions - and hence the playerID on the agent was always the last player in the game...NOT the player making the decision. 