### PR TITLE
Slim PyTAG jar + release automation

### DIFF
--- a/.github/workflows/release-pytag-jar.yml
+++ b/.github/workflows/release-pytag-jar.yml
@@ -1,0 +1,36 @@
+name: Attach PyTAG jar to release
+
+# Runs when a maintainer publishes a GitHub Release (as has always been done for
+# this repo's v1.0/v2.0/... tags). Builds the project and attaches the slim
+# PyTAG runtime jar (target/TAG-pytag.jar, see src/assembly/pytag-jar.xml) to
+# that same release as an asset named TAG.jar - the exact filename and URL
+# shape (.../releases/latest/download/TAG.jar) that PyTAG's jar_setup.py
+# expects (github.com/martinballa/PyTAG).
+on:
+  release:
+    types: [published]
+
+permissions:
+  contents: write
+
+jobs:
+  build-and-upload:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-java@v4
+        with:
+          java-version: '21'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Build
+        run: mvn -B package
+
+      - name: Upload TAG-pytag.jar as TAG.jar release asset
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh release upload "${{ github.event.release.tag_name }}" \
+            target/TAG-pytag.jar#TAG.jar --clobber

--- a/pom.xml
+++ b/pom.xml
@@ -231,6 +231,38 @@
                             </archive>
                             <finalName>TAG</finalName>
                             <appendAssemblyId>false</appendAssemblyId>
+                            <!-- Without this, this execution replaces the project's main-artifact
+                                 reference with the fat TAG.jar, which the next execution's
+                                 useProjectArtifact would then pick up instead of the plain
+                                 classes-only jar, silently defeating its dependency filtering. -->
+                            <attach>false</attach>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <!-- Slim jar for PyTAG (github.com/martinballa/PyTAG): engine + games + players
+                             + GUI/replay, without the Spark/Hadoop ML-learner, tablesaw analytics, or
+                             LLM dependency trees. See src/assembly/pytag-jar.xml for what's excluded. -->
+                        <id>make-pytag-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                        <configuration>
+                            <descriptors>
+                                <descriptor>src/assembly/pytag-jar.xml</descriptor>
+                            </descriptors>
+                            <archive>
+                                <manifest>
+                                    <mainClass>core.TAG</mainClass>
+                                </manifest>
+                                <manifestEntries>
+                                    <Implementation-Title>TAG-pytag</Implementation-Title>
+                                    <Description>Slim TAG runtime jar for PyTAG (github.com/martinballa/PyTAG): engine, games, players and GUI/replay only, no Spark/Hadoop ML-learner, tablesaw analytics or LLM dependencies.</Description>
+                                </manifestEntries>
+                            </archive>
+                            <finalName>TAG-pytag</finalName>
+                            <appendAssemblyId>false</appendAssemblyId>
+                            <attach>false</attach>
                         </configuration>
                     </execution>
                 </executions>

--- a/src/assembly/pytag-jar.xml
+++ b/src/assembly/pytag-jar.xml
@@ -1,0 +1,55 @@
+<assembly xmlns="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/plugins/maven-assembly-plugin/assembly/1.1.3 http://maven.apache.org/xsd/assembly-1.1.3.xsd">
+    <!--
+      Slimmed-down jar for PyTAG (github.com/martinballa/PyTAG): the core engine, all games,
+      the built-in players/agents, and the Swing GUI (incl. JSON-replay in gui.Frontend), but
+      none of the Spark/Hadoop-based heuristic learners, tablesaw analytics, or the LLM module.
+      Those pull in ~400MB of transitive deps (Spark, Hadoop, RocksDB, Scala, langchain4j,
+      google-cloud) that PyTAG never touches. Keep this include list in sync with pom.xml if a
+      dependency genuinely needed by core/games/players(non-heuristics/learners)/gui changes.
+    -->
+    <id>pytag</id>
+    <formats>
+        <format>jar</format>
+    </formats>
+    <includeBaseDirectory>false</includeBaseDirectory>
+    <dependencySets>
+        <dependencySet>
+            <!-- No useTransitiveFiltering: each artifact below (direct or transitive) is matched
+                 individually against the resolved dependency graph, so the full closure needed by
+                 the 9 direct deps we keep is spelled out explicitly rather than inferred. -->
+            <outputDirectory>/</outputDirectory>
+            <useProjectArtifact>true</useProjectArtifact>
+            <unpack>true</unpack>
+            <scope>runtime</scope>
+            <includes>
+                <include>ai.tabletopgames:ModernBoardGame</include>
+                <include>com.googlecode.json-simple:json-simple</include>
+                <include>com.google.code.gson:gson</include>
+                <include>com.github.davidmoten:word-wrap</include>
+                <include>com.github.davidmoten:guava-mini</include>
+                <include>org.slf4j:slf4j-nop</include>
+                <include>org.slf4j:slf4j-api</include>
+                <include>org.knowm.xchart:xchart</include>
+                <include>de.erichseifert.vectorgraphics2d:VectorGraphics2D</include>
+                <include>de.rototor.pdfbox:graphics2d</include>
+                <include>org.apache.pdfbox:pdfbox</include>
+                <include>org.apache.pdfbox:fontbox</include>
+                <include>commons-logging:commons-logging</include>
+                <include>com.madgag:animated-gif-lib</include>
+                <include>org.swinglabs:swingx</include>
+                <include>com.jhlabs:filters</include>
+                <include>org.swinglabs:swing-worker</include>
+                <include>org.apache.commons:commons-lang3</include>
+                <include>com.github.javaparser:javaparser-core</include>
+                <include>commons-io:commons-io</include>
+            </includes>
+        </dependencySet>
+    </dependencySets>
+    <containerDescriptorHandlers>
+        <containerDescriptorHandler>
+            <handlerName>metaInf-services</handlerName>
+        </containerDescriptorHandler>
+    </containerDescriptorHandlers>
+</assembly>

--- a/src/main/java/games/gofish/gui/GoFishPlayerView.java
+++ b/src/main/java/games/gofish/gui/GoFishPlayerView.java
@@ -25,7 +25,7 @@ public class GoFishPlayerView extends JComponent {
 
         // Player hand
         this.playerHandView = new GoFishDeckView(
-                humanIds.stream().toList().getFirst(),
+                humanIds.stream().findFirst().orElse(-1),
                 hand,
                 true,
                 null,

--- a/src/main/java/games/seasaltpaper/gui/SSPPlayerView.java
+++ b/src/main/java/games/seasaltpaper/gui/SSPPlayerView.java
@@ -33,7 +33,7 @@ public class SSPPlayerView extends JPanel {
         this.height = playerAreaHeight*2 + borderBottom + border + borderBottom;
         this.playerId = playerId;
 
-        int humanId = human.stream().toList().getFirst();
+        int humanId = human.stream().findFirst().orElse(-1);
         this.playerHandView = new SSPDeckView(humanId, playerHand, true, dataPath, new Rectangle(border, border, playerAreaWidth, playerAreaHeight));  // todo only visible if player is human or always fully observable
         this.playerDiscardView = new SSPDeckView(humanId, playerDiscard, true, dataPath, new Rectangle(border, border, playerAreaWidth, playerAreaHeight));
         this.pointsText = new JLabel(0 + " points");

--- a/src/main/java/games/sushigo/gui/SGPlayerView.java
+++ b/src/main/java/games/sushigo/gui/SGPlayerView.java
@@ -33,7 +33,7 @@ public class SGPlayerView extends JComponent {
 //        this.width = playerAreaWidth + border*20;
 //        this.height = playerAreaHeight + border + borderBottom;
         this.playerId = playerId;
-        int human = humanId.stream().toList().getFirst();
+        int human = humanId.stream().findFirst().orElse(-1);
         this.playerHandView = new SGDeckView(human, deck, true, dataPath, new Rectangle(border, border, playerAreaWidth-50, playerAreaHeight));
         this.playedCardsView = new SGDeckView(human, playDeck, true, dataPath, new Rectangle(border, border, playerAreaWidth-50, playerAreaHeight));
         this.pointsText = new JLabel(0 + " points");


### PR DESCRIPTION
## Summary
- Adds a second `maven-assembly-plugin` execution producing `target/TAG-pytag.jar` (~13MB vs ~404MB for the full `TAG.jar`), built from `src/assembly/pytag-jar.xml`. It keeps the core engine, all games, built-in players, and the Swing GUI/replay path, but excludes the Spark/Hadoop ML-learner, tablesaw analytics, and langchain4j/google-cloud dependency trees that [PyTAG](https://github.com/martinballa/PyTAG) never touches. Verified end-to-end against the real PyTAG package via JPype (vector + JSON obs examples, multi-agent).
- Fixes a crash (`NoSuchElementException`) in `SSPPlayerView`, `SGPlayerView`, and `GoFishPlayerView` when constructing the GUI with no human player (e.g. all-AI games, or PyTAG's RL agents) - they called `human.stream().toList().getFirst()` instead of falling back to `-1` like `LoveLetterPlayerView` already does. Found while sweeping games to verify the slim jar renders correctly.
- Adds `.github/workflows/release-pytag-jar.yml`: on publishing a GitHub release, builds the project and uploads `target/TAG-pytag.jar` as an asset named `TAG.jar`, matching the URL shape (`.../releases/latest/download/TAG.jar`) PyTAG's `jar_setup.py` expects.

## Test plan
- [x] `mvn package` builds both `TAG.jar` and `TAG-pytag.jar` cleanly
- [x] `TAG-pytag.jar` verified against a real `pip install -e .` PyTAG checkout (JPype), running `pt-action-masking.py` (vector obs, action masking) and `ma-random.py` (JSON obs, multi-agent) to completion
- [x] Swept ~11 games (incl. asset-heavy ones: Pandemic, ColtExpress, Dominion, Uno, Catan) launching the GUI manager on the slim jar with no exceptions
- [ ] Release workflow itself is untested against a real GitHub release (needs a maintainer to publish a release to trigger it)