### PR TITLE
Saboteur fixes

### DIFF
--- a/json/players/gameSpecific/Saboteur/Saboteur.json
+++ b/json/players/gameSpecific/Saboteur/Saboteur.json
@@ -7,11 +7,10 @@
     "class": "players.heuristics.LeaderHeuristic"
   },
   "K": 1,
-  "exploreEpsilon": 0.1,
   "treePolicy": "UCB_Tuned",
   "MAST": "Both",
   "rolloutType": "MAST",
   "information": "Information_Set",
   "class": "players.mcts.MCTSParams",
-  "budget": 40
+  "budget": -999
 }

--- a/json/players/gameSpecific/Saboteur/Saboteur_LoBudget.json
+++ b/json/players/gameSpecific/Saboteur/Saboteur_LoBudget.json
@@ -1,0 +1,16 @@
+{
+  "budgetType" : "BUDGET_TIME",
+  "rolloutTermination" : "END_ROUND",
+  "rolloutLength" : 0,
+  "opponentTreePolicy" : "SelfOnly",
+  "MASTGamma" : 0.200,
+  "heuristic" : {
+    "class" : "players.heuristics.PureScoreHeuristic"
+  },
+  "FPU" : 10.0,
+  "maxTreeDepth" : 1,
+  "treePolicy" : "AlphaGo",
+  "MAST" : "Rollout",
+  "class" : "players.mcts.MCTSParams",
+  "budget" : -999
+}

--- a/json/players/gameSpecific/Saboteur/Saboteur_Tuned.json
+++ b/json/players/gameSpecific/Saboteur/Saboteur_Tuned.json
@@ -1,0 +1,16 @@
+{
+  "budgetType" : "BUDGET_TIME",
+  "rolloutLengthPerPlayer" : true,
+  "rolloutTermination" : "END_ROUND",
+  "rolloutLength" : 0,
+  "MASTGamma" : 0.200,
+  "heuristic" : {
+    "class" : "players.heuristics.LeaderHeuristic"
+  },
+  "maxTreeDepth" : 1,
+  "treePolicy" : "Uniform",
+  "MAST" : "Rollout",
+  "rolloutType" : "MAST",
+  "class" : "players.mcts.MCTSParams",
+  "budget" : -999
+}

--- a/src/main/java/core/AbstractGameState.java
+++ b/src/main/java/core/AbstractGameState.java
@@ -717,14 +717,4 @@ public abstract class AbstractGameState {
     public boolean isGameOver() {
         return gameStatus.equals(GAME_END);
     }
-
-    public int getWinner() {
-        if (gameStatus.equals(GAME_END)) {
-            for (int playerId = 0; playerId < nPlayers; playerId++)
-                if (playerResults[playerId] == WIN_GAME)
-                    return playerId;
-        }
-        return -1;
-    }
-
 }

--- a/src/main/java/evaluation/ForwardModelTester.java
+++ b/src/main/java/evaluation/ForwardModelTester.java
@@ -4,6 +4,7 @@ import core.*;
 import core.actions.AbstractAction;
 import core.interfaces.IExtendedSequence;
 import games.GameType;
+import players.IAnyTimePlayer;
 import players.PlayerFactory;
 import utilities.Utils;
 
@@ -44,6 +45,7 @@ public class ForwardModelTester {
     public ForwardModelTester(AbstractParameters params, String... args) {
         String agentToPlay = Utils.getArg(args, "agent", "random");
         int numberOfGames = Utils.getArg(args, "nGames", 1);
+        int budget = Utils.getArg(args, "budget", 50);
         String gameToRun = Utils.getArg(args, "game", "MonopolyDeal");
         int nPlayers = Utils.getArg(args, "nPlayers", 2);
         boolean verbose = Arrays.asList(args).contains("verbose");
@@ -52,6 +54,9 @@ public class ForwardModelTester {
         Game game = params == null ? gt.createGameInstance(nPlayers, seed) : gt.createGameInstance(nPlayers, params);
         List<AbstractPlayer> allPlayers = new ArrayList<>();
         AbstractPlayer agent = PlayerFactory.createPlayer(agentToPlay);
+        if (agent instanceof IAnyTimePlayer mcts) {
+            mcts.setBudget(budget);
+        }
         for (int i = 0; i < nPlayers; i++)
             allPlayers.add(agent.copy());
         Random rnd = new Random(seed);

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -231,11 +231,13 @@ public class SaboteurForwardModel extends StandardForwardModel {
             }
 
             //check when its rotated
-            card.rotate();
-            if (checkPathCardPlacement(card, sgs, location)) {
-                actions.add(new PlacePathCard(sgs.gridBoard.getComponentID(), location.getX(), location.getY(), card.getComponentID(), true));
+            if (!card.isSymmetric()) {
+                card.rotate();
+                if (checkPathCardPlacement(card, sgs, location)) {
+                    actions.add(new PlacePathCard(sgs.gridBoard.getComponentID(), location.getX(), location.getY(), card.getComponentID(), true));
+                }
+                card.rotate();
             }
-            card.rotate();
         }
         return actions;
     }

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -424,8 +424,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
         if (sgs.drawDeck.getSize() != 0) {
             currentDeck.add(sgs.drawDeck.draw());
         }
-        if (action instanceof PlacePathCard currentPlacement) {
-
+        if (action instanceof PlacePathCard) {
             recalculatePathCardOptions(sgs);
             boolean treasureFound = sgs.goalLocationsFound.stream()
                     .map(loc -> (PathCard) sgs.gridBoard.getElement(loc))

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -30,13 +30,13 @@ public class SaboteurForwardModel extends StandardForwardModel {
         SaboteurGameParameters sgp = (SaboteurGameParameters) sgs.getGameParameters();
 
         sgs.roleDeck = new PartialObservableDeck<>("RoleDeck", sgs.getNPlayers(), new boolean[sgs.getNPlayers()]);
-        for (Map.Entry<RoleCard.RoleCardType, Integer> entry: sgp.roleCardDeck.entrySet())
-        {
-            for (int i = 0; i < entry.getValue(); i++)
-            {
-                sgs.roleDeck.add(new RoleCard(entry.getKey()));
-            }
-        }
+        int nSaboteurs = sgp.saboteursForPlayerCount[sgs.getNPlayers()];
+        int nMiners = sgs.getNPlayers() - nSaboteurs;
+        for (int i = 0; i < nSaboteurs; i++)
+            sgs.roleDeck.add(new RoleCard(RoleCard.RoleCardType.Saboteur));
+        for (int i = 0; i < nMiners; i++)
+            sgs.roleDeck.add(new RoleCard(RoleCard.RoleCardType.GoldMiner));
+
         sgs.goalDeck = new Deck<>("GoalDeck", HIDDEN_TO_ALL);
         int treasures = sgp.nTreasures;
         for(int i = 0; i < sgp.nGoals; i++)
@@ -73,7 +73,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
                 sgs.nuggetDeck.add(new SaboteurCard(entry.getKey()));
             }
         }
-        sgs.nuggetDeck.shuffle(new Random(sgs.getGameParameters().getRandomSeed()));
+        sgs.nuggetDeck.shuffle(sgs.getRnd());
         setupPlayerDecks(sgs);
 
         setupRound(sgs, sgp);

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -30,7 +30,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
         sgs.roleDeck = new PartialObservableDeck<>("RoleDeck", sgs.getNPlayers(), new boolean[sgs.getNPlayers()]);
         int nSaboteurs = sgp.saboteursForPlayerCount[sgs.getNPlayers()];
-        int nMiners = sgs.getNPlayers() - nSaboteurs;
+        int nMiners = sgp.minersForPlayerCount[sgs.getNPlayers()];
         for (int i = 0; i < nSaboteurs; i++)
             sgs.roleDeck.add(new RoleCard(RoleCard.RoleCardType.Saboteur));
         for (int i = 0; i < nMiners; i++)
@@ -448,7 +448,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
         return -1;
     }
 
-    //Distribute earnings for all saboteurs (if any exists)
+    //Distribute earnings for all miners
     private void distributeMinerEarnings(SaboteurGameState sgs) {
         Deck<SaboteurCard> winningPlayersNuggetDeck = sgs.playerNuggetDecks.get(sgs.getCurrentPlayer());
 
@@ -485,7 +485,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
         setupRound(sgs, (SaboteurGameParameters) sgs.getGameParameters());
     }
 
-    //Distribute earnings for all miners
+    //Distribute earnings for all saboteurs
     private void distributeSaboteurEarnings(SaboteurGameState sgs) {
         int targetNuggetValue = 0;
         targetNuggetValue = switch (sgs.nOfSaboteurs) {

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -100,7 +100,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
     private void setupStartingHand(SaboteurGameState sgs, SaboteurGameParameters sgp) {
         for (int i = 0; i < sgs.getNPlayers(); i++) {
-            for (int j = 0; j < sgp.nStartingCards; j++) {
+            for (int j = 0; j < sgp.cardsPerPlayer[sgs.getNPlayers()]; j++) {
                 sgs.playerDecks.get(i).add(sgs.drawDeck.draw());
             }
         }

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -200,7 +200,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
         //Check Each card in players deck
         //Switch Case for each type of card you would find in hand
-
+        boolean consideredRockfall = false;
         for (int i = 0; i < currentPlayersDeck.getSize(); i++) {
             SaboteurCard card = currentPlayersDeck.peek(i);
             switch (card.type) {
@@ -212,6 +212,16 @@ public class SaboteurForwardModel extends StandardForwardModel {
                     break;
 
                 case Action:
+                    // This code is for the special case that we have two Rockfall cards in hand.
+                    // In this case there is not distinction between the two cards, so we only consider one of them
+                    // this avoids the need for an expensive distinct() check when we return the final actions list
+                    ActionCard actionCard = (ActionCard) card;
+                    if (actionCard.actionType == RockFall) {
+                        if (consideredRockfall)
+                            break;
+                        else
+                            consideredRockfall = true;
+                    }
                     actions.addAll(computeActionAction((ActionCard) card, i, sgs));
                     break;
             }
@@ -223,7 +233,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
         if (actions.isEmpty()) {
             actions.add(new DoNothing());
         }
-        return actions.stream().distinct().collect(Collectors.toList());
+        return actions;
     }
 
     //Updates the map of possible path card locations and directions whenever a path card is placed

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -64,11 +64,16 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
         sgs.discardDeck = new PartialObservableDeck<>("DiscardDeck", -1, sgs.getNPlayers(), HIDDEN_TO_ALL);
 
-        // we now build a new grid board. To avoid silliness, we do not let the players build to the left
-        int spaceForGoals = (sgp.goalSpacingY + 1) * sgp.nGoals + 10;
-        sgs.startingSquare = new Vector2D(2, spaceForGoals / 2); // we start just in on the left edge, and half way down vertically
+        // we now build a new grid board. This is not infinite to void silliness.
+        // We have a start space on the left, the number of treasure cards goalSpacingX to the right, plus the defined horizontal padding on each side
+        // and enough vertical space to fit all the goals with the required spacing, plus the defined vertical padding
+        int verticalSize = (sgp.goalSpacingY + 1) * sgp.nGoals + sgp.verticalPadding * 2;
+        int horizontalSize = sgp.goalSpacingX + 2 + sgp.horizontalPadding * 2;
 
-        sgs.gridBoard = new PartialObservableGridBoard(sgp.goalSpacingX + 5, spaceForGoals, sgs.getNPlayers(), true);
+        sgs.gridBoard = new PartialObservableGridBoard(horizontalSize, verticalSize, sgs.getNPlayers(), true);
+
+        sgs.startingSquare = new Vector2D(sgp.horizontalPadding, verticalSize / 2); // we start just in on the left edge, and half way down vertically
+
         sgs.gridBoard.setElement(sgs.startingSquare.getX(), sgs.startingSquare.getY(), new PathCard(PathCard.PathCardType.Start, new boolean[]{true, true, true, true}));
         sgs.nuggetDeck = new Deck<>("NuggetDeck", HIDDEN_TO_ALL);
         for (int goldValue = 0; goldValue < sgp.goldSupply.length; goldValue++) {

--- a/src/main/java/games/saboteur/SaboteurForwardModel.java
+++ b/src/main/java/games/saboteur/SaboteurForwardModel.java
@@ -24,8 +24,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
     //region Setup Functions
     @Override
-    protected void _setup(AbstractGameState firstState)
-    {
+    protected void _setup(AbstractGameState firstState) {
         SaboteurGameState sgs = (SaboteurGameState) firstState;
         SaboteurGameParameters sgp = (SaboteurGameParameters) sgs.getGameParameters();
 
@@ -39,24 +38,19 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
         sgs.goalDeck = new Deck<>("GoalDeck", HIDDEN_TO_ALL);
         int treasures = sgp.nTreasures;
-        for(int i = 0; i < sgp.nGoals; i++)
-        {
+        for (int i = 0; i < sgp.nGoals; i++) {
             sgs.goalDeck.add(new PathCard(PathCard.PathCardType.Goal, new boolean[]{true, true, true, true}, treasures > 0));
             treasures--;
         }
 
         sgs.drawDeck = new Deck<>("DrawDeck", HIDDEN_TO_ALL);
-        for (Map.Entry<Pair<PathCard.PathCardType, boolean[]>, Integer> entry : sgp.pathCardDeck.entrySet())
-        {
-            for (int i = 0; i < entry.getValue(); i++)
-            {
+        for (Map.Entry<Pair<PathCard.PathCardType, boolean[]>, Integer> entry : sgp.pathCardDeck.entrySet()) {
+            for (int i = 0; i < entry.getValue(); i++) {
                 sgs.drawDeck.add(new PathCard(entry.getKey().a, entry.getKey().b.clone()));
             }
         }
-        for (Map.Entry<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> entry: sgp.toolCards.entrySet())
-        {
-            for (int i = 0; i < entry.getValue(); i++)
-            {
+        for (Map.Entry<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> entry : sgp.toolCards.entrySet()) {
+            for (int i = 0; i < entry.getValue(); i++) {
                 sgs.drawDeck.add(new ActionCard(entry.getKey().a, entry.getKey().b.clone()));
             }
         }
@@ -64,12 +58,10 @@ public class SaboteurForwardModel extends StandardForwardModel {
         sgs.discardDeck = new Deck<>("DiscardDeck", sgs.getNPlayers(), HIDDEN_TO_ALL);
         sgs.gridBoard = new PartialObservableGridBoard(sgp.gridSize, sgp.gridSize, sgs.getNPlayers(), true);
         sgs.centerOfGrid = (int) Math.floor(sgp.gridSize / 2.0);
-        sgs.gridBoard.setElement(sgs.centerOfGrid, sgs.centerOfGrid, new PathCard(PathCard.PathCardType.Start, new boolean[]{true,true,true,true}));
+        sgs.gridBoard.setElement(sgs.centerOfGrid, sgs.centerOfGrid, new PathCard(PathCard.PathCardType.Start, new boolean[]{true, true, true, true}));
         sgs.nuggetDeck = new Deck<>("NuggetDeck", HIDDEN_TO_ALL);
-        for (Map.Entry<Integer, Integer> entry : sgp.goldNuggetDeck.entrySet())
-        {
-            for (int i = 0; i < entry.getValue(); i++)
-            {
+        for (Map.Entry<Integer, Integer> entry : sgp.goldNuggetDeck.entrySet()) {
+            for (int i = 0; i < entry.getValue(); i++) {
                 sgs.nuggetDeck.add(new SaboteurCard(entry.getKey()));
             }
         }
@@ -79,54 +71,43 @@ public class SaboteurForwardModel extends StandardForwardModel {
         setupRound(sgs, sgp);
     }
 
-    private void setupRound(SaboteurGameState sgs, SaboteurGameParameters sgp)
-    {
+    private void setupRound(SaboteurGameState sgs, SaboteurGameParameters sgp) {
         resetBoard(sgs, sgp);
         resetDecks(sgs);
         resetPathCardOptions(sgs);
         setupStartingHand(sgs, sgp);
     }
 
-    private void setupPlayerDecks(SaboteurGameState sgs)
-    {
+    private void setupPlayerDecks(SaboteurGameState sgs) {
         Map<ActionCard.ToolCardType, Boolean> brokenTools = new HashMap<>();
-        for (ActionCard.ToolCardType toolType : ActionCard.ToolCardType.values())
-        {
+        for (ActionCard.ToolCardType toolType : ActionCard.ToolCardType.values()) {
             brokenTools.put(toolType, true);
         }
         //Initialise Player Decks
         sgs.playerDecks.clear();
         sgs.toolDeck.clear();
         sgs.playerNuggetDecks.clear();
-        for (int i = 0; i < sgs.getNPlayers(); i++)
-        {
+        for (int i = 0; i < sgs.getNPlayers(); i++) {
             sgs.playerDecks.add(new Deck<>("Player" + i + "Deck", VISIBLE_TO_OWNER));
             sgs.toolDeck.add(new HashMap<>(brokenTools));
             sgs.playerNuggetDecks.add(new Deck<>("Player" + i + "NuggetDeck", i, VISIBLE_TO_OWNER));
         }
     }
 
-    private void setupStartingHand(SaboteurGameState sgs, SaboteurGameParameters sgp)
-    {
-        for (int i = 0; i < sgs.getNPlayers(); i++)
-        {
-            for (int j = 0; j < sgp.nStartingCards; j++)
-            {
+    private void setupStartingHand(SaboteurGameState sgs, SaboteurGameParameters sgp) {
+        for (int i = 0; i < sgs.getNPlayers(); i++) {
+            for (int j = 0; j < sgp.nStartingCards; j++) {
                 sgs.playerDecks.get(i).add(sgs.drawDeck.draw());
             }
         }
     }
 
-    private void resetBoard(SaboteurGameState sgs, SaboteurGameParameters sgp)
-    {
+    private void resetBoard(SaboteurGameState sgs, SaboteurGameParameters sgp) {
         //Initialise GridBoard with starting card
         sgs.centerOfGrid = (int) Math.floor(sgp.gridSize / 2.0);
-        for (int x = 0; x < sgs.gridBoard.getWidth(); x++)
-        {
-            for (int y = 0; y < sgs.gridBoard.getHeight(); y++)
-            {
-                if (x == sgs.centerOfGrid && y == sgs.centerOfGrid)
-                {
+        for (int x = 0; x < sgs.gridBoard.getWidth(); x++) {
+            for (int y = 0; y < sgs.gridBoard.getHeight(); y++) {
+                if (x == sgs.centerOfGrid && y == sgs.centerOfGrid) {
                     continue;
                 }
                 PathCard card = (PathCard) sgs.gridBoard.getElement(x, y);
@@ -136,33 +117,28 @@ public class SaboteurForwardModel extends StandardForwardModel {
                 sgs.gridBoard.setElement(x, y, null);
             }
         }
-        resetGoals(sgs,sgp);
+        resetGoals(sgs, sgp);
     }
 
-    private void resetGoals(SaboteurGameState sgs, SaboteurGameParameters sgp)
-    {
+    private void resetGoals(SaboteurGameState sgs, SaboteurGameParameters sgp) {
         int totalLength = sgs.goalDeck.getSize() * (sgp.goalSpacingY + 1);
         int startingY = (int) Math.floor(totalLength / 2.0) - 1;
 
-        assert sgp.goalSpacingX <= Math.floor(sgs.gridBoard.getWidth() / 2.0): "Placing Goal card out of bounds for X";
+        assert sgp.goalSpacingX <= Math.floor(sgs.gridBoard.getWidth() / 2.0) : "Placing Goal card out of bounds for X";
 
-        for(SaboteurCard goalCard: sgs.goalDeck.getComponents())
-        {
-            assert startingY <= sgs.gridBoard.getHeight(): "Placing Goal card out of bounds for Y";
+        for (SaboteurCard goalCard : sgs.goalDeck.getComponents()) {
+            assert startingY <= sgs.gridBoard.getHeight() : "Placing Goal card out of bounds for Y";
             PathCard currentCard = (PathCard) goalCard;
             sgs.gridBoard.setElement(sgp.goalSpacingX + 1 + sgs.centerOfGrid, startingY + sgs.centerOfGrid, currentCard);
             startingY -= (sgp.goalSpacingY + 1);
         }
     }
 
-    private void resetDecks(SaboteurGameState sgs)
-    {
+    private void resetDecks(SaboteurGameState sgs) {
         sgs.drawDeck.add(sgs.discardDeck);
         sgs.discardDeck.clear();
-        for (int i = 0; i < sgs.getNPlayers(); i++)
-        {
-            for (ActionCard.ToolCardType toolType : ActionCard.ToolCardType.values())
-            {
+        for (int i = 0; i < sgs.getNPlayers(); i++) {
+            for (ActionCard.ToolCardType toolType : ActionCard.ToolCardType.values()) {
                 sgs.toolDeck.get(i).put(toolType, true);
             }
             sgs.drawDeck.add(sgs.playerDecks.get(i));
@@ -175,10 +151,8 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
         // Assign roles
         sgs.roleDeck.shuffle(sgs.getRnd());
-        for(int i = 0; i < sgs.roleDeck.getSize(); i++)
-        {
-            for (int j = 0; j < sgs.getNPlayers(); j++)
-            {
+        for (int i = 0; i < sgs.roleDeck.getSize(); i++) {
+            for (int j = 0; j < sgs.getNPlayers(); j++) {
                 sgs.roleDeck.setVisibilityOfComponent(i, j, i == j);
             }
         }
@@ -188,15 +162,14 @@ public class SaboteurForwardModel extends StandardForwardModel {
         //does this remove the card?
         IntStream.range(0, sgs.getNPlayers()).mapToObj(i -> (RoleCard) sgs.roleDeck.get(i)).forEach(currentRole -> {
             if (currentRole.type == RoleCard.RoleCardType.Saboteur) {
-                sgs.nOfSaboteurs ++;
+                sgs.nOfSaboteurs++;
             } else {
-                sgs.nOfMiners ++;
+                sgs.nOfMiners++;
             }
         });
     }
 
-    private void resetPathCardOptions(SaboteurGameState sgs)
-    {
+    private void resetPathCardOptions(SaboteurGameState sgs) {
         sgs.pathCardOptions.clear();
         sgs.pathCardOptions.add(new Vector2D(sgs.centerOfGrid + 1, sgs.centerOfGrid));
         sgs.pathCardOptions.add(new Vector2D(sgs.centerOfGrid - 1, sgs.centerOfGrid));
@@ -207,8 +180,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
     //region Compute Action Functions
     @Override
-    protected List<AbstractAction> _computeAvailableActions(AbstractGameState gameState)
-    {
+    protected List<AbstractAction> _computeAvailableActions(AbstractGameState gameState) {
         //Initialise ArrayList of Abstract Actions
         ArrayList<AbstractAction> actions = new ArrayList<>();
         SaboteurGameState sgs = (SaboteurGameState) gameState;
@@ -220,14 +192,11 @@ public class SaboteurForwardModel extends StandardForwardModel {
         //Check Each card in players deck
         //Switch Case for each type of card you would find in hand
 
-        for(int i = 0; i < currentPlayersDeck.getSize(); i++)
-        {
+        for (int i = 0; i < currentPlayersDeck.getSize(); i++) {
             SaboteurCard card = currentPlayersDeck.peek(i);
-            switch(card.type)
-            {
+            switch (card.type) {
                 case Path:
-                    if(!playerHasBrokenTool)
-                    {
+                    if (!playerHasBrokenTool) {
                         actions.addAll(computePathAction((PathCard) card, sgs));
                         break;
                     }
@@ -239,36 +208,30 @@ public class SaboteurForwardModel extends StandardForwardModel {
             }
         }
 
-        for(int i = 0; i < currentPlayersDeck.getSize(); i++)
-        {
+        for (int i = 0; i < currentPlayersDeck.getSize(); i++) {
             actions.add(new Pass(i));
         }
-        if(actions.isEmpty())
-        {
+        if (actions.isEmpty()) {
             actions.add(new DoNothing());
         }
         return actions;
     }
 
     //Updates the map of possible path card locations and directions whenever a path card is placed
-    private ArrayList<AbstractAction> computePathAction(PathCard card, SaboteurGameState sgs)
-    {
+    private ArrayList<AbstractAction> computePathAction(PathCard card, SaboteurGameState sgs) {
         //Check if card can fit into key pair value
         //Rotate card, and recheck
         //If it can fit
-            //Add new action to place card
+        //Add new action to place card
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        for(Vector2D location: sgs.pathCardOptions)
-        {
-            if(checkPathCardPlacement(card, sgs, location))
-            {
+        for (Vector2D location : sgs.pathCardOptions) {
+            if (checkPathCardPlacement(card, sgs, location)) {
                 actions.add(new PlacePathCard(sgs.gridBoard.getComponentID(), location.getX(), location.getY(), card.getComponentID(), false));
             }
 
             //check when its rotated
             card.rotate();
-            if(checkPathCardPlacement(card, sgs, location))
-            {
+            if (checkPathCardPlacement(card, sgs, location)) {
                 actions.add(new PlacePathCard(sgs.gridBoard.getComponentID(), location.getX(), location.getY(), card.getComponentID(), true));
             }
             card.rotate();
@@ -277,25 +240,21 @@ public class SaboteurForwardModel extends StandardForwardModel {
     }
 
     //Check if the path card can be placed at the location
-    private boolean checkPathCardPlacement(PathCard card, SaboteurGameState sgs, Vector2D location)
-    {
+    private boolean checkPathCardPlacement(PathCard card, SaboteurGameState sgs, Vector2D location) {
         if (location.getX() < 0 || location.getY() < 0
-                || location.getX() >= ((SaboteurGameParameters)sgs.getGameParameters()).gridSize
-                || location.getY() >= ((SaboteurGameParameters)sgs.getGameParameters()).gridSize) return false;
+                || location.getX() >= ((SaboteurGameParameters) sgs.getGameParameters()).gridSize
+                || location.getY() >= ((SaboteurGameParameters) sgs.getGameParameters()).gridSize) return false;
         boolean[] currentDirections = card.getDirections();
-        for(int i = 0 ; i < 4; i++)
-        {
+        for (int i = 0; i < 4; i++) {
             Vector2D offset = getCardOffset(i);
             int neighborX = location.getX() + offset.getX();
             int neighborY = location.getY() + offset.getY();
             PathCard neighborCard = (PathCard) sgs.gridBoard.getElement(neighborX, neighborY);
-            if(neighborCard == null)
-            {
+            if (neighborCard == null) {
                 continue;
             }
             boolean[] neighbourDirections = neighborCard.getDirections();
-            if(currentDirections[i] != neighbourDirections[neighborCard.getOppositeDirection(i)])
-            {
+            if (currentDirections[i] != neighbourDirections[neighborCard.getOppositeDirection(i)]) {
                 return false;
             }
         }
@@ -304,40 +263,31 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
     //For when Rockfall card is played
     //Recalculate all possible path card options via recursion
-    private void recalculatePathCardOptions(SaboteurGameState sgs)
-    {
+    private void recalculatePathCardOptions(SaboteurGameState sgs) {
         sgs.pathCardOptions.clear();
         PathCard currentCard = (PathCard) sgs.gridBoard.getElement(sgs.centerOfGrid, sgs.centerOfGrid);
         Map<Vector2D, PathCard> previousCards = new HashMap<>();
         previousCards.put(new Vector2D(sgs.centerOfGrid, sgs.centerOfGrid), currentCard);
-        recalculatePathCardOptionsRecursive(previousCards,sgs, new Vector2D(sgs.centerOfGrid, sgs.centerOfGrid));
+        recalculatePathCardOptionsRecursive(previousCards, sgs, new Vector2D(sgs.centerOfGrid, sgs.centerOfGrid));
     }
 
-    private void recalculatePathCardOptionsRecursive(Map<Vector2D, PathCard> previousCards, SaboteurGameState sgs, Vector2D location)
-    {
+    private void recalculatePathCardOptionsRecursive(Map<Vector2D, PathCard> previousCards, SaboteurGameState sgs, Vector2D location) {
         PathCard currentCard = (PathCard) sgs.gridBoard.getElement(location.getX(), location.getY());
-        if(currentCard == null)
-        {
+        if (currentCard == null) {
             sgs.pathCardOptions.add(location);
             return;
-        }
-        else if (currentCard.type == PathCard.PathCardType.Edge)
-        {
+        } else if (currentCard.type == PathCard.PathCardType.Edge) {
             return;
-        }
-        else if (previousCards.containsKey(location) && previousCards.size() != 1)
-        {
+        } else if (previousCards.containsKey(location) && previousCards.size() != 1) {
             return;
         }
         //check adjacent cards for path card
-        for(int i = 0; i < 4; i++)
-        {
+        for (int i = 0; i < 4; i++) {
             Vector2D offset = getCardOffset(i);
             int neighborX = location.getX() + offset.getX();
             int neighborY = location.getY() + offset.getY();
             PathCard neighbourCard = (PathCard) sgs.gridBoard.getElement(neighborX, neighborY);
-            if (currentCard.getDirections()[i] && neighbourCard != previousCards.get(location))
-            {
+            if (currentCard.getDirections()[i] && neighbourCard != previousCards.get(location)) {
                 previousCards.put(new Vector2D(location.getX(), location.getY()), currentCard);
                 recalculatePathCardOptionsRecursive(previousCards, sgs, new Vector2D(neighborX, neighborY));
             }
@@ -353,8 +303,7 @@ public class SaboteurForwardModel extends StandardForwardModel {
     //5
     //6
 
-    private Vector2D getCardOffset(int value)
-    {
+    private Vector2D getCardOffset(int value) {
         return switch (value) {
             case 0 -> new Vector2D(0, -1);
             case 1 -> new Vector2D(0, 1);
@@ -364,11 +313,9 @@ public class SaboteurForwardModel extends StandardForwardModel {
         };
     }
 
-    private ArrayList<AbstractAction> computeActionAction(ActionCard card, int cardIdx, SaboteurGameState sgs)
-    {
+    private ArrayList<AbstractAction> computeActionAction(ActionCard card, int cardIdx, SaboteurGameState sgs) {
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        switch(card.actionType)
-        {
+        switch (card.actionType) {
             case BrokenTools, FixTools:
                 actions.addAll(computeToolActions(card, cardIdx, sgs));
                 break;
@@ -384,23 +331,18 @@ public class SaboteurForwardModel extends StandardForwardModel {
         return actions;
     }
 
-    private ArrayList<AbstractAction> computeToolActions(ActionCard card, int cardIdx, SaboteurGameState sgs)
-    {
+    private ArrayList<AbstractAction> computeToolActions(ActionCard card, int cardIdx, SaboteurGameState sgs) {
         //for everyone's BrokenToolDeck
         //If that player doesn't have a BrokenTool Matching it
         //new action to add card onto their BrokenToolDeck
         ArrayList<AbstractAction> actions = new ArrayList<>();
-        for(int currentPlayer = 0; currentPlayer < sgs.getNPlayers(); currentPlayer++)
-        {
-            if(currentPlayer == sgs.getCurrentPlayer())
-            {
+        for (int currentPlayer = 0; currentPlayer < sgs.getNPlayers(); currentPlayer++) {
+            if (currentPlayer == sgs.getCurrentPlayer()) {
                 continue;
             }
-            for(ActionCard.ToolCardType type : card.toolTypes)
-            {
-                if(card.actionType == BrokenTools && sgs.isToolFunctional(currentPlayer, type)
-                    || card.actionType == FixTools && !sgs.isToolFunctional(currentPlayer, type))
-                {
+            for (ActionCard.ToolCardType type : card.toolTypes) {
+                if (card.actionType == BrokenTools && sgs.isToolFunctional(currentPlayer, type)
+                        || card.actionType == FixTools && !sgs.isToolFunctional(currentPlayer, type)) {
                     actions.add(new PlayToolCard(cardIdx, currentPlayer, type, card.actionType == ActionCard.ActionCardType.FixTools));
                 }
             }
@@ -408,19 +350,15 @@ public class SaboteurForwardModel extends StandardForwardModel {
         return actions;
     }
 
-    private ArrayList<AbstractAction> computeActionMap(SaboteurGameState sgs)
-    {
+    private ArrayList<AbstractAction> computeActionMap(SaboteurGameState sgs) {
         //new action to check either 1 of the 3 goals and make it visible to the player
         //need to make grid board have visibility of some kind
         ArrayList<AbstractAction> actions = new ArrayList<>();
         PartialObservableGridBoard gridBoard = sgs.gridBoard;
-        for(int x = 0; x < gridBoard.getWidth(); x++)
-        {
-            for(int y = 0; y < gridBoard.getHeight(); y++)
-            {
+        for (int x = 0; x < gridBoard.getWidth(); x++) {
+            for (int y = 0; y < gridBoard.getHeight(); y++) {
                 PathCard currentCard = (PathCard) gridBoard.getElement(x, y);
-                if(currentCard != null && currentCard.type == PathCard.PathCardType.Goal)
-                {
+                if (currentCard != null && currentCard.type == PathCard.PathCardType.Goal) {
                     actions.add(new PlayMapCard(x, y));
                 }
             }
@@ -428,16 +366,12 @@ public class SaboteurForwardModel extends StandardForwardModel {
         return actions;
     }
 
-    private List<AbstractAction> computeActionRockFall(SaboteurGameState sgs)
-    {
+    private List<AbstractAction> computeActionRockFall(SaboteurGameState sgs) {
         List<AbstractAction> actions = new ArrayList<>();
-        for(int x = 0; x < sgs.gridBoard.getWidth(); x++)
-        {
-            for(int y = 0; y < sgs.gridBoard.getHeight(); y++)
-            {
+        for (int x = 0; x < sgs.gridBoard.getWidth(); x++) {
+            for (int y = 0; y < sgs.gridBoard.getHeight(); y++) {
                 PathCard currentCard = (PathCard) sgs.gridBoard.getElement(x, y);
-                if(currentCard != null && (currentCard.type == PathCard.PathCardType.Path || currentCard.type == PathCard.PathCardType.Edge))
-                {
+                if (currentCard != null && (currentCard.type == PathCard.PathCardType.Path || currentCard.type == PathCard.PathCardType.Edge)) {
                     actions.add(new PlayRockFallCard(sgs.gridBoard.getComponentID(), x, y));
                 }
             }
@@ -448,29 +382,23 @@ public class SaboteurForwardModel extends StandardForwardModel {
 
     //region AfterAction Functions
     @Override
-    protected void _afterAction(AbstractGameState gameState, AbstractAction action)
-    {
+    protected void _afterAction(AbstractGameState gameState, AbstractAction action) {
         SaboteurGameState sgs = (SaboteurGameState) gameState;
         //draw card for player
         Deck<SaboteurCard> currentDeck = sgs.playerDecks.get(sgs.getCurrentPlayer());
-        if(sgs.drawDeck.getSize() != 0)
-        {
+        if (sgs.drawDeck.getSize() != 0) {
             currentDeck.add(sgs.drawDeck.draw());
         }
-        if (action instanceof PlacePathCard currentPlacement)
-        {
+        if (action instanceof PlacePathCard currentPlacement) {
             boolean roundOver = false;
             int goalDirection = hasGoalInPossibleDirection(sgs, currentPlacement);
-            if(goalDirection != -1)
-            {
+            if (goalDirection != -1) {
                 Vector2D offset = getCardOffset(goalDirection);
                 PathCard goalCard = (PathCard) sgs.gridBoard.getElement(((PlacePathCard) action).getX() + offset.getX(), ((PlacePathCard) action).getY() + offset.getY());
-                for(int i = 0; i < sgs.getNPlayers(); i++)
-                {
+                for (int i = 0; i < sgs.getNPlayers(); i++) {
                     sgs.gridBoard.setElementVisibility(((PlacePathCard) action).getX() + offset.getX(), ((PlacePathCard) action).getY() + offset.getY(), i, true);
                 }
-                if(goalCard.hasTreasure())
-                {
+                if (goalCard.hasTreasure()) {
                     distributeMinerEarnings(sgs);
                     roundOver = true;
                 }
@@ -496,31 +424,23 @@ public class SaboteurForwardModel extends StandardForwardModel {
                     }
                 }
             }
-        }
-        else if(action instanceof PlayRockFallCard)
-        {
+        } else if (action instanceof PlayRockFallCard) {
             recalculatePathCardOptions(sgs);
-        }
-        else if(action instanceof DoNothing)
-        {
+        } else if (action instanceof DoNothing) {
             distributeSaboteurEarnings(sgs);
         }
         endPlayerTurn(sgs);
     }
 
     //check if path card goes into a goal
-    private int hasGoalInPossibleDirection(SaboteurGameState sgs, PlacePathCard placePathCard)
-    {
+    private int hasGoalInPossibleDirection(SaboteurGameState sgs, PlacePathCard placePathCard) {
         PathCard pathCard = (PathCard) sgs.gridBoard.getElement(placePathCard.getX(), placePathCard.getY());
         boolean[] directions = pathCard.getDirections();
-        for(int i = 0; i < pathCard.getDirections().length; i++)
-        {
-            if(directions[i])
-            {
+        for (int i = 0; i < pathCard.getDirections().length; i++) {
+            if (directions[i]) {
                 getCardOffset(i);
                 PathCard currentCard = (PathCard) sgs.gridBoard.getElement(placePathCard.getX() + getCardOffset(i).getX(), placePathCard.getY() + getCardOffset(i).getY());
-                if(currentCard != null && currentCard.type == PathCard.PathCardType.Goal)
-                {
+                if (currentCard != null && currentCard.type == PathCard.PathCardType.Goal) {
                     return i;
                 }
             }
@@ -529,52 +449,44 @@ public class SaboteurForwardModel extends StandardForwardModel {
     }
 
     //Distribute earnings for all saboteurs (if any exists)
-    private void distributeMinerEarnings(SaboteurGameState sgs)
-    {
+    private void distributeMinerEarnings(SaboteurGameState sgs) {
         Deck<SaboteurCard> winningPlayersNuggetDeck = sgs.playerNuggetDecks.get(sgs.getCurrentPlayer());
 
         int highestNuggetSizeIndex = 0;
         int highestNuggetSize = 0;
-        for(int i = 0; i < sgs.nuggetDeck.getSize(); i++)
-        {
+        for (int i = 0; i < sgs.nuggetDeck.getSize(); i++) {
             int currentNuggetSize = sgs.nuggetDeck.peek(i).nOfNuggets;
-            if(currentNuggetSize > highestNuggetSize)
-            {
+            if (currentNuggetSize > highestNuggetSize) {
                 highestNuggetSize = currentNuggetSize;
                 highestNuggetSizeIndex = i;
             }
         }
-        if(sgs.nuggetDeck.getSize() != 0)
-        {
+        if (sgs.nuggetDeck.getSize() != 0) {
             winningPlayersNuggetDeck.add(sgs.nuggetDeck.pick(highestNuggetSizeIndex));
         }
 
-        for(int player = 0; player < sgs.getNPlayers(); player++)
-        {
+        for (int player = 0; player < sgs.getNPlayers(); player++) {
             RoleCard currentPlayersRole = (RoleCard) sgs.roleDeck.get(player);
-            if(player == sgs.getCurrentPlayer() || currentPlayersRole.type == RoleCard.RoleCardType.Saboteur)
-            {
+            if (player == sgs.getCurrentPlayer() || currentPlayersRole.type == RoleCard.RoleCardType.Saboteur) {
                 continue;
             }
             Deck<SaboteurCard> currentPlayerNuggetDeck = sgs.playerNuggetDecks.get(player);
-            if(sgs.nuggetDeck.getSize() != 0)
-            {
+            if (sgs.nuggetDeck.getSize() != 0) {
                 currentPlayerNuggetDeck.add(sgs.nuggetDeck.draw());
             }
         }
 
-        if(sgs.getRoundCounter() > 1)
-        {
+        if (sgs.getRoundCounter() > 1) {
             endGame(sgs);
             return;
         }
-        setupRound(sgs, (SaboteurGameParameters) sgs.getGameParameters());
+        sgs.minersWinByRound[sgs.getRoundCounter()] = true;
         endRound(sgs);
+        setupRound(sgs, (SaboteurGameParameters) sgs.getGameParameters());
     }
 
     //Distribute earnings for all miners
-    private void distributeSaboteurEarnings(SaboteurGameState sgs)
-    {
+    private void distributeSaboteurEarnings(SaboteurGameState sgs) {
         int targetNuggetValue = 0;
         targetNuggetValue = switch (sgs.nOfSaboteurs) {
             case 1 -> 4;
@@ -583,66 +495,53 @@ public class SaboteurForwardModel extends StandardForwardModel {
             default -> targetNuggetValue;
         };
 
-        for(int player = 0; player < sgs.getNPlayers(); player++)
-        {
+        for (int player = 0; player < sgs.getNPlayers(); player++) {
             RoleCard currentPlayersRole = (RoleCard) sgs.roleDeck.get(player);
-            if(currentPlayersRole.type == RoleCard.RoleCardType.GoldMiner)
-            {
+            if (currentPlayersRole.type == RoleCard.RoleCardType.GoldMiner) {
                 continue;
             }
-            if(sgs.nuggetDeck.getSize() == 0)
-            {
+            if (sgs.nuggetDeck.getSize() == 0) {
                 break;
             }
             giveSaboteurGold(sgs, targetNuggetValue, player);
 
         }
-        if(sgs.getRoundCounter() > 2)
-        {
+        if (sgs.getRoundCounter() > 2) {
             endGame(sgs);
             return;
         }
-        setupRound(sgs, (SaboteurGameParameters) sgs.getGameParameters());
+        sgs.minersWinByRound[sgs.getRoundCounter()] = false;
         endRound(sgs);
+        setupRound(sgs, (SaboteurGameParameters) sgs.getGameParameters());
     }
 
-    private boolean nuggetExists(SaboteurGameState sgs, int targetValue)
-    {
-        for(int i = 0; i < sgs.nuggetDeck.getSize(); i++)
-        {
-            if(sgs.nuggetDeck.peek(i).nOfNuggets == targetValue)
-            {
+    private boolean nuggetExists(SaboteurGameState sgs, int targetValue) {
+        for (int i = 0; i < sgs.nuggetDeck.getSize(); i++) {
+            if (sgs.nuggetDeck.peek(i).nOfNuggets == targetValue) {
                 return true;
             }
         }
         return false;
     }
 
-    private void giveSaboteurGold(SaboteurGameState sgs, int targetValue, int currentPlayer)
-    {
+    private void giveSaboteurGold(SaboteurGameState sgs, int targetValue, int currentPlayer) {
         Deck<SaboteurCard> currentNuggetDeck = sgs.playerNuggetDecks.get(currentPlayer);
         int currentValue = 0;
         int preferredNuggetValue = 3;
-        if(preferredNuggetValue > targetValue)
-        {
+        if (preferredNuggetValue > targetValue) {
             preferredNuggetValue = targetValue;
         }
-        while(targetValue != currentValue && preferredNuggetValue > 0)
-        {
-            if(nuggetExists(sgs, preferredNuggetValue))
-            {
-                for (int i = 0; i < sgs.nuggetDeck.getSize(); i++)
-                {
-                    if (sgs.nuggetDeck.peek(i).nOfNuggets == preferredNuggetValue)
-                    {
+        while (targetValue != currentValue && preferredNuggetValue > 0) {
+            if (nuggetExists(sgs, preferredNuggetValue)) {
+                for (int i = 0; i < sgs.nuggetDeck.getSize(); i++) {
+                    if (sgs.nuggetDeck.peek(i).nOfNuggets == preferredNuggetValue) {
                         currentNuggetDeck.add(sgs.nuggetDeck.pick(i));
                         currentValue += preferredNuggetValue;
                         preferredNuggetValue = targetValue - currentValue;
                         break;
                     }
                 }
-            } else
-            {
+            } else {
                 preferredNuggetValue -= 1;
             }
         }

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -6,16 +6,15 @@ import games.saboteur.components.PathCard;
 import games.saboteur.components.RoleCard;
 import utilities.Pair;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
-public class SaboteurGameParameters extends AbstractParameters
-{
-    public int nPlayers          = 10;
-    public int nNuggets          = 27;
-    public int nGoalCards        = 3;
-    public int nRounds           = 3;
+public class SaboteurGameParameters extends AbstractParameters {
+    public int nNuggets = 27;
+    public int nGoalCards = 3;
+    public int nRounds = 3;
     public int gridSize = 500;
     public int goalSpacingX = 8;
     public int goalSpacingY = 1;
@@ -24,91 +23,49 @@ public class SaboteurGameParameters extends AbstractParameters
     public int nStartingCards = 5;
 
     //map combination of specific cards to number of cards in that deck
-    public Map<Pair<PathCard.PathCardType,boolean[]>, Integer> pathCardDeck= new HashMap<>();
-    public Map<RoleCard.RoleCardType, Integer> roleCardDeck = new HashMap<>();
+    public Map<Pair<PathCard.PathCardType, boolean[]>, Integer> pathCardDeck = new HashMap<>();
     public Map<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> toolCards = new HashMap<>();
     public Map<ActionCard.ActionCardType, Integer> actionCards = new HashMap<>();
-    public Map<Pair<PathCard.PathCardType,boolean[]>, Integer> goalCardDeck = new HashMap<>();
+    public Map<Pair<PathCard.PathCardType, boolean[]>, Integer> goalCardDeck = new HashMap<>();
     public Map<Integer, Integer> goldNuggetDeck = new HashMap<>();
 
-    public SaboteurGameParameters ()
-    {
+    //All RolesCards in a deck depending on number of players
+    //nPlayers, nMiners, nSaboteurs
+    //4	    3	1
+    //5	    4	1
+    //6	    4	2
+    //7	    5	2
+    //8	    5	3
+    //9	    6	3
+    //10	7	3
+    //11    7	4
+    public int[] saboteursForPlayerCount = new int[]{0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
+
+    public SaboteurGameParameters() {
         //All Path type cards in a deck excluding goal and start card
         PathCard.PathCardType edge = PathCard.PathCardType.Edge;
         PathCard.PathCardType path = PathCard.PathCardType.Path;
 
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, true , false, false}), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, false, true , false}), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{true , true , false, false}), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, false, true , true }), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, true , false, true }), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, true , true , false}), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{true , true , false, true }), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{true , false, true , true }), 1);
-        pathCardDeck.put(new Pair<>(edge, new boolean[]{true , true , true , true }), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, true, false, false}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, false, true, false}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{true, true, false, false}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, false, true, true}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, true, false, true}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{false, true, true, false}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{true, true, false, true}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{true, false, true, true}), 1);
+        pathCardDeck.put(new Pair<>(edge, new boolean[]{true, true, true, true}), 1);
 
-        pathCardDeck.put(new Pair<>(path, new boolean[]{true , true , false, false}), 4);
-        pathCardDeck.put(new Pair<>(path, new boolean[]{false, false, true , true }), 3);
-        pathCardDeck.put(new Pair<>(path, new boolean[]{false, true , false, true }), 4);
-        pathCardDeck.put(new Pair<>(path, new boolean[]{false, true , true , false}), 5);
-        pathCardDeck.put(new Pair<>(path, new boolean[]{true , true , false, true }), 5);
-        pathCardDeck.put(new Pair<>(path, new boolean[]{true , false, true , true }), 5);
-        pathCardDeck.put(new Pair<>(path, new boolean[]{true , true , true , true }), 5);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{true, true, false, false}), 4);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{false, false, true, true}), 3);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{false, true, false, true}), 4);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{false, true, true, false}), 5);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{true, true, false, true}), 5);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{true, false, true, true}), 5);
+        pathCardDeck.put(new Pair<>(path, new boolean[]{true, true, true, true}), 5);
 
         //All goal cards
         goalCardDeck.put(new Pair<>(PathCard.PathCardType.Goal, new boolean[]{true, true, true, true}), 5);
-
-        //All RolesCards in a deck depending on number of players
-        //nPlayers, nMiners, nSaboteurs
-        //4	    3	1
-        //5	    4	1
-        //6	    4	2
-        //7	    5	2
-        //8	    5	3
-        //9	    6	3
-        //10	7	3
-        //11    7	4
-        int nMiners;
-        int nSaboteurs = switch (nPlayers) {
-            case 3 -> {
-                nMiners = 3;
-                yield 1;
-            }
-            case 4 -> {
-                nMiners = 4;
-                yield 1;
-            }
-            case 5 -> {
-                nMiners = 4;
-                yield 2;
-            }
-            case 6 -> {
-                nMiners = 5;
-                yield 2;
-            }
-            case 7 -> {
-                nMiners = 5;
-                yield 3;
-            }
-            case 8 -> {
-                nMiners = 6;
-                yield 3;
-            }
-            case 9 -> {
-                nMiners = 7;
-                yield 3;
-            }
-            case 10 -> {
-                nMiners = 7;
-                yield 4;
-            }
-            default -> {
-                nMiners = -1;
-                yield -1;
-            }
-        };
-        roleCardDeck.put(RoleCard.RoleCardType.GoldMiner, nMiners);
-        roleCardDeck.put(RoleCard.RoleCardType.Saboteur, nSaboteurs);
 
         //All Actions Cards
         ActionCard.ToolCardType mineCart = ActionCard.ToolCardType.MineCart;
@@ -126,7 +83,7 @@ public class SaboteurGameParameters extends AbstractParameters
         toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{mineCart}), 2);
         toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{lantern}), 2);
         toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{pickaxe}), 2);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{mineCart,lantern}), 1);
+        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{mineCart, lantern}), 1);
         toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{lantern, pickaxe}), 1);
         toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{pickaxe, mineCart}), 1);
 
@@ -140,10 +97,8 @@ public class SaboteurGameParameters extends AbstractParameters
     }
 
     @Override
-    protected AbstractParameters _copy()
-    {
+    protected AbstractParameters _copy() {
         SaboteurGameParameters sgp = new SaboteurGameParameters();
-        sgp.nPlayers = nPlayers;
         sgp.nNuggets = nNuggets;
         sgp.nGoalCards = nGoalCards;
         sgp.nRounds = nRounds;
@@ -153,10 +108,10 @@ public class SaboteurGameParameters extends AbstractParameters
         sgp.nGoals = nGoals;
         sgp.nTreasures = nTreasures;
         sgp.nStartingCards = nStartingCards;
+        sgp.saboteursForPlayerCount = saboteursForPlayerCount;
         sgp.pathCardDeck = new HashMap<>();
         for (Map.Entry<Pair<PathCard.PathCardType, boolean[]>, Integer> entry : pathCardDeck.entrySet())
             sgp.pathCardDeck.put(new Pair<>(entry.getKey().a, entry.getKey().b.clone()), entry.getValue());
-        sgp.roleCardDeck = new HashMap<>(roleCardDeck);
         sgp.toolCards = new HashMap<>();
         for (Map.Entry<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> entry : toolCards.entrySet())
             sgp.toolCards.put(new Pair<>(entry.getKey().a, entry.getKey().b.clone()), entry.getValue());
@@ -173,11 +128,17 @@ public class SaboteurGameParameters extends AbstractParameters
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SaboteurGameParameters that = (SaboteurGameParameters) o;
-        return nPlayers == that.nPlayers && nNuggets == that.nNuggets && nGoalCards == that.nGoalCards && nRounds == that.nRounds && gridSize == that.gridSize && goalSpacingX == that.goalSpacingX && goalSpacingY == that.goalSpacingY && nGoals == that.nGoals && nTreasures == that.nTreasures && nStartingCards == that.nStartingCards && Objects.equals(pathCardDeck, that.pathCardDeck) && Objects.equals(roleCardDeck, that.roleCardDeck) && Objects.equals(toolCards, that.toolCards) && Objects.equals(actionCards, that.actionCards) && Objects.equals(goalCardDeck, that.goalCardDeck) && Objects.equals(goldNuggetDeck, that.goldNuggetDeck);
+        return nNuggets == that.nNuggets && nGoalCards == that.nGoalCards && nRounds == that.nRounds &&
+                gridSize == that.gridSize && goalSpacingX == that.goalSpacingX && goalSpacingY == that.goalSpacingY &&
+                nGoals == that.nGoals && nTreasures == that.nTreasures && nStartingCards == that.nStartingCards &&
+                Objects.equals(pathCardDeck, that.pathCardDeck) && Objects.equals(toolCards, that.toolCards) &&
+                Objects.equals(actionCards, that.actionCards) && Objects.equals(goalCardDeck, that.goalCardDeck) &&
+                Objects.equals(goldNuggetDeck, that.goldNuggetDeck) && Arrays.equals(saboteursForPlayerCount, that.saboteursForPlayerCount);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nPlayers, nNuggets, nGoalCards, nRounds, gridSize, goalSpacingX, goalSpacingY, nGoals, nTreasures, nStartingCards, pathCardDeck, roleCardDeck, toolCards, actionCards, goalCardDeck, goldNuggetDeck);
+        return Objects.hash(nNuggets, nGoalCards, nRounds, gridSize, goalSpacingX, goalSpacingY, nGoals, nTreasures,
+                nStartingCards, pathCardDeck, toolCards, actionCards, goalCardDeck, goldNuggetDeck) + Arrays.hashCode(saboteursForPlayerCount);
     }
 }

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -20,13 +20,14 @@ public class SaboteurGameParameters extends AbstractParameters {
     public int goalSpacingY = 1;
     public int nGoals = 3;
     public int nTreasures = 1;
-    public int nStartingCards = 5;
 
     //map combination of specific cards to number of cards in that deck
     public Map<Pair<PathCard.PathCardType, boolean[]>, Integer> pathCardDeck = new HashMap<>();
     public Map<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> toolCards = new HashMap<>();
     public Map<Integer, Integer> goldNuggetDeck = new HashMap<>();
 
+
+    // TODO: Map and Rockfall cards are not implemented (well, there is some code, but action cards are never added to the deck)
     //All RolesCards in a deck depending on number of players
     //nPlayers, nMiners, nSaboteurs
     //4	    3	1
@@ -39,6 +40,7 @@ public class SaboteurGameParameters extends AbstractParameters {
     //11    7	4
     public int[] saboteursForPlayerCount = new int[]{0, 0, 0, 1, 1, 2, 2, 3, 3, 3, 4};
     public int[] minersForPlayerCount = new int[]{0, 0, 0, 3, 4, 4, 5, 5, 6, 7, 8};
+    public int[] cardsPerPlayer = new int[]{0, 0, 0, 6, 6, 6, 5, 5, 4, 4, 4};
 
 
     public SaboteurGameParameters() {
@@ -89,9 +91,9 @@ public class SaboteurGameParameters extends AbstractParameters {
         sgp.goalSpacingX = goalSpacingX;
         sgp.nGoals = nGoals;
         sgp.nTreasures = nTreasures;
-        sgp.nStartingCards = nStartingCards;
         sgp.saboteursForPlayerCount = saboteursForPlayerCount;
         sgp.minersForPlayerCount = minersForPlayerCount;
+        sgp.cardsPerPlayer = cardsPerPlayer;
         sgp.pathCardDeck = new HashMap<>();
         for (Map.Entry<Pair<PathCard.PathCardType, boolean[]>, Integer> entry : pathCardDeck.entrySet())
             sgp.pathCardDeck.put(new Pair<>(entry.getKey().a, entry.getKey().b.clone()), entry.getValue());
@@ -109,7 +111,7 @@ public class SaboteurGameParameters extends AbstractParameters {
         SaboteurGameParameters that = (SaboteurGameParameters) o;
         return nNuggets == that.nNuggets && nGoalCards == that.nGoalCards &&
                 goalSpacingX == that.goalSpacingX && goalSpacingY == that.goalSpacingY &&
-                nGoals == that.nGoals && nTreasures == that.nTreasures && nStartingCards == that.nStartingCards &&
+                nGoals == that.nGoals && nTreasures == that.nTreasures && Arrays.equals(cardsPerPlayer, that.cardsPerPlayer) &&
                 Objects.equals(pathCardDeck, that.pathCardDeck) && Objects.equals(toolCards, that.toolCards) &&
                 Objects.equals(goldNuggetDeck, that.goldNuggetDeck) && Arrays.equals(saboteursForPlayerCount, that.saboteursForPlayerCount) &&
                 Arrays.equals(minersForPlayerCount, that.minersForPlayerCount);
@@ -118,7 +120,8 @@ public class SaboteurGameParameters extends AbstractParameters {
     @Override
     public int hashCode() {
         return Objects.hash(nNuggets, nGoalCards, goalSpacingX, goalSpacingY, nGoals, nTreasures,
-                nStartingCards, pathCardDeck, toolCards, goldNuggetDeck) +
-                Arrays.hashCode(saboteursForPlayerCount) + 31 * Arrays.hashCode(minersForPlayerCount);
+                pathCardDeck, toolCards, goldNuggetDeck) +
+                Arrays.hashCode(saboteursForPlayerCount) + 31 * Arrays.hashCode(minersForPlayerCount) +
+                31 * 31 * Arrays.hashCode(cardsPerPlayer);
     }
 }

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -76,6 +76,8 @@ public class SaboteurGameParameters extends AbstractParameters {
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Lantern, Pickaxe}), 1);
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Pickaxe, MineCart}), 1);
 
+        // TODO: Add Map and Rockfall cards to the deck
+
         //Nugget cards
         goldNuggetDeck.put(3, 4);
         goldNuggetDeck.put(2, 8);

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -16,8 +16,7 @@ import static games.saboteur.components.ActionCard.ToolCardType.*;
 public class SaboteurGameParameters extends AbstractParameters {
     public int nNuggets = 27;
     public int nGoalCards = 3;
-    public int gridSize = 500;
-    public int goalSpacingX = 8;
+    public int goalSpacingX = 3;
     public int goalSpacingY = 1;
     public int nGoals = 3;
     public int nTreasures = 1;
@@ -26,8 +25,6 @@ public class SaboteurGameParameters extends AbstractParameters {
     //map combination of specific cards to number of cards in that deck
     public Map<Pair<PathCard.PathCardType, boolean[]>, Integer> pathCardDeck = new HashMap<>();
     public Map<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> toolCards = new HashMap<>();
-    public Map<ActionCard.ActionCardType, Integer> actionCards = new HashMap<>();
-    public Map<Pair<PathCard.PathCardType, boolean[]>, Integer> goalCardDeck = new HashMap<>();
     public Map<Integer, Integer> goldNuggetDeck = new HashMap<>();
 
     //All RolesCards in a deck depending on number of players
@@ -67,9 +64,6 @@ public class SaboteurGameParameters extends AbstractParameters {
         pathCardDeck.put(new Pair<>(path, new boolean[]{true, false, true, true}), 5);
         pathCardDeck.put(new Pair<>(path, new boolean[]{true, true, true, true}), 5);
 
-        //All goal cards
-        goalCardDeck.put(new Pair<>(PathCard.PathCardType.Goal, new boolean[]{true, true, true, true}), 5);
-
         toolCards.put(new Pair<>(BrokenTools, new ActionCard.ToolCardType[]{MineCart}), 3);
         toolCards.put(new Pair<>(BrokenTools, new ActionCard.ToolCardType[]{Lantern}), 3);
         toolCards.put(new Pair<>(BrokenTools, new ActionCard.ToolCardType[]{Pickaxe}), 3);
@@ -79,9 +73,6 @@ public class SaboteurGameParameters extends AbstractParameters {
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{MineCart, Lantern}), 1);
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Lantern, Pickaxe}), 1);
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Pickaxe, MineCart}), 1);
-
-        actionCards.put(Map, 3);
-        actionCards.put(RockFall, 6);
 
         //Nugget cards
         goldNuggetDeck.put(3, 4);
@@ -94,7 +85,6 @@ public class SaboteurGameParameters extends AbstractParameters {
         SaboteurGameParameters sgp = new SaboteurGameParameters();
         sgp.nNuggets = nNuggets;
         sgp.nGoalCards = nGoalCards;
-        sgp.gridSize = gridSize;
         sgp.goalSpacingY = goalSpacingY;
         sgp.goalSpacingX = goalSpacingX;
         sgp.nGoals = nGoals;
@@ -108,10 +98,6 @@ public class SaboteurGameParameters extends AbstractParameters {
         sgp.toolCards = new HashMap<>();
         for (Map.Entry<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> entry : toolCards.entrySet())
             sgp.toolCards.put(new Pair<>(entry.getKey().a, entry.getKey().b.clone()), entry.getValue());
-        sgp.actionCards = new HashMap<>(actionCards);
-        sgp.goalCardDeck = new HashMap<>();
-        for (Map.Entry<Pair<PathCard.PathCardType, boolean[]>, Integer> entry : goalCardDeck.entrySet())
-            sgp.goalCardDeck.put(new Pair<>(entry.getKey().a, entry.getKey().b.clone()), entry.getValue());
         sgp.goldNuggetDeck = new HashMap<>(goldNuggetDeck);
         return sgp;
     }
@@ -122,18 +108,17 @@ public class SaboteurGameParameters extends AbstractParameters {
         if (o == null || getClass() != o.getClass()) return false;
         SaboteurGameParameters that = (SaboteurGameParameters) o;
         return nNuggets == that.nNuggets && nGoalCards == that.nGoalCards &&
-                gridSize == that.gridSize && goalSpacingX == that.goalSpacingX && goalSpacingY == that.goalSpacingY &&
+                goalSpacingX == that.goalSpacingX && goalSpacingY == that.goalSpacingY &&
                 nGoals == that.nGoals && nTreasures == that.nTreasures && nStartingCards == that.nStartingCards &&
                 Objects.equals(pathCardDeck, that.pathCardDeck) && Objects.equals(toolCards, that.toolCards) &&
-                Objects.equals(actionCards, that.actionCards) && Objects.equals(goalCardDeck, that.goalCardDeck) &&
                 Objects.equals(goldNuggetDeck, that.goldNuggetDeck) && Arrays.equals(saboteursForPlayerCount, that.saboteursForPlayerCount) &&
                 Arrays.equals(minersForPlayerCount, that.minersForPlayerCount);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(nNuggets, nGoalCards, gridSize, goalSpacingX, goalSpacingY, nGoals, nTreasures,
-                nStartingCards, pathCardDeck, toolCards, actionCards, goalCardDeck, goldNuggetDeck) +
+        return Objects.hash(nNuggets, nGoalCards, goalSpacingX, goalSpacingY, nGoals, nTreasures,
+                nStartingCards, pathCardDeck, toolCards, goldNuggetDeck) +
                 Arrays.hashCode(saboteursForPlayerCount) + 31 * Arrays.hashCode(minersForPlayerCount);
     }
 }

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -15,17 +15,18 @@ import static games.saboteur.components.ActionCard.ActionCardType.*;
 import static games.saboteur.components.ActionCard.ToolCardType.*;
 
 public class SaboteurGameParameters extends TunableParameters<SaboteurGameParameters> {
-    public int goalSpacingX = 8;
+    public int goalSpacingX = 5;
     public int goalSpacingY = 1;
     public int nGoals = 3;
     public int nTreasures = 1;
+    public int mapCardsInDeck = 6;
+    public int rockfallCardsInDeck = 3;
 
     //map combination of specific cards to number of cards in that deck
     public Map<Pair<PathCard.PathCardType, boolean[]>, Integer> pathCardDeck = new HashMap<>();
     public Map<Pair<ActionCard.ActionCardType, ActionCard.ToolCardType[]>, Integer> toolCards = new HashMap<>();
 
 
-    // TODO: Map and Rockfall cards are not implemented (well, there is some code, but action cards are never added to the deck)
     //All RolesCards in a deck depending on number of players
     //nPlayers, nMiners, nSaboteurs
     //4	    3	1
@@ -51,6 +52,8 @@ public class SaboteurGameParameters extends TunableParameters<SaboteurGameParame
         addTunableParameter("nuggets_1", 16);
         addTunableParameter("nuggets_2", 8);
         addTunableParameter("nuggets_3", 4);
+        addTunableParameter("mapCardsInDeck", 6);
+        addTunableParameter("rockfallCardsInDeck", 3);
 
         //All Path type cards in a deck excluding goal and start card
         PathCard.PathCardType edge = PathCard.PathCardType.Edge;
@@ -84,8 +87,6 @@ public class SaboteurGameParameters extends TunableParameters<SaboteurGameParame
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Lantern, Pickaxe}), 1);
         toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Pickaxe, MineCart}), 1);
 
-        // TODO: Add Map and Rockfall cards to the deck
-
     }
 
 
@@ -98,6 +99,8 @@ public class SaboteurGameParameters extends TunableParameters<SaboteurGameParame
         nTreasures = (int) getParameterValue("nTreasures");
         goalSpacingX = (int) getParameterValue("goalSpacingX");
         goalSpacingY = (int) getParameterValue("goalSpacingY");
+        mapCardsInDeck = (int) getParameterValue("mapCardsInDeck");
+        rockfallCardsInDeck = (int) getParameterValue("rockfallCardsInDeck");
     }
 
     @Override

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -15,7 +15,7 @@ import static games.saboteur.components.ActionCard.ActionCardType.*;
 import static games.saboteur.components.ActionCard.ToolCardType.*;
 
 public class SaboteurGameParameters extends TunableParameters<SaboteurGameParameters> {
-    public int goalSpacingX = 8;
+    public int goalSpacingX = 5;
     public int goalSpacingY = 1;
     public int nGoals = 3;
     public int nTreasures = 1;

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -15,8 +15,12 @@ import static games.saboteur.components.ActionCard.ActionCardType.*;
 import static games.saboteur.components.ActionCard.ToolCardType.*;
 
 public class SaboteurGameParameters extends TunableParameters<SaboteurGameParameters> {
-    public int goalSpacingX = 5;
-    public int goalSpacingY = 1;
+    public int goalSpacingX = 8; // the distance from start to goal cards (9 means there are 8 empty spaces between them)
+    // the standard game has this set to 8, but 6 works better with general MCTS agents
+    public int goalSpacingY = 1; // the gap between goal cards (1 means there is one empty space between them)
+    int horizontalPadding = 2; // the number of spaces to left of start, and to right of goal cards
+    int verticalPadding = 3; // the number of spaces above/below the top/bottom goal cards
+
     public int nGoals = 3;
     public int nTreasures = 1;
     public int mapCardsInDeck = 6;
@@ -54,6 +58,8 @@ public class SaboteurGameParameters extends TunableParameters<SaboteurGameParame
         addTunableParameter("nuggets_3", 4);
         addTunableParameter("mapCardsInDeck", 6);
         addTunableParameter("rockfallCardsInDeck", 3);
+        addTunableParameter("horizontalPadding", 2);
+        addTunableParameter("verticalPadding", 3);
 
         //All Path type cards in a deck excluding goal and start card
         PathCard.PathCardType edge = PathCard.PathCardType.Edge;
@@ -101,6 +107,8 @@ public class SaboteurGameParameters extends TunableParameters<SaboteurGameParame
         goalSpacingY = (int) getParameterValue("goalSpacingY");
         mapCardsInDeck = (int) getParameterValue("mapCardsInDeck");
         rockfallCardsInDeck = (int) getParameterValue("rockfallCardsInDeck");
+        horizontalPadding = (int) getParameterValue("horizontalPadding");
+        verticalPadding = (int) getParameterValue("verticalPadding");
     }
 
     @Override

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -3,7 +3,6 @@ package games.saboteur;
 import core.AbstractParameters;
 import games.saboteur.components.ActionCard;
 import games.saboteur.components.PathCard;
-import games.saboteur.components.RoleCard;
 import utilities.Pair;
 
 import java.util.Arrays;
@@ -11,10 +10,12 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Objects;
 
+import static games.saboteur.components.ActionCard.ActionCardType.*;
+import static games.saboteur.components.ActionCard.ToolCardType.*;
+
 public class SaboteurGameParameters extends AbstractParameters {
     public int nNuggets = 27;
     public int nGoalCards = 3;
-    public int nRounds = 3;
     public int gridSize = 500;
     public int goalSpacingX = 8;
     public int goalSpacingY = 1;
@@ -67,28 +68,18 @@ public class SaboteurGameParameters extends AbstractParameters {
         //All goal cards
         goalCardDeck.put(new Pair<>(PathCard.PathCardType.Goal, new boolean[]{true, true, true, true}), 5);
 
-        //All Actions Cards
-        ActionCard.ToolCardType mineCart = ActionCard.ToolCardType.MineCart;
-        ActionCard.ToolCardType lantern = ActionCard.ToolCardType.Lantern;
-        ActionCard.ToolCardType pickaxe = ActionCard.ToolCardType.Pickaxe;
+        toolCards.put(new Pair<>(BrokenTools, new ActionCard.ToolCardType[]{MineCart}), 3);
+        toolCards.put(new Pair<>(BrokenTools, new ActionCard.ToolCardType[]{Lantern}), 3);
+        toolCards.put(new Pair<>(BrokenTools, new ActionCard.ToolCardType[]{Pickaxe}), 3);
+        toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{MineCart}), 2);
+        toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Lantern}), 2);
+        toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Pickaxe}), 2);
+        toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{MineCart, Lantern}), 1);
+        toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Lantern, Pickaxe}), 1);
+        toolCards.put(new Pair<>(FixTools, new ActionCard.ToolCardType[]{Pickaxe, MineCart}), 1);
 
-        ActionCard.ActionCardType brokenTools = ActionCard.ActionCardType.BrokenTools;
-        ActionCard.ActionCardType fixTools = ActionCard.ActionCardType.FixTools;
-        ActionCard.ActionCardType map = ActionCard.ActionCardType.Map;
-        ActionCard.ActionCardType rockFall = ActionCard.ActionCardType.RockFall;
-
-        toolCards.put(new Pair<>(brokenTools, new ActionCard.ToolCardType[]{mineCart}), 3);
-        toolCards.put(new Pair<>(brokenTools, new ActionCard.ToolCardType[]{lantern}), 3);
-        toolCards.put(new Pair<>(brokenTools, new ActionCard.ToolCardType[]{pickaxe}), 3);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{mineCart}), 2);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{lantern}), 2);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{pickaxe}), 2);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{mineCart, lantern}), 1);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{lantern, pickaxe}), 1);
-        toolCards.put(new Pair<>(fixTools, new ActionCard.ToolCardType[]{pickaxe, mineCart}), 1);
-
-        actionCards.put(map, 3);
-        actionCards.put(rockFall, 6);
+        actionCards.put(Map, 3);
+        actionCards.put(RockFall, 6);
 
         //Nugget cards
         goldNuggetDeck.put(3, 4);
@@ -101,7 +92,6 @@ public class SaboteurGameParameters extends AbstractParameters {
         SaboteurGameParameters sgp = new SaboteurGameParameters();
         sgp.nNuggets = nNuggets;
         sgp.nGoalCards = nGoalCards;
-        sgp.nRounds = nRounds;
         sgp.gridSize = gridSize;
         sgp.goalSpacingY = goalSpacingY;
         sgp.goalSpacingX = goalSpacingX;
@@ -128,7 +118,7 @@ public class SaboteurGameParameters extends AbstractParameters {
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
         SaboteurGameParameters that = (SaboteurGameParameters) o;
-        return nNuggets == that.nNuggets && nGoalCards == that.nGoalCards && nRounds == that.nRounds &&
+        return nNuggets == that.nNuggets && nGoalCards == that.nGoalCards &&
                 gridSize == that.gridSize && goalSpacingX == that.goalSpacingX && goalSpacingY == that.goalSpacingY &&
                 nGoals == that.nGoals && nTreasures == that.nTreasures && nStartingCards == that.nStartingCards &&
                 Objects.equals(pathCardDeck, that.pathCardDeck) && Objects.equals(toolCards, that.toolCards) &&
@@ -138,7 +128,7 @@ public class SaboteurGameParameters extends AbstractParameters {
 
     @Override
     public int hashCode() {
-        return Objects.hash(nNuggets, nGoalCards, nRounds, gridSize, goalSpacingX, goalSpacingY, nGoals, nTreasures,
+        return Objects.hash(nNuggets, nGoalCards, gridSize, goalSpacingX, goalSpacingY, nGoals, nTreasures,
                 nStartingCards, pathCardDeck, toolCards, actionCards, goalCardDeck, goldNuggetDeck) + Arrays.hashCode(saboteursForPlayerCount);
     }
 }

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -15,7 +15,7 @@ import static games.saboteur.components.ActionCard.ActionCardType.*;
 import static games.saboteur.components.ActionCard.ToolCardType.*;
 
 public class SaboteurGameParameters extends TunableParameters<SaboteurGameParameters> {
-    public int goalSpacingX = 5;
+    public int goalSpacingX = 8;
     public int goalSpacingY = 1;
     public int nGoals = 3;
     public int nTreasures = 1;

--- a/src/main/java/games/saboteur/SaboteurGameParameters.java
+++ b/src/main/java/games/saboteur/SaboteurGameParameters.java
@@ -40,7 +40,9 @@ public class SaboteurGameParameters extends AbstractParameters {
     //9	    6	3
     //10	7	3
     //11    7	4
-    public int[] saboteursForPlayerCount = new int[]{0, 0, 0, 0, 1, 1, 2, 2, 3, 3, 4, 4};
+    public int[] saboteursForPlayerCount = new int[]{0, 0, 0, 1, 1, 2, 2, 3, 3, 3, 4};
+    public int[] minersForPlayerCount = new int[]{0, 0, 0, 3, 4, 4, 5, 5, 6, 7, 8};
+
 
     public SaboteurGameParameters() {
         //All Path type cards in a deck excluding goal and start card
@@ -99,6 +101,7 @@ public class SaboteurGameParameters extends AbstractParameters {
         sgp.nTreasures = nTreasures;
         sgp.nStartingCards = nStartingCards;
         sgp.saboteursForPlayerCount = saboteursForPlayerCount;
+        sgp.minersForPlayerCount = minersForPlayerCount;
         sgp.pathCardDeck = new HashMap<>();
         for (Map.Entry<Pair<PathCard.PathCardType, boolean[]>, Integer> entry : pathCardDeck.entrySet())
             sgp.pathCardDeck.put(new Pair<>(entry.getKey().a, entry.getKey().b.clone()), entry.getValue());
@@ -123,12 +126,14 @@ public class SaboteurGameParameters extends AbstractParameters {
                 nGoals == that.nGoals && nTreasures == that.nTreasures && nStartingCards == that.nStartingCards &&
                 Objects.equals(pathCardDeck, that.pathCardDeck) && Objects.equals(toolCards, that.toolCards) &&
                 Objects.equals(actionCards, that.actionCards) && Objects.equals(goalCardDeck, that.goalCardDeck) &&
-                Objects.equals(goldNuggetDeck, that.goldNuggetDeck) && Arrays.equals(saboteursForPlayerCount, that.saboteursForPlayerCount);
+                Objects.equals(goldNuggetDeck, that.goldNuggetDeck) && Arrays.equals(saboteursForPlayerCount, that.saboteursForPlayerCount) &&
+                Arrays.equals(minersForPlayerCount, that.minersForPlayerCount);
     }
 
     @Override
     public int hashCode() {
         return Objects.hash(nNuggets, nGoalCards, gridSize, goalSpacingX, goalSpacingY, nGoals, nTreasures,
-                nStartingCards, pathCardDeck, toolCards, actionCards, goalCardDeck, goldNuggetDeck) + Arrays.hashCode(saboteursForPlayerCount);
+                nStartingCards, pathCardDeck, toolCards, actionCards, goalCardDeck, goldNuggetDeck) +
+                Arrays.hashCode(saboteursForPlayerCount) + 31 * Arrays.hashCode(minersForPlayerCount);
     }
 }

--- a/src/main/java/games/saboteur/SaboteurGameState.java
+++ b/src/main/java/games/saboteur/SaboteurGameState.java
@@ -28,7 +28,7 @@ public class SaboteurGameState extends AbstractGameState
     boolean[] minersWinByRound = new boolean[3]; // track if miners win each of the 3 rounds
 
     Set<Vector2D> pathCardOptions;
-    int centerOfGrid;
+    Vector2D startingSquare;
 
     int nOfMiners;
     int nOfSaboteurs;
@@ -85,7 +85,7 @@ public class SaboteurGameState extends AbstractGameState
             copy.pathCardOptions.add(pathCardOption.copy());
         }
 
-        copy.centerOfGrid = centerOfGrid;
+        copy.startingSquare = startingSquare.copy();
         copy.nOfMiners = nOfMiners;
         copy.nOfSaboteurs = nOfSaboteurs;
 
@@ -278,7 +278,7 @@ public class SaboteurGameState extends AbstractGameState
     public boolean _equals(Object o) {
         if (this == o) return true;
         if (!(o instanceof SaboteurGameState that)) return false;
-        return centerOfGrid == that.centerOfGrid &&
+        return startingSquare.equals(that.startingSquare) &&
                 nOfMiners == that.nOfMiners &&
                 nOfSaboteurs == that.nOfSaboteurs &&
                 Objects.equals(playerDecks, that.playerDecks) &&
@@ -297,7 +297,7 @@ public class SaboteurGameState extends AbstractGameState
     public int hashCode() {
         return Objects.hash(playerDecks, toolDeck, roleDeck, playerNuggetDecks,
                 drawDeck, discardDeck, goalDeck, gridBoard, nuggetDeck, pathCardOptions,
-                centerOfGrid, nOfMiners, nOfSaboteurs);
+                startingSquare, nOfMiners, nOfSaboteurs);
     }
 
     @Override
@@ -306,7 +306,7 @@ public class SaboteurGameState extends AbstractGameState
         return String.format("%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s|%s",
                 playerDecks.hashCode(), toolDeck.hashCode(), roleDeck.hashCode(), playerNuggetDecks.hashCode(),
                 drawDeck.hashCode(), discardDeck.hashCode(), goalDeck.hashCode(), gridBoard.hashCode(), nuggetDeck.hashCode(),
-                pathCardOptions.hashCode(), centerOfGrid, nOfMiners, nOfSaboteurs);
+                pathCardOptions.hashCode(), startingSquare, nOfMiners, nOfSaboteurs);
     }
 
 }

--- a/src/main/java/games/saboteur/SaboteurGameState.java
+++ b/src/main/java/games/saboteur/SaboteurGameState.java
@@ -59,14 +59,13 @@ public class SaboteurGameState extends AbstractGameState {
             add(gridBoard);
             add(nuggetDeck);
             addAll(playerNuggetDecks);
-
         }};
     }
 
 
     @Override
     protected SaboteurGameState _copy(int playerId) {
-        SaboteurGameState copy = new SaboteurGameState(gameParameters.copy(), getNPlayers());
+        SaboteurGameState copy = new SaboteurGameState(gameParameters, getNPlayers());
 
         //copying brokenToolsDeck
         copy.toolDeck = new ArrayList<>();

--- a/src/main/java/games/saboteur/SaboteurGameState.java
+++ b/src/main/java/games/saboteur/SaboteurGameState.java
@@ -25,6 +25,8 @@ public class SaboteurGameState extends AbstractGameState
     PartialObservableGridBoard gridBoard;
     Deck<SaboteurCard> nuggetDeck;
 
+    boolean[] minersWinByRound = new boolean[3]; // track if miners win each of the 3 rounds
+
     Set<Vector2D> pathCardOptions;
     int centerOfGrid;
 
@@ -91,6 +93,7 @@ public class SaboteurGameState extends AbstractGameState
         copy.roleDeck = roleDeck.copy();
         copy.nuggetDeck = nuggetDeck.copy();
         copy.drawDeck = drawDeck.copy();
+        copy.minersWinByRound = Arrays.copyOf(minersWinByRound, minersWinByRound.length);
 
         // Board
         copy.gridBoard = gridBoard.emptyCopy();

--- a/src/main/java/games/saboteur/SaboteurGameState.java
+++ b/src/main/java/games/saboteur/SaboteurGameState.java
@@ -8,6 +8,7 @@ import core.components.PartialObservableDeck;
 import core.components.PartialObservableGridBoard;
 import games.GameType;
 import games.saboteur.components.*;
+import utilities.DeterminisationUtilities;
 import utilities.Vector2D;
 
 import java.util.*;
@@ -195,10 +196,9 @@ public class SaboteurGameState extends AbstractGameState {
                 }
             }
 
-            // Shuffle role deck to hide info. Current player should have same role
-            SaboteurCard rc = copy.roleDeck.pick(playerId);
-            copy.roleDeck.shuffle(redeterminisationRnd);
-            copy.roleDeck.add(rc, playerId);
+            // Shuffle role deck to hide info. Current player should have same role, and we keep any they know (if Saboteur has played Rockfall)
+            // DeterminisationUtils will automatically take into account partial observability of the deck
+            DeterminisationUtilities.reshuffle(playerId, List.of(copy.roleDeck), i -> true, redeterminisationRnd);
         } else {
             //copying playerDecks
             copy.playerDecks = new ArrayList<>();

--- a/src/main/java/games/saboteur/SaboteurMetrics.java
+++ b/src/main/java/games/saboteur/SaboteurMetrics.java
@@ -1,0 +1,45 @@
+package games.saboteur;
+
+import core.interfaces.IGameEvent;
+import evaluation.listeners.MetricsGameListener;
+import evaluation.metrics.AbstractMetric;
+import evaluation.metrics.Event;
+import evaluation.metrics.IMetricsCollection;
+import games.saboteur.components.RoleCard;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+
+public class SaboteurMetrics implements IMetricsCollection {
+
+    public static class PlayerStatus extends AbstractMetric {
+
+        @Override
+        public Set<IGameEvent> getDefaultEventTypes() {
+            return Set.of(Event.GameEvent.ROUND_OVER);
+        }
+
+        @Override
+        public Map<String, Class<?>> getColumns(int nPlayersPerGame, Set<String> playerNames) {
+            Map<String, Class<?>> columns = new HashMap<>();
+            for (int p = 0; p < nPlayersPerGame; p++) {
+                columns.put("Player" + p + "_Role", String.class);
+            }
+            columns.put("WinnerType", String.class);
+            return columns;
+        }
+
+        @Override
+        protected boolean _run(MetricsGameListener listener, Event e, Map<String, Object> records) {
+            SaboteurGameState sgs = (SaboteurGameState) e.state;
+            for (int p = 0; p < sgs.getNPlayers(); p++) {
+                RoleCard card = (RoleCard) sgs.roleDeck.get(p);
+                records.put("Player" + p + "_Role", card.type.name());
+            }
+            records.put("WinnerType", sgs.minersWinByRound[sgs.getRoundCounter()] ? "Miners" : "Saboteurs");
+            return true;
+        }
+
+    }
+}

--- a/src/main/java/games/saboteur/actions/Pass.java
+++ b/src/main/java/games/saboteur/actions/Pass.java
@@ -18,7 +18,9 @@ public class Pass extends AbstractAction
     public boolean execute(AbstractGameState gs) {
         SaboteurGameState sgs = (SaboteurGameState) gs;
         Deck<SaboteurCard> currentDeck = sgs.getPlayerDecks().get(sgs.getCurrentPlayer());
-        sgs.getDiscardDeck().add(currentDeck.pick(cardIdx));
+        boolean[] visibility = new boolean[sgs.getNPlayers()];
+        visibility[sgs.getCurrentPlayer()] = true;
+        sgs.getDiscardDeck().add(currentDeck.pick(cardIdx), visibility);
         return true;
     }
 

--- a/src/main/java/games/saboteur/actions/PlacePathCard.java
+++ b/src/main/java/games/saboteur/actions/PlacePathCard.java
@@ -54,11 +54,12 @@ public class PlacePathCard extends SetGridValueAction
     }
 
     @Override
-    public String getString(AbstractGameState gameState) {
-        return super.getString(gameState) + (rotated ? " rotated" : "");
+    public String getString(AbstractGameState state) {
+        PathCard pathCard = (PathCard) state.getComponentById(getValueID());
+        return String.format("Place %s at (%d,%d) %s.", pathCard.getString(), getX(), getY(), rotated ? " rotated" : "");
     }
 
     public String toString() {
-        return super.toString() + (rotated ? " rotated" : "");
+        return String.format("Place %d at (%d,%d) %s.", getValueID(), getX(), getY(), rotated ? " rotated" : "");
     }
 }

--- a/src/main/java/games/saboteur/actions/PlayMapCard.java
+++ b/src/main/java/games/saboteur/actions/PlayMapCard.java
@@ -55,7 +55,7 @@ public class PlayMapCard extends AbstractAction {
 
     @Override
     public int hashCode() {
-        return Objects.hash(position);
+        return Objects.hash(position) - 29874;
     }
 
     @Override

--- a/src/main/java/games/saboteur/actions/PlayRockFallCard.java
+++ b/src/main/java/games/saboteur/actions/PlayRockFallCard.java
@@ -8,31 +8,34 @@ import games.saboteur.components.ActionCard;
 import games.saboteur.components.SaboteurCard;
 
 
-public class PlayRockFallCard extends SetGridValueAction
-{
+public class PlayRockFallCard extends SetGridValueAction {
     public PlayRockFallCard(int gridBoard, int x, int y) {
         super(gridBoard, x, y, -1);
     }
 
     public boolean execute(AbstractGameState gs) {
         SaboteurGameState sgs = (SaboteurGameState) gs;
+        SaboteurCard deletedCard = (SaboteurCard) sgs.getGridBoard().getElement(getX(), getY());
         sgs.getGridBoard().setElement(getX(), getY(), null);
 
         Deck<SaboteurCard> currentDeck = sgs.getPlayerDecks().get(sgs.getCurrentPlayer());
         int idx = -1;
         for (int i = 0; i < currentDeck.getSize(); i++) {
             SaboteurCard card = currentDeck.getComponents().get(i);
-            if (card instanceof ActionCard && ((ActionCard)card).actionType == ActionCard.ActionCardType.RockFall) {
+            if (card instanceof ActionCard && ((ActionCard) card).actionType == ActionCard.ActionCardType.RockFall) {
                 idx = i;
                 break;
             }
         }
-        // reveal identity to all players
-        for (int p = 0; p < sgs.getNPlayers(); p++)
-            sgs.getRoleDeck().setVisibilityOfComponent(sgs.getCurrentPlayer(), p, true);
+        // reveal identity to all players if they Rockfalled a Path
+        if (deletedCard.type == SaboteurCard.SaboteurCardType.Path) {
+            for (int p = 0; p < sgs.getNPlayers(); p++)
+                sgs.getRoleDeck().setVisibilityOfComponent(sgs.getCurrentPlayer(), p, true);
+        }
         sgs.getDiscardDeck().add(currentDeck.pick(idx));
         return true;
     }
+
     @Override
     public PlayRockFallCard copy() {
         return this;
@@ -45,7 +48,7 @@ public class PlayRockFallCard extends SetGridValueAction
 
     @Override
     public int hashCode() {
-        return super.hashCode();
+        return super.hashCode() + 67;
     }
 
     @Override

--- a/src/main/java/games/saboteur/actions/PlayRockFallCard.java
+++ b/src/main/java/games/saboteur/actions/PlayRockFallCard.java
@@ -27,6 +27,9 @@ public class PlayRockFallCard extends SetGridValueAction
                 break;
             }
         }
+        // reveal identity to all players
+        for (int p = 0; p < sgs.getNPlayers(); p++)
+            sgs.getRoleDeck().setVisibilityOfComponent(sgs.getCurrentPlayer(), p, true);
         sgs.getDiscardDeck().add(currentDeck.pick(idx));
         return true;
     }

--- a/src/main/java/games/saboteur/components/ActionCard.java
+++ b/src/main/java/games/saboteur/components/ActionCard.java
@@ -19,7 +19,7 @@ public class ActionCard extends SaboteurCard
                 }
                 case Lantern -> { return "Lant";
                 }
-                case Pickaxe -> { return "PAxe";
+                case Pickaxe -> { return "Axe";
                 }
             }
             return "";

--- a/src/main/java/games/saboteur/components/PathCard.java
+++ b/src/main/java/games/saboteur/components/PathCard.java
@@ -7,6 +7,7 @@ public class PathCard extends SaboteurCard {
     final private boolean[] directions;  // The array is final - but the contents are not!
     final public PathCardType type;
     final boolean hasTreasure;
+    final boolean symmetric;
 
     public enum PathCardType {
         Edge,
@@ -24,6 +25,7 @@ public class PathCard extends SaboteurCard {
         this.type = type;
         this.directions = direction;
         this.hasTreasure = hasTreasure;
+        this.symmetric = direction[0] == direction[1] && direction[2] == direction[3];
     }
 
     public PathCard(PathCardType type, boolean[] direction, boolean hasTreasure, int componentID) {
@@ -31,6 +33,7 @@ public class PathCard extends SaboteurCard {
         this.type = type;
         this.directions = direction;
         this.hasTreasure = hasTreasure;
+        this.symmetric = direction[0] == direction[1] && direction[2] == direction[3];
     }
 
     public void rotate()
@@ -59,6 +62,8 @@ public class PathCard extends SaboteurCard {
             default -> -1;
         };
     }
+
+    public boolean isSymmetric() {return symmetric;}
 
 
     public boolean hasTreasure() {

--- a/src/main/java/games/saboteur/components/SaboteurCard.java
+++ b/src/main/java/games/saboteur/components/SaboteurCard.java
@@ -55,4 +55,9 @@ public class SaboteurCard extends BoardNode
     public int hashCode() {
         return Objects.hash(super.hashCode(), type, nOfNuggets);
     }
+
+    @Override
+    public String toString() {
+        return String.format("%s (%d)", type.name(), nOfNuggets);
+    }
 }

--- a/src/main/java/games/saboteur/gui/SaboteurBoardView.java
+++ b/src/main/java/games/saboteur/gui/SaboteurBoardView.java
@@ -61,7 +61,8 @@ public class SaboteurBoardView extends JComponent {
         for (int i = 0; i < board.getHeight(); i++) {
             for (int j = 0; j < board.getWidth(); j++) {
                 PathCard card = (PathCard) board.getElement(j, i);
-                if (card != null) drawPathCard((Graphics2D) g, card, panPos.x + j * cellWidth, panPos.y + i * cellHeight);
+                int humanID = gui.getHumanPlayerIds().iterator().next();
+                if (card != null) drawPathCard((Graphics2D) g, card, panPos.x + j * cellWidth, panPos.y + i * cellHeight, board.getElementVisibility(j, i).get(humanID));
                 if (gui.gridHighlight != null && gui.gridHighlight.x == j && gui.gridHighlight.y == i) {
                     g.setColor(Color.green);
                     g.drawRect(panPos.x + j * cellWidth, panPos.y + i * cellHeight, cellWidth, cellHeight);
@@ -70,7 +71,7 @@ public class SaboteurBoardView extends JComponent {
         }
     }
 
-    public static void drawPathCard (Graphics2D g, PathCard card, int pX, int pY) {
+    public static void drawPathCard (Graphics2D g, PathCard card, int pX, int pY, boolean visibility) {
         int mX = pX + cellWidth/2;
         int mY = pY + cellHeight/2;
 
@@ -121,10 +122,14 @@ public class SaboteurBoardView extends JComponent {
 
         if (card.type == PathCard.PathCardType.Goal) {
             // Draw treasure in center of card
-            if (card.hasTreasure()) {
-                g.setColor(Color.yellow);
+            if (visibility) {
+                if (card.hasTreasure()) {
+                    g.setColor(Color.yellow);
+                } else {
+                    g.setColor(Color.black);
+                }
             } else {
-                g.setColor(Color.black);
+                g.setColor(Color.darkGray);
             }
             g.fillOval(pX + cellWidth/2, pY + cellWidth/2, 10, 10);
         }

--- a/src/main/java/games/saboteur/gui/SaboteurGUIManager.java
+++ b/src/main/java/games/saboteur/gui/SaboteurGUIManager.java
@@ -30,8 +30,8 @@ import java.util.Set;
 public class SaboteurGUIManager extends AbstractGUIManager {
     //all subjected to change
     final static int playerAreaWidth = 200;
-    final static int playerAreaHeight = 100;
-    final static int boardSize = 500;
+    final static int playerAreaHeight = 150;
+    final static int boardSize = 400;
 
     SaboteurGameState gs;
     SaboteurForwardModel fm;

--- a/src/main/java/games/saboteur/gui/SaboteurGUIManager.java
+++ b/src/main/java/games/saboteur/gui/SaboteurGUIManager.java
@@ -83,9 +83,9 @@ public class SaboteurGUIManager extends AbstractGUIManager {
                 // Find required size of window
                 int nPlayers = gameState.getNPlayers();
                 int nHorizAreas = 4;
-                double nVertAreas = Math.floor(nPlayers / 4.);
+                int nVertAreas = 2;
                 this.width = playerAreaWidth * nHorizAreas;
-                this.height = (int) (playerAreaHeight * nVertAreas) + boardSize;
+                this.height = (playerAreaHeight * nVertAreas) + boardSize;
                 ruleText.setPreferredSize(new Dimension(width + 50, height + defaultInfoPanelHeight));
 
                 parent.setBackground(ImageIO.GetInstance().getImage("data/loveletter/bg.png"));

--- a/src/main/java/games/saboteur/gui/SaboteurPlayerView.java
+++ b/src/main/java/games/saboteur/gui/SaboteurPlayerView.java
@@ -59,7 +59,7 @@ public class SaboteurPlayerView extends DeckView<SaboteurCard> {
                     }
                 }
             } else if (component instanceof PathCard) {
-                drawPathCard(g, (PathCard) component, rect.x, rect.y);
+                drawPathCard(g, (PathCard) component, rect.x, rect.y, true);
             } else if (component instanceof RoleCard roleCard) {
                 g.drawString(""+roleCard.type.name().charAt(0), rect.x + 5, rect.y + 20);
             }

--- a/src/main/java/games/saboteur/gui/SaboteurPlayerView.java
+++ b/src/main/java/games/saboteur/gui/SaboteurPlayerView.java
@@ -72,14 +72,17 @@ public class SaboteurPlayerView extends DeckView<SaboteurCard> {
 
         // Draw player role and number of nugget cards
         g.setColor(Color.black);
-        g.drawString("Role: " + gs.getRole(idx).name() + "; nuggetCards: " + gs.getPlayerNuggetDecks().get(idx).getSize(), 7, (int) (SaboteurBoardView.cellHeight * 1.5));
+        if (human)
+            g.drawString( gs.getRole(idx).name() + "; Nuggets: " + gs.getPlayerNuggetDecks().get(idx).getSize(), 7, (int) (SaboteurBoardView.cellHeight * 1.5));
+        else
+            g.drawString( "Nuggets: " + gs.getPlayerNuggetDecks().get(idx).getSize(), 7, (int) (SaboteurBoardView.cellHeight * 1.5));
 
         // Draw tool status
-        String tools = "";
+        StringBuilder tools = new StringBuilder();
         for (ActionCard.ToolCardType tt: ActionCard.ToolCardType.values()) {
-            tools += tt.name() + ": " + (gs.isToolFunctional(idx, tt) ? "ok" : "broken") + "   ";
+            tools.append(tt.shortString()).append(": ").append(gs.isToolFunctional(idx, tt) ? "ok" : "XX").append("   ");
         }
-        g.drawString(tools, 7, (int) (SaboteurBoardView.cellHeight * 1.5) + 20);
+        g.drawString(tools.toString(), 7, (int) (SaboteurBoardView.cellHeight * 1.5) + 20);
     }
 
     public void update(boolean front) {

--- a/src/main/java/games/saboteur/gui/SaboteurPlayerView.java
+++ b/src/main/java/games/saboteur/gui/SaboteurPlayerView.java
@@ -88,6 +88,14 @@ public class SaboteurPlayerView extends DeckView<SaboteurCard> {
 
     @Override
     public Dimension getPreferredSize() {
-        return new Dimension(SaboteurBoardView.cellWidth*8, SaboteurBoardView.cellHeight*3);
+        return new Dimension(SaboteurBoardView.cellWidth * 6, SaboteurGUIManager.playerAreaHeight);
+    }
+    @Override
+    public Dimension getMinimumSize() {
+        return getPreferredSize();
+    }
+    @Override
+    public Dimension getMaximumSize() {
+        return getPreferredSize();
     }
 }

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -11,7 +11,7 @@ public class ForwardModelTestsWithMCTS {
 
     @Test
     public void testSaboteur() {
-        new ForwardModelTester("game=Saboteur", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Saboteur.json");
+        new ForwardModelTester("game=Saboteur", "nGames=3", "nPlayers=5", "agent=json\\players\\gameSpecific\\Saboteur\\Saboteur.json");
     }
 
     @Test

--- a/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
+++ b/src/test/java/games/fmtester/ForwardModelTestsWithMCTS.java
@@ -11,7 +11,7 @@ public class ForwardModelTestsWithMCTS {
 
     @Test
     public void testSaboteur() {
-        new ForwardModelTester("game=Saboteur", "nGames=1", "nPlayers=3", "agent=json\\players\\gameSpecific\\Saboteur.json");
+        new ForwardModelTester("game=Saboteur", "nGames=1", "nPlayers=5", "agent=json\\players\\gameSpecific\\Saboteur.json");
     }
 
     @Test


### PR DESCRIPTION
Various fixes and refactors to Saboteur to fix some issues.

The main problem was that games were always ending in the same result depending on the random seed. This was because MCTS agents never got anywhere near a reward with search, and as a result the Saboteurs won every single round.

- Added parameterisation of the distance from the starting line to the gold nuggets
- Set boundaries on the expanse of the overall board to stop very silly placing of tiles (now the board ends at a line 2 squares to the left of the starting point, and also has a lmit of 5 squares above/below the top/bottom nuggets).
- Fixed the GUI so that you can now see the cards you have and the actions that are available.
- Also implemented the missing cards (Map and Rockfall cards were never added to player hands, and hence never used)

This revealed that there were some other deeper/more subtle problems. The key one was that the game did not allow a path from the start to track *through* an empty destination card, which made the game really very difficult for the miners! Hence I refactored parts of the route-checking to make this both more accurate and robust (and profiled to ensure this was not a performance issue).