### PR TITLE
MCTS and game fixes

### DIFF
--- a/src/main/java/evaluation/optimisation/ITPSearchSpace.java
+++ b/src/main/java/evaluation/optimisation/ITPSearchSpace.java
@@ -253,12 +253,23 @@ public class ITPSearchSpace<T> extends AgentSearchSpace<T> {
         return itp.instanceToJSON(true, settingsMap);
     }
 
-    @SuppressWarnings("unchecked")
-    public void writeAgentJSON(int[] settings, String fileName) {
+    /*
+    This is subtly different from the above method in that it will write the JSON to a file.
+    This means that it needs to use the defaults from the underlying classes, and not from the search space
+    This is because for those items with no setting (i.e. fixed in search space), we need to pick up this as the default during search
+    BUT - the default is elided when we write to file is not in settings
+     */
+    public JSONObject constructAgentJSONToWriteToFile(int[] settings) {
         JSONObject json = constructAgentJSON(settings);
         int budget = (int) itp.getParameterValue("budget");
         if (budget > 0)
             json.put("budget", budget);
+        return json;
+    }
+
+    @SuppressWarnings("unchecked")
+    public void writeAgentJSON(int[] settings, String fileName) {
+        JSONObject json = constructAgentJSONToWriteToFile(settings);
         JSONUtils.writeJSON(json, fileName);
     }
 

--- a/src/main/java/evaluation/optimisation/TunableParameters.java
+++ b/src/main/java/evaluation/optimisation/TunableParameters.java
@@ -435,7 +435,8 @@ public abstract class TunableParameters<T> extends AbstractParameters implements
                     Map<String, Integer> subSettings = settings.entrySet().stream()
                             .filter(e -> e.getKey().contains("."))
                             .collect(toMap(e -> e.getKey().substring(e.getKey().indexOf(".") + 1), Map.Entry::getValue));
-                    value = tp.instanceToJSON(excludeDefaults, subSettings);
+                    // because all values are hoisted up to the top level in a search space, we do not reliably have all the defaults at lower levels
+                    value = tp.instanceToJSON(false, subSettings);
                 } else {
                     if (value instanceof Enum) {
                         value = value.toString();

--- a/src/main/java/games/chess/ChessForwardModel.java
+++ b/src/main/java/games/chess/ChessForwardModel.java
@@ -47,7 +47,7 @@ public class ChessForwardModel extends StandardForwardModel {
         chessState.setPiece(5, 7, new ChessPiece(ChessPiece.ChessPieceType.BISHOP, 1, 5, 7, ChessPiece.MovedState.NOT_RELEVANT));
         chessState.setPiece(6, 7, new ChessPiece(ChessPiece.ChessPieceType.KNIGHT, 1, 6, 7, ChessPiece.MovedState.NOT_RELEVANT));
         chessState.setPiece(7, 7, new ChessPiece(ChessPiece.ChessPieceType.ROOK, 1, 7, 7, ChessPiece.MovedState.NOT_MOVED));
-        chessState.AddCheckRepetitionCount();
+        chessState.addCheckRepetitionCount();
 
         chessState.halfMoveClock = 0;
     }
@@ -576,8 +576,8 @@ public class ChessForwardModel extends StandardForwardModel {
 
 
         //Check draw by repetition. The game is drawn if a board position is repeated drawByRepetition times. Default is 3, if set to 0, it is disabled.
-        if (chessState.isNotTerminal() && chessParameters.drawByRepetition != 0) {
-            if (chessState.AddCheckRepetitionCount()) {
+        if (chessState.isNotTerminal()) {
+            if (chessState.addCheckRepetitionCount()) {
                 chessState.setPlayerResult(CoreConstants.GameResult.DRAW_GAME, chessState.getCurrentPlayer());
                 chessState.setPlayerResult(CoreConstants.GameResult.DRAW_GAME, 1 - chessState.getCurrentPlayer());
                 chessState.setGameStatus(CoreConstants.GameResult.GAME_END);

--- a/src/main/java/games/chess/ChessGameState.java
+++ b/src/main/java/games/chess/ChessGameState.java
@@ -29,10 +29,6 @@ public class ChessGameState extends AbstractGameState {
     //Number of moves without a pawn move or capture
     int halfMoveClock = 0;
 
-
-    
-    
-
     public ChessGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, nPlayers);
 
@@ -70,47 +66,11 @@ public class ChessGameState extends AbstractGameState {
             // Simple value for each piece on the board, weighted by its type. Find the difference between the two players.
             double playerScore = 0.0; 
             double opponentScore = 0.0;
-            for (ChessPiece piece : getPlayerPieces(1 - playerId)) {   
-                ChessPiece.ChessPieceType type = piece.getChessPieceType();
-                switch (type) {
-                    case PAWN:
-                        opponentScore += 1;
-                        break;
-                    case KNIGHT:
-                    case BISHOP:
-                        opponentScore += 3;
-                        break;
-                    case ROOK:
-                        opponentScore += 5;
-                        break;
-                    case QUEEN:
-                        opponentScore += 9;
-                        break;
-                    case KING:
-                        opponentScore += 0;
-                        break;
-                }
+            for (ChessPiece piece : getPlayerPieces(1 - playerId)) {
+                opponentScore = getChessHeuristic(opponentScore, piece);
             }
             for (ChessPiece piece : getPlayerPieces(playerId)) {
-                ChessPiece.ChessPieceType type = piece.getChessPieceType();
-                switch (type) {
-                    case PAWN:
-                        playerScore += 1;
-                        break;
-                    case KNIGHT:
-                    case BISHOP:
-                        playerScore += 3;
-                        break;
-                    case ROOK:
-                        playerScore += 5;
-                        break;
-                    case QUEEN:
-                        playerScore += 9;
-                        break;
-                    case KING:
-                        playerScore += 0;
-                        break;
-                }
+                playerScore = getChessHeuristic(playerScore, piece);
             }
             //Reward check
             if (isInCheck(1-playerId)) {
@@ -127,12 +87,35 @@ public class ChessGameState extends AbstractGameState {
         }
     }
 
+    private double getChessHeuristic(double currentHeuristic, ChessPiece piece) {
+        ChessPiece.ChessPieceType type = piece.getChessPieceType();
+        switch (type) {
+            case PAWN:
+                currentHeuristic += 1;
+                break;
+            case KNIGHT:
+            case BISHOP:
+                currentHeuristic += 3;
+                break;
+            case ROOK:
+                currentHeuristic += 5;
+                break;
+            case QUEEN:
+                currentHeuristic += 9;
+                break;
+            case KING:
+                currentHeuristic += 0;
+                break;
+        }
+        return currentHeuristic;
+    }
+
     @Override
     public double getGameScore(int playerId) {
         if (isNotTerminal()) {
             return 0;
         } else {
-            return (double) (getPlayerResults()[playerId].value+1) / 2.0;
+            return (getPlayerResults()[playerId].value+1) / 2.0;
         }
     }
 
@@ -374,7 +357,9 @@ public class ChessGameState extends AbstractGameState {
     public void resetHalfMoveClock() {
         halfMoveClock = 0;
     }
-    public boolean AddCheckRepetitionCount() {
+    public boolean addCheckRepetitionCount() {
+        if (((ChessParameters) gameParameters).drawByRepetition == 0)
+            return false;
         // Check if the current board state has been seen before
         int boardHash = Objects.hash(board.hashCode(), getCurrentPlayer());
         if (gameStateCounts.containsKey(boardHash)) {

--- a/src/main/java/games/chess/ChessParameters.java
+++ b/src/main/java/games/chess/ChessParameters.java
@@ -16,11 +16,9 @@ public class ChessParameters extends TunableParameters {
     public int drawByRepetition = 3; // Number of times a position must be repeated for a draw by repetition to be declared, 0 for no limit
     public String dataPathString = "data/chess/"; // Path to the data folder for the game, used for loading images and other resources
 
-    
-
     public ChessParameters() {
         addTunableParameter("maxRounds", 100, Arrays.asList(50, 100, 200, 300)); //Note: current forward model checks for this before checkmate e.g. if the last move ends in checkmate, the game will end in a draw
-        addTunableParameter("drawByRepetition", 3, Arrays.asList(0, 1, 2, 3));
+        addTunableParameter("drawByRepetition", 0, Arrays.asList(0, 1, 2, 3));
         _reset();
     }
     

--- a/src/main/java/games/hearts/HeartsForwardModel.java
+++ b/src/main/java/games/hearts/HeartsForwardModel.java
@@ -56,6 +56,12 @@ public class HeartsForwardModel extends StandardForwardModel {
         hgs.drawDeck = FrenchCard.generateDeck("DrawDeck", CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
         hgs.playerTricksTaken = new int[hgs.getNPlayers()];
 
+        // known voids are only valid for the current round, as hands are re-dealt each round
+        hgs.knownVoids = new ArrayList<>();
+        for (int i = 0; i < hgs.getNPlayers(); i++) {
+            hgs.knownVoids.add(EnumSet.noneOf(FrenchCard.Suite.class));
+        }
+
         int numOfPlayers = hgs.getNPlayers();
 
         hgs.drawDeck.removeAll(params.cardsToRemove.get(numOfPlayers));

--- a/src/main/java/games/hearts/HeartsGameState.java
+++ b/src/main/java/games/hearts/HeartsGameState.java
@@ -9,6 +9,7 @@ import core.components.FrenchCard;
 import core.interfaces.IGamePhase;
 import games.GameType;
 import games.hearts.heuristics.HeartsHeuristic;
+import utilities.DeterminisationUtilities;
 
 import java.util.ArrayList;
 import java.util.*;
@@ -34,6 +35,11 @@ public class HeartsGameState extends AbstractGameState {
     public Map<Integer, Integer> playerPoints;
     public List<Map.Entry<Integer, FrenchCard>> currentPlayedCards = new ArrayList<>();
     public FrenchCard.Suite firstCardSuit;
+    /**
+     * For each player, the suits that they are publicly known to be void in; i.e. the suits that
+     * were led in a trick this round to which they did not follow suit.
+     */
+    public List<Set<FrenchCard.Suite>> knownVoids;
 
     public HeartsGameState(AbstractParameters gameParameters, int nPlayers) {
         super(gameParameters, nPlayers);
@@ -72,6 +78,14 @@ public class HeartsGameState extends AbstractGameState {
      */
     public List<Deck<FrenchCard>> getPlayerDecks() {
         return playerDecks;
+    }
+
+    /**
+     * The suits that the specified player is publicly known to be void in, from having failed to
+     * follow suit earlier in the current round. This is information available to all players.
+     */
+    public Set<FrenchCard.Suite> getKnownVoids(int playerId) {
+        return knownVoids.get(playerId);
     }
 
     public void scorePointsAtEndOfRound() {
@@ -160,32 +174,35 @@ public class HeartsGameState extends AbstractGameState {
 
         copy.firstCardSuit = firstCardSuit;
 
+        // Deep Copy knownVoids
+        copy.knownVoids = new ArrayList<>();
+        for (Set<FrenchCard.Suite> voids : knownVoids) {
+            Set<FrenchCard.Suite> voidCopy = EnumSet.noneOf(FrenchCard.Suite.class);
+            voidCopy.addAll(voids);
+            copy.knownVoids.add(voidCopy);
+        }
+
         if (getCoreGameParameters().partialObservable && playerId != -1) {
-            // Now we need to blank out the passed cards that the player cannot see
-            // and these need to go into the draw deck for shuffling
+            // We cannot see the cards that the other players have passed, so we put these into their hands.
+            // The agent can then use its opponent model to figure out what was passed.
+            // Passing is all simultaneous
             for (int i = 0; i < getNPlayers(); i++) {
                 if (i != playerId) {
-                    copy.drawDeck.add(copy.pendingPasses.get(i));
-                    copy.drawDeck.add(copy.playerDecks.get(i));
-                    copy.playerDecks.get(i).clear();
+                    copy.playerDecks.get(i).add(copy.pendingPasses.get(i));
                     copy.pendingPasses.get(i).clear();
                 }
             }
-            copy.drawDeck.shuffle(redeterminisationRnd);
 
-            for (int i = 0; i < getNPlayers(); i++) {
-                if (i != playerId) {
-                    for (int j = 0; j < playerDecks.get(i).getSize(); j++) {
-                        copy.playerDecks.get(i).add(copy.drawDeck.draw());
-                    }
-                    for (int j = 0; j < pendingPasses.get(i).size(); j++) {
-                        // We put the previously pending cards into the hand
-                        // the agent can then use its opponent model to figure out what was passed
-                        // Passing is all simultaneous
-                        copy.playerDecks.get(i).add(copy.drawDeck.draw());
-                    }
-                }
-            }
+            // Then we reshuffle everything we cannot see across the other hands and the draw deck.
+            // A player who has failed to follow suit is known to hold no cards of that suit, so we
+            // must not deal them any.
+            List<Deck<FrenchCard>> decksToShuffle = new ArrayList<>(copy.playerDecks);
+            decksToShuffle.add(copy.drawDeck);
+            BiPredicate<Deck<FrenchCard>, FrenchCard> voidConstraint =
+                    ((HeartsParameters) gameParameters).rememberVoids
+                            ? (deck, card) -> deck.getOwnerId() < 0 || !copy.knownVoids.get(deck.getOwnerId()).contains(card.suite)
+                            : null;  // a null constraint gives the unconstrained reshuffle
+            DeterminisationUtilities.reshuffle(playerId, decksToShuffle, c -> true, redeterminisationRnd, voidConstraint);
         }
 
         return copy;
@@ -236,14 +253,15 @@ public class HeartsGameState extends AbstractGameState {
                 Objects.equals(pendingPasses, that.pendingPasses) &&
                 Objects.equals(playerPoints, that.playerPoints) &&
                 Objects.equals(currentPlayedCards, that.currentPlayedCards) &&
-                Objects.equals(firstCardSuit, that.firstCardSuit);
+                Objects.equals(firstCardSuit, that.firstCardSuit) &&
+                Objects.equals(knownVoids, that.knownVoids);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(super.hashCode(), playerDecks, drawDeck, heartsBroken,
                 firstCardSuit, trickDecks,
-                pendingPasses, playerPoints, currentPlayedCards);
+                pendingPasses, playerPoints, currentPlayedCards, knownVoids);
         result = 31 * result + Arrays.hashCode(playerTricksTaken);
         return result;
     }

--- a/src/main/java/games/hearts/HeartsParameters.java
+++ b/src/main/java/games/hearts/HeartsParameters.java
@@ -19,7 +19,7 @@ import java.util.*;
  * <p>The class can optionally extend from {@link evaluation.optimisation.TunableParameters} instead, which allows to use
  * automatic game parameter optimisation tools in the framework.</p>
  */
-public class HeartsParameters extends AbstractParameters {
+public class HeartsParameters extends TunableParameters<HeartsParameters> {
     public String dataPath = "data/FrenchCards/";
     public final int shootTheMoon = 26;
     public final int heartCard = 1;
@@ -29,6 +29,9 @@ public class HeartsParameters extends AbstractParameters {
     public final int queenOfSpades = 13;
     public final int cardsPassedPerRound = 3;
     public final int matchScore = 50;
+    // If true then a player who fails to follow suit is remembered as being void in it, and
+    // redeterminisation will not deal them any cards of that suit
+    public boolean rememberVoids = true;
 
     // Number of cards per player - index to array is nPlayers
     public final int[] numberOfCardsPerPlayer = new int[]{0, 0, 0,
@@ -37,6 +40,7 @@ public class HeartsParameters extends AbstractParameters {
     Map<Integer, List<FrenchCard>> cardsToRemove = new HashMap<>();
 
     public HeartsParameters() {
+        addTunableParameter("rememberVoids", true, Arrays.asList(false, true));
         cardsToRemove.put(3, Collections.singletonList(new FrenchCard(FrenchCard.FrenchCardType.Number, FrenchCard.Suite.Diamonds, 2)));
         cardsToRemove.put(4, Collections.emptyList());
         cardsToRemove.put(5, Arrays.asList(new FrenchCard(FrenchCard.FrenchCardType.Number, FrenchCard.Suite.Diamonds, 2),
@@ -48,6 +52,16 @@ public class HeartsParameters extends AbstractParameters {
         cardsToRemove.put(7, Arrays.asList(new FrenchCard(FrenchCard.FrenchCardType.Number, FrenchCard.Suite.Diamonds, 2),
                 new FrenchCard(FrenchCard.FrenchCardType.Number, FrenchCard.Suite.Diamonds, 3),
                 new FrenchCard(FrenchCard.FrenchCardType.Number, FrenchCard.Suite.Clubs, 3)));
+    }
+
+    @Override
+    public void _reset() {
+        rememberVoids = (boolean) getParameterValue("rememberVoids");
+    }
+
+    @Override
+    public HeartsParameters instantiate() {
+        return this;
     }
 
     public String getDataPath() {
@@ -64,9 +78,7 @@ public class HeartsParameters extends AbstractParameters {
     @Override
     public boolean _equals(Object o) {
         if (this == o) return true;
-        if (!(o instanceof HeartsParameters)) return false;
-        if (!super.equals(o)) return false;
-        HeartsParameters that = (HeartsParameters) o;
+        if (!(o instanceof HeartsParameters that)) return false;
         return Objects.equals(dataPath, that.dataPath);
     }
 

--- a/src/main/java/games/hearts/actions/Play.java
+++ b/src/main/java/games/hearts/actions/Play.java
@@ -6,6 +6,7 @@ import core.components.Deck;
 import core.components.FrenchCard;
 import core.interfaces.IPrintable;
 import games.hearts.HeartsGameState;
+import games.hearts.HeartsParameters;
 
 import java.util.AbstractMap;
 import java.util.Objects;
@@ -34,6 +35,10 @@ public class Play extends AbstractAction implements IPrintable {
 
                 if (hgs.currentPlayedCards.isEmpty()) {
                     hgs.firstCardSuit = card.suite;  // Save the suit of the first card
+                } else if (card.suite != hgs.firstCardSuit
+                        && ((HeartsParameters) hgs.getGameParameters()).rememberVoids) {
+                    // The player could not follow suit, so everyone now knows they are void in it
+                    hgs.knownVoids.get(playerID).add(hgs.firstCardSuit);
                 }
 
                 // Store played card and its player ID

--- a/src/main/java/games/spades/SpadesForwardModel.java
+++ b/src/main/java/games/spades/SpadesForwardModel.java
@@ -13,6 +13,7 @@ import utilities.Pair;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Set;
 import java.util.Map;
 import java.util.stream.IntStream;
 
@@ -286,6 +287,11 @@ public class SpadesForwardModel extends StandardForwardModel {
         state.setGamePhase(SpadesGameState.Phase.BIDDING);
         state.setSpadesBroken(false);
         state.leadSuit = null;
+
+        // known voids are only valid for the current round, as hands are re-dealt each round
+        for (Set<FrenchCard.Suite> voids : state.knownVoids) {
+            voids.clear();
+        }
 
         for (int i = 0; i < state.getNPlayers(); i++) {
             Deck<FrenchCard> hand = state.getPlayerHands().get(i);

--- a/src/main/java/games/spades/SpadesGameState.java
+++ b/src/main/java/games/spades/SpadesGameState.java
@@ -14,10 +14,13 @@ import utilities.Pair;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Set;
+import java.util.function.BiPredicate;
 
 public class SpadesGameState extends AbstractGameState implements IPrintable {
 
@@ -31,6 +34,11 @@ public class SpadesGameState extends AbstractGameState implements IPrintable {
     public boolean[] playerBlindNil;
     public FrenchCard.Suite leadSuit;
     public boolean spadesBroken = false;
+    /**
+     * For each player, the suits that they are publicly known to be void in; i.e. the suits that
+     * were led in a trick this round to which they did not follow suit.
+     */
+    public List<Set<FrenchCard.Suite>> knownVoids;
 
     public enum Phase implements IGamePhase {
         BIDDING,
@@ -50,6 +58,10 @@ public class SpadesGameState extends AbstractGameState implements IPrintable {
         teamScores = new int[2];
         teamSandbags = new int[2];
         playerBlindNil = new boolean[nPlayers];
+        knownVoids = new ArrayList<>();
+        for (int i = 0; i < nPlayers; i++) {
+            knownVoids.add(EnumSet.noneOf(FrenchCard.Suite.class));
+        }
     }
 
     @Override
@@ -102,6 +114,13 @@ public class SpadesGameState extends AbstractGameState implements IPrintable {
         copy.leadSuit = leadSuit;
         copy.spadesBroken = spadesBroken;
 
+        copy.knownVoids = new ArrayList<>();
+        for (Set<FrenchCard.Suite> voids : knownVoids) {
+            Set<FrenchCard.Suite> voidCopy = EnumSet.noneOf(FrenchCard.Suite.class);
+            voidCopy.addAll(voids);
+            copy.knownVoids.add(voidCopy);
+        }
+
         copy.playerHands = new ArrayList<>();
         for (int i = 0; i < playerHands.size(); i++) {
             Deck<FrenchCard> originalHand = playerHands.get(i);
@@ -116,7 +135,13 @@ public class SpadesGameState extends AbstractGameState implements IPrintable {
                 if (p != playerId)
                     otherPlayerDecks.add(copy.playerHands.get(p));
             }
-            DeterminisationUtilities.reshuffle(playerId, otherPlayerDecks, x -> true, redeterminisationRnd);
+            // a player who has failed to follow suit is known to hold no cards of that suit,
+            // so we must not deal them any
+            BiPredicate<Deck<FrenchCard>, FrenchCard> voidConstraint =
+                    ((SpadesParameters) gameParameters).rememberVoids
+                            ? (deck, card) -> deck.getOwnerId() < 0 || !copy.knownVoids.get(deck.getOwnerId()).contains(card.suite)
+                            : null;  // a null constraint gives the unconstrained reshuffle
+            DeterminisationUtilities.reshuffle(playerId, otherPlayerDecks, x -> true, redeterminisationRnd, voidConstraint);
         }
 
         return copy;
@@ -148,6 +173,14 @@ public class SpadesGameState extends AbstractGameState implements IPrintable {
 
     public List<Deck<FrenchCard>> getPlayerHands() {
         return playerHands;
+    }
+
+    /**
+     * The suits that the specified player is publicly known to be void in, from having failed to
+     * follow suit earlier in the current round. This is information available to all players.
+     */
+    public Set<FrenchCard.Suite> getKnownVoids(int playerId) {
+        return knownVoids.get(playerId);
     }
 
     public int getPlayerBid(int playerId) {
@@ -229,13 +262,14 @@ public class SpadesGameState extends AbstractGameState implements IPrintable {
                 Arrays.equals(teamSandbags, that.teamSandbags) &&
                 Arrays.equals(playerBlindNil, that.playerBlindNil) &&
                 leadSuit == that.leadSuit &&
-                spadesBroken == that.spadesBroken;
+                spadesBroken == that.spadesBroken &&
+                Objects.equals(knownVoids, that.knownVoids);
     }
 
     @Override
     public int hashCode() {
         int result = Objects.hash(super.hashCode(), playerHands, currentTrick, tricksWon,
-                leadSuit == null ? -1 : leadSuit.ordinal(), spadesBroken);
+                leadSuit == null ? -1 : leadSuit.ordinal(), spadesBroken, knownVoids);
         result = 31 * result + Arrays.hashCode(playerBids);
         result = 31 * result + Arrays.hashCode(tricksTaken);
         result = 31 * result + Arrays.hashCode(teamScores);

--- a/src/main/java/games/spades/SpadesParameters.java
+++ b/src/main/java/games/spades/SpadesParameters.java
@@ -3,6 +3,7 @@ package games.spades;
 import core.AbstractParameters;
 import evaluation.optimisation.TunableParameters;
 
+import java.util.Arrays;
 import java.util.Objects;
 
 public class SpadesParameters extends TunableParameters<SpadesParameters> {
@@ -20,6 +21,9 @@ public class SpadesParameters extends TunableParameters<SpadesParameters> {
     
     public boolean allowBlindNil = false;
     public boolean allowNilOverbid = false; // Nil can be bid even if team has >= 500 points
+    // If true then a player who fails to follow suit is remembered as being void in it, and
+    // redeterminisation will not deal them any cards of that suit
+    public boolean rememberVoids = true;
     
     public SpadesParameters() {
         super();
@@ -37,6 +41,7 @@ public class SpadesParameters extends TunableParameters<SpadesParameters> {
         addTunableParameter("allowBlindNil", false);
         addTunableParameter("allowNilOverbid", false);
         addTunableParameter("pointsPerTrick", 10);
+        addTunableParameter("rememberVoids", true, Arrays.asList(false, true));
     }
 
     @Override
@@ -52,6 +57,7 @@ public class SpadesParameters extends TunableParameters<SpadesParameters> {
         allowBlindNil = (boolean) getParameterValue("allowBlindNil");
         allowNilOverbid = (boolean) getParameterValue("allowNilOverbid");
         pointsPerTrick = (int) getParameterValue("pointsPerTrick");
+        rememberVoids = (boolean) getParameterValue("rememberVoids");
     }
     
     public SpadesParameters(long seed) {

--- a/src/main/java/games/spades/actions/PlayCard.java
+++ b/src/main/java/games/spades/actions/PlayCard.java
@@ -6,6 +6,7 @@ import core.components.Deck;
 import core.components.FrenchCard;
 import core.interfaces.IPrintable;
 import games.spades.SpadesGameState;
+import games.spades.SpadesParameters;
 import utilities.Pair;
 
 import java.util.AbstractMap;
@@ -40,6 +41,12 @@ public class PlayCard extends AbstractAction implements IPrintable {
         // Remove card from player's hand
         if (!playerHand.getComponents().remove(card)) {
             throw new AssertionError("Card not found in player's hand: " + card.toString());
+        }
+
+        if (!state.getCurrentTrick().isEmpty() && card.suite != state.getLeadSuit()
+                && ((SpadesParameters) state.getGameParameters()).rememberVoids) {
+            // The player could not follow suit, so everyone now knows they are void in it
+            state.knownVoids.get(playerId).add(state.getLeadSuit());
         }
         
         // Add card to current trick

--- a/src/main/java/players/mcts/SingleTreeNode.java
+++ b/src/main/java/players/mcts/SingleTreeNode.java
@@ -816,9 +816,7 @@ public class SingleTreeNode {
         // default to standard UCB
         int effectiveTotalVisits = validVisitsFor(action);
         // use first play urgency as replacement for exploration term if action not previously taken
-        // we add in the second term based on the AlphaGo selection rule, so that the exploration term is monotonically increasing with N
-        // this will come into play for small values of FPU and acts as soft-pruning rather than the harder form if FPU is a fixed constant
-        double explorationTerm = Math.max(params.firstPlayUrgency, params.K * Math.sqrt(effectiveTotalVisits));
+        double explorationTerm = params.firstPlayUrgency;
         if (actionVisits > 0) {
             explorationTerm = switch (params.treePolicy) {
                 case UCB_Tuned -> {
@@ -841,7 +839,7 @@ public class SingleTreeNode {
                     yield params.K * Math.sqrt(Math.log(effectiveTotalVisits) / actionVisits * minTerm);
                 }
                 case AlphaGo -> params.K * Math.sqrt(effectiveTotalVisits) / actionVisits;
-                default -> Math.sqrt(Math.log(effectiveTotalVisits) / actionVisits);
+                default -> params.K * Math.sqrt(Math.log(effectiveTotalVisits) / actionVisits);
             };
         }
         if (params.pUCTTemperature < 10000.0) {

--- a/src/main/java/utilities/DeterminisationUtilities.java
+++ b/src/main/java/utilities/DeterminisationUtilities.java
@@ -5,11 +5,27 @@ import core.components.Component;
 import core.components.Deck;
 import core.components.PartialObservableDeck;
 
+import java.util.ArrayList;
+import java.util.IdentityHashMap;
 import java.util.List;
 import java.util.Random;
+import java.util.function.BiPredicate;
 import java.util.function.Predicate;
 
 public class DeterminisationUtilities {
+
+    /**
+     * The constrained reshuffle is exponential in the number of decks being filled, so we refuse to
+     * attempt it for an unreasonable number of them.
+     */
+    private static final int MAX_CONSTRAINED_DECKS = 10;
+
+    /**
+     * A single position within a deck that holds a card the perspective player cannot see, and which
+     * is therefore a candidate for reshuffling.
+     */
+    private record Slot<C extends Component>(Deck<C> deck, int index) {
+    }
 
     /**
      *  Reshuffles all cards across the list of decks that meet the lambda predicate, and are not visible to player.
@@ -23,18 +39,179 @@ public class DeterminisationUtilities {
      * @param <C>
      */
     public static <C extends Component> void reshuffle(int player, List<Deck<C>> decks, Predicate<C> lambda, Random rnd) {
-        // Gather up all unknown cards for reshuffling
         if (player < 0) return;
+        unconstrainedReshuffle(hiddenSlots(player, decks, lambda), rnd);
+    }
 
+    private static <C extends Component> void unconstrainedReshuffle(List<Slot<C>> slots, Random rnd) {
         Deck<C> allCards = new Deck<>("temp", -1, CoreConstants.VisibilityMode.HIDDEN_TO_ALL);
+        for (Slot<C> slot : slots)
+            allCards.add(slot.deck().get(slot.index()));
+        allCards.shuffle(rnd);
+        for (Slot<C> slot : slots)
+            slot.deck().setComponent(slot.index(), allCards.draw());
+    }
 
-        // The fully observable decks care now filtered to remove any that are visible to us
+    /**
+     * As {@link #reshuffle(int, List, Predicate, Random)}, but constrained so that a card is only ever placed
+     * in a deck for which {@code permitted} holds. This supports the common situation in which we know
+     * something about what another player <i>cannot</i> have; for example that they are void in a suit
+     * because they failed to follow it in a previous trick.
+     * <p>
+     * The reshuffle honours all of the constraints simultaneously, or none of them. A card is picked at
+     * random for each position from those that are still compatible with a valid completion, so no
+     * back-tracking or retrying is needed.
+     *
+     * @param permitted given a deck and a card, is that card a valid holding for that deck? Decks with no
+     *                  constraints (a draw pile, say) should simply return true for everything.
+     * @return true if all the constraints were met. If they are mutually inconsistent (which means the
+     *         information they are derived from is itself inconsistent) then the decks are reshuffled
+     *         without any constraints, and false is returned.
+     */
+    public static <C extends Component> boolean reshuffle(int player, List<Deck<C>> decks, Predicate<C> lambda,
+                                                          Random rnd, BiPredicate<Deck<C>, C> permitted) {
+        if (player < 0) return true;
+        if (permitted == null) {
+            reshuffle(player, decks, lambda, rnd);
+            return true;
+        }
+        // slots is the decks/indices that are to be shuffled (not perfectly known to perspective player)
+        List<Slot<C>> slots = hiddenSlots(player, decks, lambda);
+        if (slots.isEmpty()) return true;
+        int nCards = slots.size();
+
+        // The distinct decks that we have to fill. targetIndex provides the index to the list for any Deck (using reference equality)
+        // slotTarget stores which underlying Deck each of the target slots is in; we can then assign cards to slots, and later put them into Decks
+        List<Deck<C>> targets = new ArrayList<>();
+        IdentityHashMap<Deck<C>, Integer> targetIndex = new IdentityHashMap<>();
+        int[] slotTarget = new int[nCards]; //
+        for (int i = 0; i < nCards; i++) {
+            Deck<C> deck = slots.get(i).deck();
+            slotTarget[i] = targetIndex.computeIfAbsent(deck, d -> {
+                targets.add(d);
+                return targets.size() - 1;
+            });
+        }
+        int nTargets = targets.size();
+        if (nTargets > MAX_CONSTRAINED_DECKS)
+            throw new IllegalArgumentException("Constrained reshuffle is not supported for " + nTargets + " decks");
+        int nSubsets = 1 << nTargets;
+
+        int[] capacity = new int[nTargets];
+        for (int t : slotTarget) capacity[t]++;
+
+        // Each card is compatible with some subset of the target decks, held as a bitmask. Cards with the
+        // same mask are interchangeable, so we count how many there are of each mask.
+        List<C> cards = cardsIn(slots);  // cards to shuffle
+        int[] cardMask = new int[nCards];
+        int[] cardsWithMask = new int[nSubsets];
+        int distinctMasks = 0;
+        for (int i = 0; i < nCards; i++) {
+            int mask = 0;
+            C card = cards.get(i);
+            // the mask for a card is the decks it is permitted to be in
+            // the potential number of masks is 2^decks (nSubsets)
+            for (int t = 0; t < nTargets; t++)
+                if (permitted.test(targets.get(t), card)) mask |= 1 << t;
+            cardMask[i] = mask;
+            if (cardsWithMask[mask] == 0) distinctMasks++;
+            cardsWithMask[mask]++;
+        }
+
+        if (distinctMasks == 1 && cardsWithMask[nSubsets - 1] == nCards) {
+            // nothing is actually restricted, so there is no point in doing any of the work below
+            unconstrainedReshuffle(slots, rnd);
+            return true;
+        }
+
+        // A valid assignment exists when, for every subset D of the target decks, the number of
+        // positions to fill in D is no greater than the number of cards that are allowed in any deck of D
+        // (aka Hall's condition). We track this for every subset and only ever place a card where
+        // doing so leaves it non-negative; this guarantees that the assignment can always be completed.
+        // cardsWithMask[] hold the number of cards permitted for the mask (and each mask is one subset D)
+        int[] headroom = new int[nSubsets];
+        for (int subset = 1; subset < nSubsets; subset++) {
+            int demand = 0, supply = 0;
+            for (int t = 0; t < nTargets; t++)
+                if ((subset >> t & 1) == 1) demand += capacity[t];
+            for (int mask = 1; mask < nSubsets; mask++)
+                if ((mask & subset) != 0) supply += cardsWithMask[mask];
+            headroom[subset] = supply - demand;
+            if (headroom[subset] < 0) {
+                // the constraints contradict each other, so we fall back on an unconstrained reshuffle
+                unconstrainedReshuffle(slots, rnd);
+                return false;
+            }
+        }
+
+        // Deal the cards out in a random order, each to a random deck that still leaves a valid completion
+        int[] order = new int[nCards];
+        for (int i = 0; i < nCards; i++) order[i] = i;
+        shuffle(order, nCards, rnd);
+
+        int[] cardTarget = new int[nCards];
+        int[] candidates = new int[nTargets];
+        for (int i = 0; i < nCards; i++) {
+            int card = order[i];
+            int mask = cardMask[card];
+            int nCandidates = 0;
+            for (int t = 0; t < nTargets; t++)
+                if ((mask >> t & 1) == 1 && capacity[t] > 0) candidates[nCandidates++] = t;
+            shuffle(candidates, nCandidates, rnd);
+
+            int chosen = -1;
+            for (int c = 0; c < nCandidates && chosen == -1; c++) {
+                // placing this card in t reduces the headroom of every subset that excludes t, but could
+                // otherwise have used the card
+                int t = candidates[c];
+                boolean valid = true;
+                for (int subset = 1; subset < nSubsets && valid; subset++)
+                    if ((subset >> t & 1) == 0 && (subset & mask) != 0 && headroom[subset] < 1) valid = false;
+                if (valid) chosen = t;
+            }
+            if (chosen == -1)
+                throw new AssertionError("No valid deck for card despite Hall's condition holding");
+
+            for (int subset = 1; subset < nSubsets; subset++)
+                if ((subset >> chosen & 1) == 0 && (subset & mask) != 0) headroom[subset]--;
+            capacity[chosen]--;
+            cardTarget[card] = chosen;
+        }
+
+        // Finally group the cards by the deck they have been assigned to, and fill that deck's positions
+        int[] cursor = new int[nTargets];
+        for (int t = 1; t < nTargets; t++) cursor[t] = cursor[t - 1] + countOf(cardTarget, t - 1);
+        int[] cardsByTarget = new int[nCards];
+        int[] next = cursor.clone();
+        for (int card = 0; card < nCards; card++)
+            cardsByTarget[next[cardTarget[card]]++] = card;
+
+        for (int i = 0; i < nCards; i++) {
+            int t = slotTarget[i];
+            slots.get(i).deck().setComponent(slots.get(i).index(), cards.get(cardsByTarget[cursor[t]++]));
+        }
+        return true;
+    }
+
+    private static int countOf(int[] values, int target) {
+        int retValue = 0;
+        for (int value : values) if (value == target) retValue++;
+        return retValue;
+    }
+
+    /**
+     * The positions across all the decks that hold a card the specified player cannot see, and which also
+     * meet the lambda predicate. This takes account of hidden information in PartialObservableDecks, and
+     * the visibility mode of Decks.
+     */
+    private static <C extends Component> List<Slot<C>> hiddenSlots(int player, List<Deck<C>> decks, Predicate<C> lambda) {
+        List<Slot<C>> retValue = new ArrayList<>();
         for (Deck<C> d : decks) {
             int length = d.getSize();
             if (d instanceof PartialObservableDeck<C> pod) {
                 for (int i = 0; i < length; i++) {
                     if (!pod.getVisibilityForPlayer(i, player) && lambda.test(pod.get(i)))
-                        allCards.add(pod.get(i));
+                        retValue.add(new Slot<>(d, i));
                 }
             } else {
                 switch (d.getVisibilityMode()) {
@@ -47,59 +224,40 @@ public class DeterminisationUtilities {
                     case HIDDEN_TO_ALL:
                         for (int i = 0; i < length; i++)
                             if (lambda.test(d.get(i)))
-                                allCards.add(d.get(i));
+                                retValue.add(new Slot<>(d, i));
                         break;
                     case TOP_VISIBLE_TO_ALL:
                         for (int i = 1; i < length; i++)
                             if (lambda.test(d.get(i)))
-                                allCards.add(d.get(i));
+                                retValue.add(new Slot<>(d, i));
                         break;
                     case BOTTOM_VISIBLE_TO_ALL:
-                        for (int i = 0; i < length - 1;  i++)
+                        for (int i = 0; i < length - 1; i++)
                             if (lambda.test(d.get(i)))
-                                allCards.add(d.get(i));
+                                retValue.add(new Slot<>(d, i));
                         break;
                     case MIXED_VISIBILITY:
                         throw new AssertionError("Not supported : MIXED_VISIBILITTY");
                 }
             }
         }
-        allCards.shuffle(rnd);
+        return retValue;
+    }
 
-        // and put the shuffled cards in place
-        for (Deck<C> d : decks) {
-            int length = d.getSize();
-            if (d instanceof PartialObservableDeck<C> pod) {
-                for (int i = 0; i < length; i++) {
-                    if (!pod.getVisibilityForPlayer(i, player) && lambda.test(pod.get(i)))
-                        pod.setComponent(i, allCards.draw());
-                }
-            } else {
-                switch (d.getVisibilityMode()) {
-                    case VISIBLE_TO_ALL:
-                        break;
-                    case VISIBLE_TO_OWNER:
-                        if (d.getOwnerId() == player)
-                            break;
-                    case HIDDEN_TO_ALL:
-                        for (int i = 0; i < length; i++)
-                            if (lambda.test(d.get(i)))
-                                d.setComponent(i, allCards.draw());
-                        break;
-                    case TOP_VISIBLE_TO_ALL:
-                        for (int i = 1; i < length; i++)
-                            if (lambda.test(d.get(i)))
-                                d.setComponent(i, allCards.draw());
-                        break;
-                    case BOTTOM_VISIBLE_TO_ALL:
-                        for (int i = 0; i < length - 1;  i++)
-                            if (lambda.test(d.get(i)))
-                                d.setComponent(i, allCards.draw());
-                        break;
-                    case MIXED_VISIBILITY:
-                        throw new AssertionError("Not supported : MIXED_VISIBILITTY");
-                }
-            }
+    private static <C extends Component> List<C> cardsIn(List<Slot<C>> slots) {
+        List<C> retValue = new ArrayList<>(slots.size());
+        for (Slot<C> slot : slots)
+            retValue.add(slot.deck().get(slot.index()));
+        return retValue;
+    }
+
+    /**
+     * A Fisher-Yates shuffle of the first count entries of the array.
+     */
+    private static void shuffle(int[] values, int count, Random rnd) {
+        for (int i = count - 1; i > 0; i--) {
+            int j = rnd.nextInt(i + 1);
+            Utils.swap(values, i, j);
         }
     }
 }

--- a/src/test/java/evaluation/MCTSSearch_CoarseTunableFixed.json
+++ b/src/test/java/evaluation/MCTSSearch_CoarseTunableFixed.json
@@ -1,0 +1,28 @@
+{
+        "class":"players.mcts.MCTSParams",
+        "K" : 1.0,
+        "rolloutLength" : [30, 100, 300, 1000],
+        "maxTreeDepth" : 100,
+        "budgetType" : "BUDGET_TIME",
+        "information" : "Information_Set",
+        "selectionPolicy" : "SIMPLE",
+        "treePolicy" : "UCB_Tuned",
+        "paranoid" : false,
+        "opponentTreePolicy" : ["OneTree", "MultiTree", "SelfOnly"],
+        "rolloutType" : "MAST",
+        "oppModelType" : ["DEFAULT", "RANDOM", "MAST"],
+        "MAST" : ["Tree", "Rollout", "Both"],
+        "MASTGamma" : [0.0, 0.5, 0.9, 1.0],
+        "MASTDefaultValue" : [-100.0, -10.0, 0.0, 10.0, 100.0],
+        "MASTBoltzmann" : [0.01, 0.1, 1.0, 10.0, 100.0],
+        "budget" : 40,
+        "epsilon" : 1e-6,
+        "breakMS" : 0,
+        "exploreEpsilon" : 0.37,
+        "rolloutTermination" : "EXACT",
+        "maintainMasterState" : false,
+        "heuristic" : {
+                "class" : "players.heuristics.CoarseTunableHeuristic",
+                "heuristicType" : "LEADER"
+        }
+}

--- a/src/test/java/evaluation/TunableParametersTest.java
+++ b/src/test/java/evaluation/TunableParametersTest.java
@@ -2,6 +2,7 @@ package evaluation;
 
 import core.AbstractPlayer;
 import evaluation.optimisation.ITPSearchSpace;
+import evaluation.optimisation.TunableParameters;
 import games.puertorico.PuertoRicoActionHeuristic001;
 import org.apache.hadoop.shaded.org.eclipse.jetty.util.ajax.JSON;
 import org.apache.spark.sql.catalyst.expressions.Abs$;
@@ -211,6 +212,24 @@ public class TunableParametersTest {
     }
 
     @Test
+    public void toJSONWithoutNestedDefaults() {
+        params.setParameterValue("budgetType", BUDGET_TIME);
+        CoarseTunableHeuristic heuristic = new CoarseTunableHeuristic();
+        heuristic.setParameterValue("heuristicType", SCORE_PLUS);
+        params.setParameterValue("heuristic", heuristic);
+
+        JSONObject json = params.instanceToJSON(true, Collections.emptyMap());
+
+        MCTSParams noChange = (MCTSParams) params.instanceFromJSON(json);
+        assertTrue(params.allParametersAndValuesEqual(noChange));
+        JSONObject heuristicJSON = (JSONObject) json.get("heuristic");
+        assertEquals("SCORE_PLUS", heuristicJSON.get("heuristicType"));
+
+        MCTSParams fromJSON = (MCTSParams) params.instanceFromJSON(json);
+        assertTrue(fromJSON.allParametersAndValuesEqual(noChange));
+    }
+
+    @Test
     public void toJSONWithParameterisedJSONObject() {
         JSONObject json = JSONUtils.loadJSONFile("src/test/java/evaluation/MCTSSearch_Heuristic.json");
         params.setRawJSON(json);
@@ -319,7 +338,31 @@ public class TunableParametersTest {
         JSONObject heuristicJSON = (JSONObject) json.get("heuristic");
         assertNotNull(heuristicJSON);
         assertEquals("players.heuristics.CoarseTunableHeuristic", heuristicJSON.get("class"));
-        assertNull(heuristicJSON.get("heuristicType"));
+        assertEquals("WIN_ONLY", heuristicJSON.get("heuristicType"));
+    }
+
+    @Test
+    public void writingJSONWithDefaultUsesClassDefault() {
+        ITPSearchSpace<MCTSPlayer> itp = new ITPSearchSpace(params, "src/test/java/evaluation/MCTSSearch_CoarseTunableFixed.json");
+        assertEquals("RANDOM", params.getDefaultParameterValue("rolloutType").toString());
+        int[] settings = new int[]{0, 0, 0, 1, 2, 0, 2};
+        JSONObject json = itp.constructAgentJSON(settings);
+        JSONObject fileJson = itp.constructAgentJSONToWriteToFile(settings);
+
+        assertEquals("MAST", json.get("rolloutType"));
+        assertEquals("MAST", fileJson.get("rolloutType"));
+    }
+
+    @Test
+    public void writingJSONWithDefaultUsesNestedClassDefault() {
+        ITPSearchSpace<MCTSPlayer> itp = new ITPSearchSpace(params, "src/test/java/evaluation/MCTSSearch_CoarseTunableFixed.json");
+        assertEquals("LEADER", params.getDefaultParameterValue("heuristic.heuristicType").toString());
+        int[] settings = new int[]{0, 0, 0, 1, 2, 0, 2};
+        JSONObject json = itp.constructAgentJSON(settings);
+        JSONObject fileJson = itp.constructAgentJSONToWriteToFile(settings);
+
+        assertEquals("LEADER", ((JSONObject) json.get("heuristic")).get("heuristicType"));
+        assertEquals("LEADER", ((JSONObject) fileJson.get("heuristic")).get("heuristicType"));
     }
 
     @Test

--- a/src/test/java/games/chess/ActionTests.java
+++ b/src/test/java/games/chess/ActionTests.java
@@ -175,7 +175,10 @@ public class ActionTests {
     }
     @Test
     public void drawByRepetitionTest() {
+        ChessParameters params = (ChessParameters) game.getGameState().getGameParameters();
+        params.setParameterValue("drawByRepetition", 3);
         ChessGameState state = (ChessGameState) game.getGameState().copy();
+        fm.setup(state);
         //Setup the board for draw by repetition 
         fm.next(state, new MovePiece(1,0, 2, 2)); // Move knight
         fm.next(state, new MovePiece(1,7, 2, 5)); // Move knight

--- a/src/test/java/games/hearts/TestHeartsKnownVoids.java
+++ b/src/test/java/games/hearts/TestHeartsKnownVoids.java
@@ -1,0 +1,335 @@
+package games.hearts;
+
+import core.actions.AbstractAction;
+import core.components.FrenchCard;
+import games.hearts.actions.Play;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the tracking of suits in which a player is publicly known to be void, as a result of
+ * having failed to follow suit earlier in the round.
+ */
+public class TestHeartsKnownVoids {
+
+    private HeartsForwardModel forwardModel;
+    private HeartsGameState gameState;
+    private HeartsParameters gameParameters;
+
+    @Before
+    public void setUp() {
+        gameParameters = new HeartsParameters();
+        gameParameters.setRandomSeed(2934);
+        forwardModel = new HeartsForwardModel();
+        gameState = new HeartsGameState(gameParameters, 4);
+        forwardModel.setup(gameState);
+    }
+
+    @Test
+    public void knownVoidsStartEmpty() {
+        assertEquals(4, gameState.knownVoids.size());
+        for (int p = 0; p < 4; p++) {
+            assertTrue(gameState.getKnownVoids(p).isEmpty());
+        }
+    }
+
+    /**
+     * Plays random actions until a player fails to follow suit, and then checks that this
+     * is recorded against that player.
+     */
+    @Test
+    public void failureToFollowSuitIsRecorded() {
+        Random rnd = new Random(6);
+        for (int i = 0; i < 1000 && gameState.isNotTerminal(); i++) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.firstCardSuit;
+            boolean failsToFollow = chosen instanceof Play && ledSuit != null
+                    && ((Play) chosen).card.suite != ledSuit;
+
+            forwardModel.next(gameState, chosen);
+
+            if (failsToFollow) {
+                assertTrue("Player " + player + " failed to follow " + ledSuit + " but this was not recorded",
+                        gameState.getKnownVoids(player).contains(ledSuit));
+                return;
+            }
+        }
+        fail("No player failed to follow suit within the actions played");
+    }
+
+    /**
+     * As above, but checks that we only record a void against the player who actually failed to
+     * follow suit, and only in the suit that was led.
+     */
+    @Test
+    public void noVoidRecordedForPlayersWhoFollowSuit() {
+        Random rnd = new Random(6);
+        for (int i = 0; i < 1000 && gameState.isNotTerminal(); i++) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.firstCardSuit;
+            boolean followsSuit = chosen instanceof Play && ledSuit != null
+                    && ((Play) chosen).card.suite == ledSuit;
+
+            forwardModel.next(gameState, chosen);
+
+            if (followsSuit) {
+                assertFalse(gameState.getKnownVoids(player).contains(ledSuit));
+            }
+        }
+    }
+
+    /**
+     * Any voids recorded should be carried across by a copy, whether or not this is from the
+     * perspective of a single player.
+     */
+    @Test
+    public void knownVoidsAreCopied() {
+        Random rnd = new Random(6);
+        for (int i = 0; i < 1000 && gameState.isNotTerminal(); i++) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.firstCardSuit;
+            boolean failsToFollow = chosen instanceof Play && ledSuit != null
+                    && ((Play) chosen).card.suite != ledSuit;
+
+            forwardModel.next(gameState, chosen);
+
+            if (failsToFollow) {
+                HeartsGameState fullCopy = (HeartsGameState) gameState.copy();
+                HeartsGameState playerCopy = (HeartsGameState) gameState.copy(0);
+                assertEquals(gameState.knownVoids, fullCopy.knownVoids);
+                assertEquals(gameState.knownVoids, playerCopy.knownVoids);
+                assertTrue(fullCopy.getKnownVoids(player).contains(ledSuit));
+                assertTrue(playerCopy.getKnownVoids(player).contains(ledSuit));
+
+                // and the copies must be independent of the original
+                Set<FrenchCard.Suite> originalVoids = gameState.getKnownVoids(player);
+                fullCopy.getKnownVoids(player).clear();
+                assertTrue(originalVoids.contains(ledSuit));
+                return;
+            }
+        }
+        fail("No player failed to follow suit within the actions played");
+    }
+
+    /**
+     * Over a whole game, a player recorded as void in a suit must genuinely hold no cards of that
+     * suit. This is the invariant that redeterminisation will rely on.
+     */
+    @Test
+    public void recordedVoidsAreConsistentWithActualHands() {
+        Random rnd = new Random(42);
+        int voidsSeen = 0;
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+
+            for (int p = 0; p < gameState.getNPlayers(); p++) {
+                for (FrenchCard.Suite suit : gameState.getKnownVoids(p)) {
+                    voidsSeen++;
+                    assertFalse("Player " + p + " is recorded void in " + suit + " but holds one",
+                            gameState.getPlayerDecks().get(p).stream().anyMatch(c -> c.suite == suit));
+                }
+            }
+        }
+        assertTrue("No voids were recorded over a whole game", voidsSeen > 0);
+    }
+
+    /**
+     * Redeterminisation from one player's perspective reshuffles the other players' hands. It must
+     * not deal a player a card in a suit that they are publicly known to be void in.
+     * <p>
+     * We sample a redeterminisation at every point in a whole game, and count both the violations and
+     * the opportunities to violate - a state in which a void player could have been dealt a card of
+     * their void suit, because one of the other hidden hands holds one.
+     */
+    @Test
+    public void redeterminisationRespectsKnownVoids() {
+        Random rnd = new Random(6);
+        int violations = 0, opportunities = 0;
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+
+            List<FrenchCard> hiddenCards = new ArrayList<>(gameState.getDrawDeck().getComponents());
+            for (int p = 1; p < gameState.getNPlayers(); p++) {
+                hiddenCards.addAll(gameState.getPlayerDecks().get(p).getComponents());
+                hiddenCards.addAll(gameState.pendingPasses.get(p));
+            }
+
+            HeartsGameState copy = (HeartsGameState) gameState.copy(0);
+            for (int p = 1; p < gameState.getNPlayers(); p++) {
+                if (gameState.getPlayerDecks().get(p).getSize() == 0) continue;
+                for (FrenchCard.Suite suit : gameState.getKnownVoids(p)) {
+                    if (hiddenCards.stream().anyMatch(c -> c.suite == suit)) opportunities++;
+                    if (copy.getPlayerDecks().get(p).stream().anyMatch(c -> c.suite == suit)) violations++;
+                }
+            }
+        }
+        assertTrue("The voids were never put to the test", opportunities > 0);
+        assertEquals("Redeterminisation dealt cards in a known void suit", 0, violations);
+    }
+
+    /**
+     * Honouring the voids must not otherwise disturb the redeterminisation - hand sizes, the player's own
+     * hand, and the full set of cards in play all have to be preserved.
+     */
+    @Test
+    public void redeterminisationRemainsValid() {
+        Random rnd = new Random(6);
+        while (gameState.isNotTerminal() && !opponentWithVoidAndCardsInHand()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+        }
+        List<FrenchCard> expectedCards = allHeldCards(gameState);
+        List<FrenchCard> ownHand = gameState.getPlayerDecks().get(0).getComponents();
+
+        for (int i = 0; i < 50; i++) {
+            HeartsGameState copy = (HeartsGameState) gameState.copy(0);
+            for (int p = 0; p < gameState.getNPlayers(); p++) {
+                assertEquals(gameState.getPlayerDecks().get(p).getSize() + (p == 0 ? 0 : gameState.pendingPasses.get(p).size()),
+                        copy.getPlayerDecks().get(p).getSize());
+            }
+            assertEquals(ownHand, copy.getPlayerDecks().get(0).getComponents());
+
+            List<FrenchCard> actualCards = allHeldCards(copy);
+            assertEquals(expectedCards.size(), actualCards.size());
+            assertTrue(actualCards.containsAll(expectedCards));
+        }
+    }
+
+    /** every card still held in a hand, in a pending pass, or in the draw deck */
+    private List<FrenchCard> allHeldCards(HeartsGameState state) {
+        List<FrenchCard> retValue = new ArrayList<>(state.getDrawDeck().getComponents());
+        for (int p = 0; p < state.getNPlayers(); p++) {
+            retValue.addAll(state.getPlayerDecks().get(p).getComponents());
+            retValue.addAll(state.pendingPasses.get(p));
+        }
+        return retValue;
+    }
+
+    private boolean opponentWithVoidAndCardsInHand() {
+        for (int p = 1; p < gameState.getNPlayers(); p++) {
+            if (!gameState.getKnownVoids(p).isEmpty() && gameState.getPlayerDecks().get(p).getSize() > 0)
+                return true;
+        }
+        return false;
+    }
+
+    /**
+     * Voids only apply to the current round, as hands are re-dealt at the start of each round.
+     */
+    @Test
+    public void voidsAreClearedAtTheStartOfANewRound() {
+        Random rnd = new Random(6);
+        boolean voidSeenInFirstRound = false;
+        while (gameState.isNotTerminal() && gameState.getRoundCounter() == 0) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+            if (gameState.getRoundCounter() == 0) {
+                voidSeenInFirstRound |= gameState.knownVoids.stream().anyMatch(v -> !v.isEmpty());
+            }
+        }
+        assertTrue("Expected at least one void to be recorded in the first round", voidSeenInFirstRound);
+        assertEquals(1, gameState.getRoundCounter());
+        for (int p = 0; p < gameState.getNPlayers(); p++) {
+            assertTrue(gameState.getKnownVoids(p).isEmpty());
+        }
+    }
+
+    // ========================================
+    // The rememberVoids parameter
+    // ========================================
+
+    @Test
+    public void rememberVoidsDefaultsToTrue() {
+        HeartsParameters params = new HeartsParameters();
+        assertTrue(params.rememberVoids);
+        assertEquals(true, params.getParameterValue("rememberVoids"));
+    }
+
+    @Test
+    public void rememberVoidsSurvivesAParameterCopy() {
+        HeartsParameters params = (HeartsParameters) gameState.getGameParameters();
+        params.setParameterValue("rememberVoids", false);
+        assertFalse(params.rememberVoids);
+        assertFalse(((HeartsParameters) params.copy()).rememberVoids);
+    }
+
+    @Test
+    public void noVoidsAreRecordedWhenTheyAreNotRemembered() {
+        ((HeartsParameters) gameState.getGameParameters()).setParameterValue("rememberVoids", false);
+        Random rnd = new Random(42);
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+            for (int p = 0; p < gameState.getNPlayers(); p++)
+                assertTrue(gameState.getKnownVoids(p).isEmpty());
+        }
+    }
+
+    /**
+     * With the parameter off we fall back on the old behaviour, which takes no account of who is void
+     * in what. We track the voids in the test itself to show that they really are being ignored.
+     */
+    @Test
+    public void redeterminisationIsUnconstrainedWhenVoidsAreNotRemembered() {
+        ((HeartsParameters) gameState.getGameParameters()).setParameterValue("rememberVoids", false);
+        Random rnd = new Random(6);
+        List<Set<FrenchCard.Suite>> observedVoids = new ArrayList<>();
+        for (int p = 0; p < gameState.getNPlayers(); p++)
+            observedVoids.add(EnumSet.noneOf(FrenchCard.Suite.class));
+
+        int violations = 0, opportunities = 0, round = 0;
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.firstCardSuit;
+            boolean failsToFollow = chosen instanceof Play && ledSuit != null
+                    && ((Play) chosen).card.suite != ledSuit;
+
+            forwardModel.next(gameState, chosen);
+            if (failsToFollow) observedVoids.get(player).add(ledSuit);
+            if (gameState.getRoundCounter() != round) {
+                // hands are re-dealt each round, so what we know is wiped
+                round = gameState.getRoundCounter();
+                observedVoids.forEach(Set::clear);
+                continue;
+            }
+
+            List<FrenchCard> hiddenCards = new ArrayList<>(gameState.getDrawDeck().getComponents());
+            for (int p = 1; p < gameState.getNPlayers(); p++) {
+                hiddenCards.addAll(gameState.getPlayerDecks().get(p).getComponents());
+                hiddenCards.addAll(gameState.pendingPasses.get(p));
+            }
+
+            HeartsGameState copy = (HeartsGameState) gameState.copy(0);
+            for (int p = 1; p < gameState.getNPlayers(); p++) {
+                if (gameState.getPlayerDecks().get(p).getSize() == 0) continue;
+                for (FrenchCard.Suite suit : observedVoids.get(p)) {
+                    if (hiddenCards.stream().anyMatch(c -> c.suite == suit)) opportunities++;
+                    if (copy.getPlayerDecks().get(p).stream().anyMatch(c -> c.suite == suit)) violations++;
+                }
+            }
+        }
+        assertTrue("The voids were never put to the test", opportunities > 0);
+        assertTrue("With rememberVoids off the redeterminisation should ignore the voids", violations > 0);
+    }
+}

--- a/src/test/java/games/spades/TestSpadesKnownVoids.java
+++ b/src/test/java/games/spades/TestSpadesKnownVoids.java
@@ -1,0 +1,318 @@
+package games.spades;
+
+import core.actions.AbstractAction;
+import core.components.FrenchCard;
+import games.spades.actions.PlayCard;
+import org.junit.Before;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.EnumSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
+
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the tracking of suits in which a player is publicly known to be void, as a result of
+ * having failed to follow suit earlier in the round.
+ */
+public class TestSpadesKnownVoids {
+
+    private SpadesForwardModel forwardModel;
+    private SpadesGameState gameState;
+
+    @Before
+    public void setUp() {
+        SpadesParameters gameParameters = new SpadesParameters();
+        gameParameters.setRandomSeed(2934);
+        forwardModel = new SpadesForwardModel();
+        gameState = new SpadesGameState(gameParameters, 4);
+        forwardModel.setup(gameState);
+    }
+
+    @Test
+    public void knownVoidsStartEmpty() {
+        assertEquals(4, gameState.knownVoids.size());
+        for (int p = 0; p < 4; p++) {
+            assertTrue(gameState.getKnownVoids(p).isEmpty());
+        }
+    }
+
+    /**
+     * Plays random actions until a player fails to follow suit, and then checks that this
+     * is recorded against that player.
+     */
+    @Test
+    public void failureToFollowSuitIsRecorded() {
+        Random rnd = new Random(6);
+        for (int i = 0; i < 1000 && gameState.isNotTerminal(); i++) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.getLeadSuit();
+            boolean failsToFollow = chosen instanceof PlayCard && !gameState.getCurrentTrick().isEmpty()
+                    && ((PlayCard) chosen).card.suite != ledSuit;
+
+            forwardModel.next(gameState, chosen);
+
+            if (failsToFollow) {
+                assertTrue("Player " + player + " failed to follow " + ledSuit + " but this was not recorded",
+                        gameState.getKnownVoids(player).contains(ledSuit));
+                return;
+            }
+        }
+        fail("No player failed to follow suit within the actions played");
+    }
+
+    /**
+     * As above, but checks that we only record a void against the player who actually failed to
+     * follow suit, and only in the suit that was led.
+     */
+    @Test
+    public void noVoidRecordedForPlayersWhoFollowSuit() {
+        Random rnd = new Random(6);
+        for (int i = 0; i < 1000 && gameState.isNotTerminal(); i++) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.getLeadSuit();
+            boolean followsSuit = chosen instanceof PlayCard && !gameState.getCurrentTrick().isEmpty()
+                    && ((PlayCard) chosen).card.suite == ledSuit;
+
+            forwardModel.next(gameState, chosen);
+
+            if (followsSuit) {
+                assertFalse(gameState.getKnownVoids(player).contains(ledSuit));
+            }
+        }
+    }
+
+    /**
+     * Over a whole game, a player recorded as void in a suit must genuinely hold no cards of that
+     * suit. This is the invariant that redeterminisation relies on.
+     */
+    @Test
+    public void recordedVoidsAreConsistentWithActualHands() {
+        Random rnd = new Random(42);
+        int voidsSeen = 0;
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+
+            for (int p = 0; p < gameState.getNPlayers(); p++) {
+                for (FrenchCard.Suite suit : gameState.getKnownVoids(p)) {
+                    voidsSeen++;
+                    assertFalse("Player " + p + " is recorded void in " + suit + " but holds one",
+                            gameState.getPlayerHands().get(p).stream().anyMatch(c -> c.suite == suit));
+                }
+            }
+        }
+        assertTrue("No voids were recorded over a whole game", voidsSeen > 0);
+    }
+
+    /**
+     * Voids only apply to the current round, as hands are re-dealt at the start of each round.
+     */
+    @Test
+    public void voidsAreClearedAtTheStartOfANewRound() {
+        Random rnd = new Random(6);
+        boolean voidSeenInFirstRound = false;
+        while (gameState.isNotTerminal() && gameState.getRoundCounter() == 0) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+            if (gameState.getRoundCounter() == 0) {
+                voidSeenInFirstRound |= gameState.knownVoids.stream().anyMatch(v -> !v.isEmpty());
+            }
+        }
+        assertTrue("Expected at least one void to be recorded in the first round", voidSeenInFirstRound);
+        assertEquals(1, gameState.getRoundCounter());
+        for (int p = 0; p < gameState.getNPlayers(); p++) {
+            assertTrue(gameState.getKnownVoids(p).isEmpty());
+        }
+    }
+
+    /**
+     * Any voids recorded should be carried across by a copy, whether or not this is from the
+     * perspective of a single player.
+     */
+    @Test
+    public void knownVoidsAreCopied() {
+        playUntilOpponentVoid();
+        int voidPlayer = firstOpponentWithVoid();
+        FrenchCard.Suite voidSuit = gameState.getKnownVoids(voidPlayer).iterator().next();
+
+        SpadesGameState fullCopy = (SpadesGameState) gameState.copy();
+        SpadesGameState playerCopy = (SpadesGameState) gameState.copy(0);
+        assertEquals(gameState.knownVoids, fullCopy.knownVoids);
+        assertEquals(gameState.knownVoids, playerCopy.knownVoids);
+
+        // and the copies must be independent of the original
+        Set<FrenchCard.Suite> originalVoids = gameState.getKnownVoids(voidPlayer);
+        fullCopy.getKnownVoids(voidPlayer).clear();
+        assertTrue(originalVoids.contains(voidSuit));
+    }
+
+    /**
+     * Redeterminisation from one player's perspective reshuffles the other players' hands. It must
+     * not deal a player a card in a suit that they are publicly known to be void in.
+     * <p>
+     * We sample a redeterminisation at every point in a whole game, and count both the violations and
+     * the opportunities to violate - a state in which a void player could have been dealt a card of
+     * their void suit, because one of the other hidden hands holds one.
+     */
+    @Test
+    public void redeterminisationRespectsKnownVoids() {
+        Random rnd = new Random(6);
+        int violations = 0, opportunities = 0;
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+
+            List<FrenchCard> hiddenCards = new ArrayList<>();
+            for (int p = 1; p < gameState.getNPlayers(); p++)
+                hiddenCards.addAll(gameState.getPlayerHands().get(p).getComponents());
+
+            SpadesGameState copy = (SpadesGameState) gameState.copy(0);
+            for (int p = 1; p < gameState.getNPlayers(); p++) {
+                if (gameState.getPlayerHands().get(p).getSize() == 0) continue;
+                for (FrenchCard.Suite suit : gameState.getKnownVoids(p)) {
+                    if (hiddenCards.stream().anyMatch(c -> c.suite == suit)) opportunities++;
+                    if (copy.getPlayerHands().get(p).stream().anyMatch(c -> c.suite == suit)) violations++;
+                }
+            }
+        }
+        assertTrue("The voids were never put to the test", opportunities > 0);
+        assertEquals("Redeterminisation dealt cards in a known void suit", 0, violations);
+    }
+
+    /**
+     * Honouring the voids must not otherwise disturb the redeterminisation - hand sizes, the player's own
+     * hand, and the full set of cards in play all have to be preserved.
+     */
+    @Test
+    public void redeterminisationRemainsValid() {
+        playUntilOpponentVoid();
+        List<FrenchCard> expectedCards = allHeldCards(gameState);
+        List<FrenchCard> ownHand = gameState.getPlayerHands().get(0).getComponents();
+
+        for (int i = 0; i < 50; i++) {
+            SpadesGameState copy = (SpadesGameState) gameState.copy(0);
+            for (int p = 0; p < gameState.getNPlayers(); p++) {
+                assertEquals(gameState.getPlayerHands().get(p).getSize(), copy.getPlayerHands().get(p).getSize());
+            }
+            assertEquals(ownHand, copy.getPlayerHands().get(0).getComponents());
+
+            List<FrenchCard> actualCards = allHeldCards(copy);
+            assertEquals(expectedCards.size(), actualCards.size());
+            assertTrue(actualCards.containsAll(expectedCards));
+        }
+    }
+
+    /** plays on until an opponent of player 0 is known to be void in something, with cards still in hand */
+    private void playUntilOpponentVoid() {
+        Random rnd = new Random(6);
+        while (gameState.isNotTerminal() && firstOpponentWithVoid() == -1) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+        }
+        assertNotEquals("Expected an opponent to become known void while still holding cards",
+                -1, firstOpponentWithVoid());
+    }
+
+    private int firstOpponentWithVoid() {
+        for (int p = 1; p < gameState.getNPlayers(); p++) {
+            if (!gameState.getKnownVoids(p).isEmpty() && gameState.getPlayerHands().get(p).getSize() > 0)
+                return p;
+        }
+        return -1;
+    }
+
+    private List<FrenchCard> allHeldCards(SpadesGameState state) {
+        List<FrenchCard> retValue = new ArrayList<>();
+        for (int p = 0; p < state.getNPlayers(); p++)
+            retValue.addAll(state.getPlayerHands().get(p).getComponents());
+        return retValue;
+    }
+
+    // ========================================
+    // The rememberVoids parameter
+    // ========================================
+
+    @Test
+    public void rememberVoidsDefaultsToTrue() {
+        SpadesParameters params = new SpadesParameters();
+        assertTrue(params.rememberVoids);
+        assertEquals(true, params.getParameterValue("rememberVoids"));
+    }
+
+    @Test
+    public void rememberVoidsSurvivesAParameterCopy() {
+        SpadesParameters params = (SpadesParameters) gameState.getGameParameters();
+        params.setParameterValue("rememberVoids", false);
+        assertFalse(params.rememberVoids);
+        assertFalse(((SpadesParameters) params.copy()).rememberVoids);
+    }
+
+    @Test
+    public void noVoidsAreRecordedWhenTheyAreNotRemembered() {
+        ((SpadesParameters) gameState.getGameParameters()).setParameterValue("rememberVoids", false);
+        Random rnd = new Random(42);
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            forwardModel.next(gameState, actions.get(rnd.nextInt(actions.size())));
+            for (int p = 0; p < gameState.getNPlayers(); p++)
+                assertTrue(gameState.getKnownVoids(p).isEmpty());
+        }
+    }
+
+    /**
+     * With the parameter off we fall back on the old behaviour, which takes no account of who is void
+     * in what. We track the voids in the test itself to show that they really are being ignored.
+     */
+    @Test
+    public void redeterminisationIsUnconstrainedWhenVoidsAreNotRemembered() {
+        ((SpadesParameters) gameState.getGameParameters()).setParameterValue("rememberVoids", false);
+        Random rnd = new Random(6);
+        List<Set<FrenchCard.Suite>> observedVoids = new ArrayList<>();
+        for (int p = 0; p < gameState.getNPlayers(); p++)
+            observedVoids.add(EnumSet.noneOf(FrenchCard.Suite.class));
+
+        int violations = 0, opportunities = 0, round = 0;
+        while (gameState.isNotTerminal()) {
+            List<AbstractAction> actions = forwardModel.computeAvailableActions(gameState);
+            AbstractAction chosen = actions.get(rnd.nextInt(actions.size()));
+            int player = gameState.getCurrentPlayer();
+            FrenchCard.Suite ledSuit = gameState.getLeadSuit();
+            boolean failsToFollow = chosen instanceof PlayCard && !gameState.getCurrentTrick().isEmpty()
+                    && ((PlayCard) chosen).card.suite != ledSuit;
+
+            forwardModel.next(gameState, chosen);
+            if (failsToFollow) observedVoids.get(player).add(ledSuit);
+            if (gameState.getRoundCounter() != round) {
+                // hands are re-dealt each round, so what we know is wiped
+                round = gameState.getRoundCounter();
+                observedVoids.forEach(Set::clear);
+                continue;
+            }
+
+            List<FrenchCard> hiddenCards = new ArrayList<>();
+            for (int p = 1; p < gameState.getNPlayers(); p++)
+                hiddenCards.addAll(gameState.getPlayerHands().get(p).getComponents());
+
+            SpadesGameState copy = (SpadesGameState) gameState.copy(0);
+            for (int p = 1; p < gameState.getNPlayers(); p++) {
+                if (gameState.getPlayerHands().get(p).getSize() == 0) continue;
+                for (FrenchCard.Suite suit : observedVoids.get(p)) {
+                    if (hiddenCards.stream().anyMatch(c -> c.suite == suit)) opportunities++;
+                    if (copy.getPlayerHands().get(p).stream().anyMatch(c -> c.suite == suit)) violations++;
+                }
+            }
+        }
+        assertTrue("The voids were never put to the test", opportunities > 0);
+        assertTrue("With rememberVoids off the redeterminisation should ignore the voids", violations > 0);
+    }
+}

--- a/src/test/java/utilities/TestConstrainedDeterminisation.java
+++ b/src/test/java/utilities/TestConstrainedDeterminisation.java
@@ -1,0 +1,147 @@
+package utilities;
+
+import core.CoreConstants;
+import core.components.Deck;
+import core.components.FrenchCard;
+import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Random;
+import java.util.function.BiPredicate;
+
+import static core.components.FrenchCard.Suite.*;
+import static org.junit.Assert.*;
+
+/**
+ * Tests for the constrained variant of {@link DeterminisationUtilities#reshuffle}, which redeals hidden
+ * cards subject to per-deck restrictions on what each deck is allowed to hold.
+ */
+public class TestConstrainedDeterminisation {
+
+    // the perspective player; none of the decks below belong to them, so everything is hidden from them
+    private static final int PERSPECTIVE = 9;
+
+    private Deck<FrenchCard> hand(int owner, FrenchCard.Suite... suits) {
+        Deck<FrenchCard> deck = new Deck<>("Player " + owner, owner, CoreConstants.VisibilityMode.VISIBLE_TO_OWNER);
+        int number = 2;
+        for (FrenchCard.Suite suit : suits)
+            deck.add(new FrenchCard(FrenchCard.FrenchCardType.Number, suit, number++));
+        return deck;
+    }
+
+    private List<FrenchCard.Suite> suitsOf(Deck<FrenchCard> deck) {
+        List<FrenchCard.Suite> retValue = new ArrayList<>();
+        for (FrenchCard card : deck.getComponents()) retValue.add(card.suite);
+        return retValue;
+    }
+
+    /**
+     * Deck 0 can only take Hearts, and deck 1 can take Hearts or Spades. With two of each in the pool the
+     * only valid deal is Hearts to deck 0 and Spades to deck 1 - a greedy deal that starts by giving deck 1
+     * a Heart paints itself into a corner.
+     */
+    @Test
+    public void tightConstraintsAreAlwaysSatisfied() {
+        BiPredicate<Deck<FrenchCard>, FrenchCard> permitted = (deck, card) ->
+                deck.getOwnerId() == 0 ? card.suite == Hearts : card.suite == Hearts || card.suite == Spades;
+
+        Random rnd = new Random(7);
+        for (int i = 0; i < 50; i++) {
+            Deck<FrenchCard> deck0 = hand(0, Hearts, Spades);
+            Deck<FrenchCard> deck1 = hand(1, Hearts, Spades);
+            assertTrue(DeterminisationUtilities.reshuffle(PERSPECTIVE, List.of(deck0, deck1), c -> true, rnd, permitted));
+
+            assertEquals(List.of(Hearts, Hearts), suitsOf(deck0));
+            assertEquals(List.of(Spades, Spades), suitsOf(deck1));
+        }
+    }
+
+    /**
+     * With room to manoeuvre the deal must still respect the constraints, and must vary between calls.
+     */
+    @Test
+    public void looseConstraintsAreSatisfiedAndStillRandom() {
+        // deck 0 is void in Hearts, deck 1 is void in Spades, deck 2 is unconstrained
+        BiPredicate<Deck<FrenchCard>, FrenchCard> permitted = (deck, card) ->
+                switch (deck.getOwnerId()) {
+                    case 0 -> card.suite != Hearts;
+                    case 1 -> card.suite != Spades;
+                    default -> true;
+                };
+
+        Random rnd = new Random(7);
+        List<List<FrenchCard.Suite>> distinctDeals = new ArrayList<>();
+        for (int i = 0; i < 50; i++) {
+            Deck<FrenchCard> deck0 = hand(0, Hearts, Spades, Clubs);
+            Deck<FrenchCard> deck1 = hand(1, Hearts, Spades, Diamonds);
+            Deck<FrenchCard> deck2 = hand(2, Hearts, Spades, Clubs);
+            assertTrue(DeterminisationUtilities.reshuffle(PERSPECTIVE, List.of(deck0, deck1, deck2), c -> true, rnd, permitted));
+
+            assertFalse(suitsOf(deck0).contains(Hearts));
+            assertFalse(suitsOf(deck1).contains(Spades));
+            // no cards created or destroyed
+            List<FrenchCard.Suite> all = new ArrayList<>(suitsOf(deck0));
+            all.addAll(suitsOf(deck1));
+            all.addAll(suitsOf(deck2));
+            assertEquals(3, all.stream().filter(s -> s == Hearts).count());
+            assertEquals(3, all.stream().filter(s -> s == Spades).count());
+            assertEquals(2, all.stream().filter(s -> s == Clubs).count());
+            assertEquals(1, all.stream().filter(s -> s == Diamonds).count());
+
+            if (!distinctDeals.contains(suitsOf(deck2))) distinctDeals.add(suitsOf(deck2));
+        }
+        assertTrue("The deal should vary between calls", distinctDeals.size() > 1);
+    }
+
+    /**
+     * If the constraints cannot all be met then we say so, and fall back on an unconstrained reshuffle so
+     * that the state is at least still a legal one.
+     */
+    @Test
+    public void inconsistentConstraintsFallBackToAnUnconstrainedShuffle() {
+        // both decks claim to be void in Spades, but there are two Spades that have to go somewhere
+        BiPredicate<Deck<FrenchCard>, FrenchCard> permitted = (deck, card) -> card.suite != Spades;
+
+        Deck<FrenchCard> deck0 = hand(0, Hearts, Spades);
+        Deck<FrenchCard> deck1 = hand(1, Hearts, Spades);
+        assertFalse(DeterminisationUtilities.reshuffle(PERSPECTIVE, List.of(deck0, deck1), c -> true, new Random(7), permitted));
+
+        List<FrenchCard.Suite> all = new ArrayList<>(suitsOf(deck0));
+        all.addAll(suitsOf(deck1));
+        assertEquals(2, all.stream().filter(s -> s == Hearts).count());
+        assertEquals(2, all.stream().filter(s -> s == Spades).count());
+    }
+
+    /**
+     * A deck belonging to the perspective player is visible to them, and so must be left alone.
+     */
+    @Test
+    public void thePerspectivePlayersOwnDeckIsUntouched() {
+        BiPredicate<Deck<FrenchCard>, FrenchCard> permitted = (deck, card) -> card.suite != Hearts;
+
+        Deck<FrenchCard> ownHand = hand(PERSPECTIVE, Hearts, Hearts);
+        Deck<FrenchCard> otherHand = hand(1, Clubs, Diamonds);
+        assertTrue(DeterminisationUtilities.reshuffle(PERSPECTIVE, List.of(ownHand, otherHand), c -> true, new Random(7), permitted));
+
+        assertEquals(List.of(Hearts, Hearts), suitsOf(ownHand));
+    }
+
+    /**
+     * A null constraint is equivalent to the unconstrained reshuffle, and must give identical results for
+     * the same seed so that existing callers are unaffected.
+     */
+    @Test
+    public void nullConstraintMatchesTheUnconstrainedReshuffle() {
+        Deck<FrenchCard> constrained0 = hand(0, Hearts, Spades, Clubs);
+        Deck<FrenchCard> constrained1 = hand(1, Hearts, Spades, Diamonds);
+        DeterminisationUtilities.reshuffle(PERSPECTIVE, List.of(constrained0, constrained1), c -> true, new Random(7), null);
+
+        Deck<FrenchCard> plain0 = hand(0, Hearts, Spades, Clubs);
+        Deck<FrenchCard> plain1 = hand(1, Hearts, Spades, Diamonds);
+        DeterminisationUtilities.reshuffle(PERSPECTIVE, List.of(plain0, plain1), c -> true, new Random(7));
+
+        assertEquals(suitsOf(plain0), suitsOf(constrained0));
+        assertEquals(suitsOf(plain1), suitsOf(constrained1));
+    }
+}


### PR DESCRIPTION
Some small fixes (as I try to avoid mammoth kitchen-sink PRs)

1) Fix for MCTS K / FPU interaction. A bug I introduced some time ago meant that any K < 1 with UCB was treated effectively as K = 1.0.

2) Chess now defaults NOT to have the rule on repeating a position 3 times leads to a draw. This is because it was calculating (and storing for comparison) the hashcode of the whole position on every move. This kills MCTS search with any rollouts to a couple of iterations per second. This can still be switched on via Game Params.

3) Hearts and Spades now correctly implement the knowledge that if a player did not follow suit, then they must have no cards of that suit. Previously redeterminisation ignored this knowledge leading to illegal shuffles.